### PR TITLE
Fix Kokkos_DEVICES spelling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(ArborX INTERFACE Kokkos::Kokkos MPI::MPI_CXX)
 #target_compile_features(ArborX INTERFACE cxx_std_14)
 
 # FIXME
-if(KOKKOS_DEVICES MATCHES "Cuda")
+if(Kokkos_DEVICES MATCHES "Cuda")
   find_package(CUDA REQUIRED)
   get_filename_component(CUDA_LIBRARY_DIR ${CUDA_cudadevrt_LIBRARY} DIRECTORY)
   target_link_directories(ArborX INTERFACE ${CUDA_LIBRARY_DIR})


### PR DESCRIPTION
In #27 the spelling of `KOKKOS_DEVICES` changed to `Kokkos_DEVICES`.