### PR TITLE
Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,130 @@
+ARG BASE=ubuntu:18.04
+FROM $BASE
+
+ARG NPROCS=4
+
+RUN apt-get update && apt-get install -y \
+        build-essential \
+        bc \
+        curl \
+        git \
+        wget \
+        vim \
+        lcov \
+        ccache \
+        gdb \
+        ninja-build \
+        libbz2-dev \
+        libicu-dev \
+        python-dev \
+        autotools-dev \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install CMake
+ENV CMAKE_DIR=/opt/cmake
+RUN CMAKE_VERSION=3.13.4 && \
+    CMAKE_VERSION_SHORT=3.13 && \
+    CMAKE_URL=https://cmake.org/files/v${CMAKE_VERSION_SHORT}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
+    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
+    wget --quiet ${CMAKE_URL} --output-document=${CMAKE_SCRIPT} && \
+    mkdir -p ${CMAKE_DIR} && \
+    sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
+    rm ${CMAKE_SCRIPT}
+ENV PATH=${CMAKE_DIR}/bin:$PATH
+
+# Install Clang/LLVM
+ENV LLVM_DIR=/opt/llvm
+RUN LLVM_VERSION=7.0.1 && \
+    LLVM_KEY=86419D8A && \
+    LLVM_URL=http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
+    LLVM_ARCHIVE=llvm-${LLVM_VERSION}.tar.xz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${LLVM_URL} --output-document=${LLVM_ARCHIVE} && \
+    wget --quiet ${LLVM_URL}.sig --output-document=${LLVM_ARCHIVE}.sig && \
+    gpg --keyserver pool.sks-keyservers.net --recv-keys ${LLVM_KEY} && \
+    gpg --verify ${LLVM_ARCHIVE}.sig ${LLVM_ARCHIVE} && \
+    mkdir -p ${LLVM_DIR} && \
+    tar -xvf ${LLVM_ARCHIVE} -C ${LLVM_DIR} --strip-components=1 && \
+    echo "${LLVM_DIR}/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig && \
+    rm -rf /root/.gnupg && \
+    rm -rf ${SCRATCH_DIR}
+ENV PATH=${LLVM_DIR}/bin:$PATH
+
+# Install OpenMPI
+ENV OPENMPI_DIR=/opt/openmpi
+RUN OPENMPI_VERSION=3.1.3 && \
+    OPENMPI_VERSION_SHORT=3.1 && \
+    OPENMPI_SHA1=b3c60e2bdd5a8a8e758fd741f9a5bebb84da5e81 && \
+    OPENMPI_URL=https://download.open-mpi.org/release/open-mpi/v${OPENMPI_VERSION_SHORT}/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    OPENMPI_ARCHIVE=openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    [ ! -z "${CUDA_VERSION}" ] && CUDA_OPTIONS=--with-cuda || true && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${OPENMPI_URL} --output-document=${OPENMPI_ARCHIVE} && \
+    echo "${OPENMPI_SHA1} ${OPENMPI_ARCHIVE}" | sha1sum -c && \
+    mkdir -p openmpi && \
+    tar -xf ${OPENMPI_ARCHIVE} -C openmpi --strip-components=1 && \
+    mkdir -p build && cd build && \
+    ../openmpi/configure --prefix=${OPENMPI_DIR} ${CUDA_OPTIONS} && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}
+ENV PATH=${OPENMPI_DIR}/bin:$PATH
+
+# Install Boost
+ENV BOOST_DIR=/opt/boost
+RUN BOOST_VERSION=1.67.0 && \
+    BOOST_VERSION_UNDERSCORE=$(echo "$BOOST_VERSION" | sed -e "s/\./_/g") && \
+    BOOST_URL=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2 && \
+    BOOST_SHA256=2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba && \
+    BOOST_ARCHIVE=boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2 && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${BOOST_URL} --output-document=${BOOST_ARCHIVE} && \
+    echo "${BOOST_SHA256} ${BOOST_ARCHIVE}" | sha256sum -c && \
+    mkdir -p boost && \
+    tar -xf ${BOOST_ARCHIVE} -C boost --strip-components=1 && \
+    cd boost && \
+    ./bootstrap.sh \
+        --prefix=${BOOST_DIR} \
+        && \
+    echo "using mpi ;" >> project-config.jam && \
+    ./b2 -j${NPROCS} \
+        hardcode-dll-paths=true dll-path=${BOOST_DIR}/lib \
+        link=shared \
+        variant=release \
+        install \
+        && \
+    rm -rf ${SCRATCH_DIR}
+
+# Install Google Benchmark support library
+ENV BENCHMARK_DIR=/opt/benchmark
+RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    git clone https://github.com/google/benchmark.git -b v1.4.1 && \
+    cd benchmark && \
+    git clone https://github.com/google/googletest.git -b release-1.8.1 && \
+    mkdir build && cd build && \
+    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} .. && \
+    make -j${NPROCS} && make install && \
+    rm -rf ${SCRATCH_DIR}
+
+# Install Kokkos
+ENV KOKKOS_DIR=/opt/kokkos
+COPY kokkos.patch /root
+RUN KOKKOS_VERSION=5d6e7fb38e96aec88d2c514e1f9be1cf2b549b57 && \
+    KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
+    KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${KOKKOS_URL} --output-document=${KOKKOS_ARCHIVE} && \
+    mkdir -p kokkos && \
+    tar -xf ${KOKKOS_ARCHIVE} -C kokkos --strip-components=1 && \
+    cd kokkos && \
+    patch -p1 < /root/kokkos.patch && \
+    mkdir -p build && cd build && \
+    [ ! -z "${CUDA_VERSION}" ] && CUDA_OPTIONS="--with-cuda --with-cuda-options=enable_lambda,enable_uvm" || true && \
+    ../generate_makefile.bash --prefix=${KOKKOS_DIR} \
+       --with-serial --with-openmp ${CUDA_OPTIONS} \
+       --arch=SNB,Volta70 \
+       --cxxstandard=c++14 && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR} && \
+    rm /root/kokkos.patch

--- a/docker/jenkins/build.sh
+++ b/docker/jenkins/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+EXTRA_ARGS=("$@")
+
+rm -f  CMakeCache.txt
+rm -rf CMakeFiles/
+
+ARGS=(
+    -D CMAKE_BUILD_TYPE=Debug
+    -D BUILD_SHARED_LIBS=ON
+
+    ### TPLs
+    -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BENCHMARK_DIR;$BOOST_DIR"
+
+    ### COMPILERS AND FLAGS ###
+    -D CMAKE_CXX_COMPILER="$KOKKOS_DIR/bin/nvcc_wrapper"
+    -D CMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic"
+
+    ### MISC ###
+    -D MPIEXEC_PREFLAGS="--allow-run-as-root"
+)
+
+cd $ARBORX_DIR
+rm -rf build
+mkdir build
+cd build
+
+cmake "${ARGS[@]}" "${EXTRA_ARGS[@]}" "${ARBORX_DIR}"
+
+make -j${NPROCS}
+
+ctest --no-compress-output -T Test

--- a/docker/jenkins/docker-compose.yml
+++ b/docker/jenkins/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+  arborx_ci:
+    image: dalg24/arborx_base:cuda-9.2
+    volumes:
+      # Cannot mount subdirectory jenkins_data/workspace/$JOBNAME in data
+      # volume so have to mount the entire volume and climb up two directories.
+      # NOTE: it is possible to find out what the actual mount point of the
+      # volume that stores Jenkins home directory on the host but it is
+      # probably wiser not to do so.
+      - jenkins_data:$WORKSPACE/../..
+    environment:
+      - NPROCS=8
+      - ARBORX_DIR=$WORKSPACE
+    command: $WORKSPACE/docker/jenkins/build.sh
+    cap_add:
+      # required to mount DTK into Trilinos source directory
+      - SYS_ADMIN
+      # required to use CLang's LeakSanitizer
+      - SYS_PTRACE
+    network_mode: none
+volumes:
+  jenkins_data:
+    external:
+      name: $JENKINS_DATA_VOLUME

--- a/docker/kokkos.patch
+++ b/docker/kokkos.patch
@@ -1,0 +1,155 @@
+diff --git a/core/cmake/kokkos-config.cmake.in b/core/cmake/kokkos-config.cmake.in
+new file mode 100644
+index 00000000..bfa1657d
+--- /dev/null
++++ b/core/cmake/kokkos-config.cmake.in
+@@ -0,0 +1,92 @@
++set(KOKKOS_INSTALL_PREFIX @KOKKOS_INSTALL_PREFIX@)
++set(KOKKOS_LINK_LIBS -lkokkos @KOKKOS_EXTRA_LIBS_LIST@)
++set(KOKKOS_COMPILE_OPTIONS @KOKKOS_CXXFLAGS@)
++set(KOKKOS_LINK_OPTIONS @KOKKOS_LINK_FLAGS@)
++set(KOKKOS_DEVICES @KOKKOS_DEVICES@)
++set(KOKKOS_ARCH @KOKKOS_ARCH@)
++set(KOKKOS_CXX_STANDARD @KOKKOS_CXX_STANDARD@)
++
++# Replace comma separators with semicolons
++foreach(_var KOKKOS_DEVICES KOKKOS_ARCH)
++  string(REPLACE "," ";" ${_var} "${${_var}}")
++  if(Kokkos_DEBUG)
++    message("${_var} = \"${${_var}}\"")
++  endif()
++endforeach()
++
++# Find out what C++ standard to use
++if(KOKKOS_CXX_STANDARD STREQUAL c++11)
++  set(KOKKOS_COMPILE_FEATURES cxx_std_11)
++elseif(KOKKOS_CXX_STANDARD STREQUAL c++14)
++  set(KOKKOS_COMPILE_FEATURES cxx_std_14)
++elseif(KOKKOS_CXX_STANDARD STREQUAL c++17)
++  set(KOKKOS_COMPILE_FEATURES cxx_std_17)
++else()
++  message(WARNING "kokkos cxx standard not supported")
++endif()
++
++# Remove flag that set the C++ standard from the compile options
++set(_COMPILE_OPTIONS)
++foreach(_opt ${KOKKOS_COMPILE_OPTIONS})
++  if(_opt MATCHES "c\\+\\+")
++    if(Kokkos_DEBUG)
++      message("Removing \"${_opt}\" flag from kokkos compile options")
++    endif()
++  else()
++    list(APPEND _COMPILE_OPTIONS ${_opt})
++  endif()
++endforeach()
++set(KOKKOS_COMPILE_OPTIONS ${_COMPILE_OPTIONS})
++unset(_COMPILE_OPTIONS)
++
++# Find the headers and library
++find_path(KOKKOS_INCLUDE_DIR Kokkos_Core.hpp PATHS ${KOKKOS_INSTALL_PREFIX}/include NO_DEFAULT_PATH)
++find_library(KOKKOS_LIBRARY NAMES kokkos PATHS ${KOKKOS_INSTALL_PREFIX}/lib NO_DEFAULT_PATH)
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(KOKKOS DEFAULT_MSG KOKKOS_INCLUDE_DIR KOKKOS_LIBRARY)
++get_filename_component(KOKKOS_LIBRARY_DIR ${KOKKOS_LIBRARY} DIRECTORY)
++
++# Setup the target
++add_library(Kokkos::kokkos INTERFACE IMPORTED)
++set_target_properties(Kokkos::kokkos PROPERTIES
++  INTERFACE_INCLUDE_DIRECTORIES "${KOKKOS_INCLUDE_DIR}"
++  INTERFACE_LINK_LIBRARIES "${KOKKOS_LINK_LIBS}"
++  INTERFACE_LINK_DIRECTORIES "${KOKKOS_LIBRARY_DIR}"
++  INTERFACE_COMPILE_OPTIONS "${KOKKOS_COMPILE_OPTIONS}"
++  INTERFACE_LINK_OPTIONS "${KOKKOS_LINK_OPTIONS}"
++  #INTERFACE_COMPILE_FEATURES "${KOKKOS_COMPILE_FEATURES}"
++)
++
++#   This function makes sure that kokkos was built with the requested backends
++#   and target architectures and generates a fatal error if it was not.
++#
++#   kokkos_check_requested(
++#     [DEVICES <devices>...] # Set of backends (e.g. "OpenMP" and/or "Cuda")
++#     [ARCH <archs>...]      # Target architectures (e.g. "Power9" and/or "Volta70")
++#   )
++function(kokkos_check_requested)
++  cmake_parse_arguments(_KOKKOS_REQUESTED "" "" "DEVICES;ARCH" ${ARGN})
++  set(_KOKKOS_REQUESTED_ARGS)
++  foreach(_X DEVICES ARCH)
++    if(_KOKKOS_REQUESTED_${_X})
++      list(APPEND _KOKKOS_REQUESTED_ARGS ${_X})
++    endif()
++  endforeach()
++  set(_KOKKOS_CHECK_REQUESTED_SUCCESS TRUE)
++  foreach(_X ${_KOKKOS_REQUESTED_ARGS})
++    foreach(_requested ${_KOKKOS_REQUESTED_${_X}})
++      foreach(_provided ${KOKKOS_${_X}})
++        if(_requested STREQUAL _provided)
++          string(REPLACE ";" " " ${_requested} "${_KOKKOS_REQUESTED_${_X}}")
++        endif()
++      endforeach()
++    endforeach()
++    find_package_handle_standard_args("KOKKOS_${_X}" DEFAULT_MSG ${_KOKKOS_REQUESTED_${_X}})
++    if(NOT KOKKOS_${_X}_FOUND)
++      set(_KOKKOS_CHECK_REQUESTED_SUCCESS FALSE)
++    endif()
++  endforeach()
++  if(NOT _KOKKOS_CHECK_REQUESTED_SUCCESS)
++    message(FATAL_ERROR "Kokkos does NOT provide all backends and/or architectures requested")
++  endif()
++endfunction()
+diff --git a/core/src/Makefile b/core/src/Makefile
+index c2dbddf4..8ed3658f 100644
+--- a/core/src/Makefile
++++ b/core/src/Makefile
+@@ -73,6 +73,7 @@ mkdir:
+	mkdir -p $(PREFIX)/include
+	mkdir -p $(PREFIX)/lib
+	mkdir -p $(PREFIX)/lib/pkgconfig
++	mkdir -p $(PREFIX)/lib/cmake/kokkos
+	mkdir -p $(PREFIX)/include/impl
+
+ copy-cuda: mkdir
+@@ -102,6 +103,7 @@ install: mkdir $(CONDITIONAL_COPIES) build-lib generate_build_settings
+	$(CP) $(COPY_FLAG) $(KOKKOS_MAKEFILE)  $(PREFIX)
+	$(CP) $(COPY_FLAG) $(KOKKOS_CMAKEFILE)  $(PREFIX)
+	$(CP) $(COPY_FLAG) $(KOKKOS_PKGCONFIG)  $(PREFIX)/lib/pkgconfig
++	$(CP) $(COPY_FLAG) $(KOKKOS_CMAKECONFIG)  $(PREFIX)/lib/cmake/kokkos
+	$(CP) $(COPY_FLAG) libkokkos.a $(PREFIX)/lib
+	$(CP) $(COPY_FLAG) $(KOKKOS_CONFIG_HEADER) $(PREFIX)/include
+
+diff --git a/core/src/Makefile.generate_build_files b/core/src/Makefile.generate_build_files
+index cc856ee9..26e1921e 100644
+--- a/core/src/Makefile.generate_build_files
++++ b/core/src/Makefile.generate_build_files
+@@ -6,6 +6,7 @@
+ KOKKOS_MAKEFILE=Makefile.kokkos
+ KOKKOS_CMAKEFILE=kokkos_generated_settings.cmake
+ KOKKOS_PKGCONFIG=kokkos.pc
++KOKKOS_CMAKECONFIG=kokkos-config.cmake
+
+ ifeq ($(KOKKOS_DEBUG),"no")
+   KOKKOS_DEBUG_CMAKE = OFF
+@@ -50,13 +51,23 @@ $(KOKKOS_PKGCONFIG): $(KOKKOS_PATH)/core/src/$(KOKKOS_PKGCONFIG).in
+	    -e 's|@KOKKOS_LINK_FLAGS@|$(KOKKOS_LINK_FLAGS)|g' \
+	     $< > $@
+
++$(KOKKOS_CMAKECONFIG): $(KOKKOS_PATH)/core/cmake/$(KOKKOS_CMAKECONFIG).in
++	@sed -e 's|@KOKKOS_INSTALL_PREFIX@|$(PREFIX)|g' \
++	    -e 's|@KOKKOS_CXXFLAGS@|$(patsubst -I%,,$(KOKKOS_CXXFLAGS))|g' \
++	    -e 's|@KOKKOS_EXTRA_LIBS_LIST@|$(KOKKOS_EXTRA_LIBS)|g' \
++	    -e 's|@KOKKOS_LINK_FLAGS@|$(KOKKOS_LINK_FLAGS)|g' \
++	    -e 's|@KOKKOS_DEVICES@|$(KOKKOS_DEVICES)|g' \
++	    -e 's|@KOKKOS_ARCH@|$(KOKKOS_ARCH)|g' \
++	    -e 's|@KOKKOS_CXX_STANDARD@|$(KOKKOS_CXX_STANDARD)|g' \
++	     $< > $@
++
+ kokkos_fixup_sed = $(call kokkos_fixup_sed_impl,$(KOKKOS_MAKEFILE)); $(call kokkos_fixup_sed_impl,$(KOKKOS_CMAKEFILE))
+
+ #This function should be used for variables whose values are different in GNU Make versus CMake,
+ #especially lists which are delimited by commas in one case and semicolons in another
+ kokkos_append_gmakevar = $(call kokkos_appendvar_makefile,$1); $(call kokkos_append_gmakevar_cmakefile,$1,$2)
+
+-generate_build_settings: $(KOKKOS_CONFIG_HEADER) $(KOKKOS_PKGCONFIG)
++generate_build_settings: $(KOKKOS_CONFIG_HEADER) $(KOKKOS_PKGCONFIG) $(KOKKOS_CMAKECONFIG)
+	@rm -f $(KOKKOS_MAKEFILE)
+	@rm -f $(KOKKOS_CMAKEFILE)
+	@$(call kokkos_append_string, "#Global Settings used to generate this library")

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -415,7 +415,7 @@ int main( int argc, char *argv[] )
         else if ( node == "cuda" )
         {
 #ifdef KOKKOS_ENABLE_CUDA
-            typedef Kokkos::Cuda Node;
+            typedef Kokkos::CudaUVMSpace Node;
             main_<Node>( pass_further );
 #else
             throw std::runtime_error( "CUDA node type is disabled" );

--- a/test/ArborX_EnableDeviceTypes.hpp.in
+++ b/test/ArborX_EnableDeviceTypes.hpp.in
@@ -1,10 +1,19 @@
 #ifndef ARBORX_ENABLE_DEVICE_TYPES_HPP
 #define ARBORX_ENABLE_DEVICE_TYPES_HPP
 
-#include <boost/mpl/list.hpp>
+#include <Kokkos_Macros.hpp>
+
 #include <boost/utility/identity_type.hpp>
 
+#if defined( KOKKOS_COMPILER_CLANG )
+#include <boost/mpl/list.hpp>
+#define WORKAROUND_SEQUENCE_OF_TYPES boost::mpl::list
+#else
+#include <tuple>
+#define WORKAROUND_SEQUENCE_OF_TYPES std::tuple
+#endif
+
 // clang-format off
-#cmakedefine ARBORX_DEVICE_TYPES BOOST_IDENTITY_TYPE((boost::mpl::list<@ARBORX_DEVICE_TYPES@>))
+#cmakedefine ARBORX_DEVICE_TYPES BOOST_IDENTITY_TYPE((WORKAROUND_SEQUENCE_OF_TYPES<@ARBORX_DEVICE_TYPES@>))
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ configure_file(ArborX_EnableDeviceTypes.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/Arbor
 add_executable(ArborX_HelloWorld.exe tstHelloWorld.cpp utf_main.cpp)
 target_link_libraries(ArborX_HelloWorld.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_HelloWorld.exe PRIVATE BOOST_TEST_DYN_LINK ARBORX_MPI_UNIT_TEST)
-add_test(NAME ArborX_HelloWorld COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS}./ArborX_HelloWorld.exe ${MPIEXEC_POSTFLAGS})
+add_test(NAME ArborX_HelloWorld COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ./ArborX_HelloWorld.exe ${MPIEXEC_POSTFLAGS})
 
 add_executable(ArborX_Exception.exe tstException.cpp)
 # TODO link Boost::dynamic_linking interface target to enable dynamic linking
@@ -64,7 +64,7 @@ add_executable(ArborX_DistributedSearchTree.exe tstDistributedSearchTree.cpp utf
 target_link_libraries(ArborX_DistributedSearchTree.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_DistributedSearchTree.exe PRIVATE BOOST_TEST_DYN_LINK ARBORX_MPI_UNIT_TEST)
 target_include_directories(ArborX_DistributedSearchTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME ArborX_DistributedSearchTree COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS}./ArborX_DistributedSearchTree.exe ${MPIEXEC_POSTFLAGS})
+add_test(NAME ArborX_DistributedSearchTree COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ./ArborX_DistributedSearchTree.exe ${MPIEXEC_POSTFLAGS})
 
 add_executable(ArborX_DetailsDistributedSearchTreeImpl.exe tstDetailsDistributedSearchTreeImpl.cpp utf_main.cpp)
 target_link_libraries(ArborX_DetailsDistributedSearchTreeImpl.exe PRIVATE ArborX Boost::unit_test_framework)


### PR DESCRIPTION
- Updating clang to 8.0 will require updating clang-format
- Not tested yet as there is no build system in place
- Unclear what version of OpenMPI to use
  Would like to match to Spectrum MPI installed on Summit