### PR TITLE
Move adding CUDA link directory to FindKokkos.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,6 @@ if(ArborX_ENABLE_MPI)
 endif()
 #target_compile_features(ArborX INTERFACE cxx_std_14)
 
-# FIXME
-if(Kokkos_DEVICES MATCHES "Cuda")
-  find_package(CUDA REQUIRED)
-  get_filename_component(CUDA_LIBRARY_DIR ${CUDA_cudadevrt_LIBRARY} DIRECTORY)
-  target_link_directories(ArborX INTERFACE ${CUDA_LIBRARY_DIR})
-endif()
-
 target_include_directories(ArborX INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/details>

--- a/cmake/FindKokkos.cmake
+++ b/cmake/FindKokkos.cmake
@@ -87,12 +87,20 @@ foreach(_var NVCC_WRAPPER KOKKOS_PATH KOKKOS_GMAKE_DEVICES KOKKOS_GMAKE_ARCH KOK
   unset(${_var} CACHE)
 endforeach()
 
+# For clang we need to add the cudart library explicitly
+# since Kokkos doesn't do that for us.
+if(Kokkos_DEVICES MATCHES "Cuda")
+  find_package(CUDA REQUIRED)
+  get_filename_component(Kokkos_CUDA_LIBRARY_DIR ${CUDA_cudadevrt_LIBRARY} DIRECTORY)
+  set(Kokkos_CUDA_LDFLAGS "-L${Kokkos_CUDA_LIBRARY_DIR}")
+endif()
+
 if(Kokkos_FOUND AND NOT TARGET Kokkos::Kokkos)
   add_library(Kokkos::Kokkos UNKNOWN IMPORTED)
   set_target_properties(Kokkos::Kokkos PROPERTIES
     IMPORTED_LOCATION "${Kokkos_LIBRARY}"
     INTERFACE_COMPILE_OPTIONS "${PC_Kokkos_CFLAGS_OTHER}"
-    INTERFACE_LINK_LIBRARIES "${PC_Kokkos_LDFLAGS}"
+    INTERFACE_LINK_LIBRARIES "${Kokkos_CUDA_LDFLAGS} ${PC_Kokkos_LDFLAGS}"
     INTERFACE_INCLUDE_DIRECTORIES "${Kokkos_INCLUDE_DIR}"
   )
 endif()

--- a/cmake/FindKokkos.cmake
+++ b/cmake/FindKokkos.cmake
@@ -89,7 +89,7 @@ endforeach()
 
 # For clang we need to add the cudart library explicitly
 # since Kokkos doesn't do that for us.
-if(Kokkos_DEVICES MATCHES "Cuda")
+if(Kokkos_DEVICES MATCHES "Cuda" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   find_package(CUDA REQUIRED)
   get_filename_component(Kokkos_CUDA_LIBRARY_DIR ${CUDA_cudadevrt_LIBRARY} DIRECTORY)
   set(Kokkos_CUDA_LDFLAGS "-L${Kokkos_CUDA_LIBRARY_DIR}")

--- a/cmake/FindKokkos.cmake
+++ b/cmake/FindKokkos.cmake
@@ -92,7 +92,7 @@ endforeach()
 if(Kokkos_DEVICES MATCHES "Cuda" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   find_package(CUDA REQUIRED)
   get_filename_component(Kokkos_CUDA_LIBRARY_DIR ${CUDA_cudadevrt_LIBRARY} DIRECTORY)
-  set(Kokkos_CUDA_LDFLAGS "-L${Kokkos_CUDA_LIBRARY_DIR}")
+  set(PC_Kokkos_LDFLAGS "-L${Kokkos_CUDA_LIBRARY_DIR} ${PC_Kokkos_LDFLAGS}")
 endif()
 
 if(Kokkos_FOUND AND NOT TARGET Kokkos::Kokkos)
@@ -100,7 +100,7 @@ if(Kokkos_FOUND AND NOT TARGET Kokkos::Kokkos)
   set_target_properties(Kokkos::Kokkos PROPERTIES
     IMPORTED_LOCATION "${Kokkos_LIBRARY}"
     INTERFACE_COMPILE_OPTIONS "${PC_Kokkos_CFLAGS_OTHER}"
-    INTERFACE_LINK_LIBRARIES "${Kokkos_CUDA_LDFLAGS} ${PC_Kokkos_LDFLAGS}"
+    INTERFACE_LINK_LIBRARIES "${PC_Kokkos_LDFLAGS}"
     INTERFACE_INCLUDE_DIRECTORIES "${Kokkos_INCLUDE_DIR}"
   )
 endif()


### PR DESCRIPTION
Part of #36. This is the closest I could come up with. Admittedly, adding `-L${Kokkos_CUDA_LIBRARY_DIR}` is not nice, but should at least work for *nix systems.