### PR TITLE
Print error message if clang-format executable cannot be found

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -61,9 +61,6 @@ pipeline {
                     label 'docker'
                 }
             }
-            environment {
-                CLANG_FORMAT_EXE = 'clang-format'
-            }
             steps {
                 sh './scripts/check_format_cpp.sh'
             }

--- a/scripts/check_format_cpp.sh
+++ b/scripts/check_format_cpp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-clang_format_executable=${CLANG_FORMAT_EXE:-clang-format-7}
+clang_format_executable=${CLANG_FORMAT_EXE:-clang-format}
 
 this_program=$(basename "$0")
 usage="Usage:

--- a/scripts/check_format_cpp.sh
+++ b/scripts/check_format_cpp.sh
@@ -38,6 +38,9 @@ do
   shift
 done
 
+# stop right here if clang-format does not exist in $PATH
+command -v $clang_format_executable >/dev/null 2>&1 || { echo >&2 "clang-format executable '$clang_format_executable' not found.  Aborting."; exit 1; }
+
 # shamelessy redirecting everything to /dev/null in quiet mode
 if [ $verbose -eq 0 ]; then
     exec &>/dev/null


### PR DESCRIPTION
Fix #43 

Instead of printing all source code and report it as files not properly formatted :)
