### PR TITLE
Add CUDA memory space test in bvh_driver

### DIFF
--- a/examples/bvh_driver/bvh_driver.cpp
+++ b/examples/bvh_driver/bvh_driver.cpp
@@ -321,9 +321,10 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
-  // using Cuda = Kokkos::Cuda::device_type; // <- FIXME segfault
-  using Cuda = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+  using Cuda = Kokkos::Cuda::device_type;
   REGISTER_BENCHMARK(ArborX::BVH<Cuda>);
+  using CudaUVM = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+  REGISTER_BENCHMARK(ArborX::BVH<CudaUVM>);
 #endif
 
 #if defined(KOKKOS_ENABLE_SERIAL)


### PR DESCRIPTION
The test doesn't segfault anymore, also see #45.