### PR TITLE
Find Boost in subdirectories that actually require it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.13)
 project(ArborX CXX)
 
 find_package(kokkos REQUIRED)
-find_package(Boost REQUIRED COMPONENTS program_options unit_test_framework)
 find_package(MPI REQUIRED)
 
 add_library(ArborX INTERFACE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Boost REQUIRED COMPONENTS program_options)
+
 add_subdirectory(bvh_driver)
 add_subdirectory(distributed_tree_driver)
 add_subdirectory(viz)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 string(REPLACE ";" "," ARBORX_DEVICE_TYPES "${ARBORX_DEVICE_TYPES}")
 configure_file(ArborX_EnableDeviceTypes.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/ArborX_EnableDeviceTypes.hpp @ONLY)
 
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
 add_executable(ArborX_Exception.exe tstException.cpp)
 # TODO link Boost::dynamic_linking interface target to enable dynamic linking


### PR DESCRIPTION
Thought about doing something like
```CMake
find_package(Boost QUIET COMPONENTS program_options unit_test_framework)
if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
  add_subdirectory(test)
endif()
```
but I am delaying until we introduce a solid logic for enabling/disabling things.