### PR TITLE
[WIP] Introduce DistanceReturnType

### DIFF
--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -86,11 +86,7 @@ public:
                 Kokkos::abort( "Invalid arguemnt: DistanceReturnType constructor
        " "requires non-negative floating-point value" );*/
   }
-  // TODO consider removing implicit conversion to double
-  KOKKOS_INLINE_FUNCTION operator double() const
-  { /*abort();*/
-    return std::sqrt(sq);
-  }
+  KOKKOS_INLINE_FUNCTION double to_double() const { return std::sqrt(sq); }
   KOKKOS_INLINE_FUNCTION bool operator<(DistanceReturnType const &rhs) const
   {
     return sq < rhs.sq;
@@ -169,16 +165,7 @@ public:
   {
     return lhs * lhs != rhs.sq;
   }
-
-  friend DistanceReturnType operator-(DistanceReturnType const &left,
-                                      double const &right);
 };
-
-inline DistanceReturnType operator-(DistanceReturnType const &left,
-                                    double const &right)
-{
-  return DistanceReturnType(left.sq - right * right);
-}
 
 // distance point-point
 KOKKOS_INLINE_FUNCTION
@@ -215,8 +202,9 @@ KOKKOS_INLINE_FUNCTION
 DistanceReturnType distance(Point const &point, Sphere const &sphere)
 {
   using KokkosExt::max;
-  return max(distance(point, sphere.centroid()) - sphere.radius(),
-             DistanceReturnType(0.));
+  double const real_distance =
+      max(distance(point, sphere.centroid()).to_double() - sphere.radius(), 0.);
+  return DistanceReturnType(real_distance * real_distance);
 }
 
 // expand an axis-aligned bounding box to include a point

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -159,13 +159,14 @@ public:
     return std::make_tuple(tmp_offset, tmp_indices);
   }
 
+  template <typename T>
   static std::tuple<Kokkos::View<int *, DeviceType>,
                     Kokkos::View<int *, DeviceType>,
-                    Kokkos::View<double *, DeviceType>>
+                    Kokkos::View<T *, DeviceType>>
   reversePermutation(Kokkos::View<size_t const *, DeviceType> permute,
                      Kokkos::View<int const *, DeviceType> offset,
                      Kokkos::View<int const *, DeviceType> indices,
-                     Kokkos::View<double const *, DeviceType> distances)
+                     Kokkos::View<T const *, DeviceType> distances)
   {
     auto const tmp_offset = permuteOffset(permute, offset);
 

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -159,14 +159,14 @@ public:
     return std::make_tuple(tmp_offset, tmp_indices);
   }
 
-  template <typename T>
   static std::tuple<Kokkos::View<int *, DeviceType>,
                     Kokkos::View<int *, DeviceType>,
-                    Kokkos::View<T *, DeviceType>>
-  reversePermutation(Kokkos::View<size_t const *, DeviceType> permute,
-                     Kokkos::View<int const *, DeviceType> offset,
-                     Kokkos::View<int const *, DeviceType> indices,
-                     Kokkos::View<T const *, DeviceType> distances)
+                    Kokkos::View<DistanceReturnType *, DeviceType>>
+  reversePermutation(
+      Kokkos::View<size_t const *, DeviceType> permute,
+      Kokkos::View<int const *, DeviceType> offset,
+      Kokkos::View<int const *, DeviceType> indices,
+      Kokkos::View<DistanceReturnType const *, DeviceType> distances)
   {
     auto const tmp_offset = permuteOffset(permute, offset);
 

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -18,6 +18,7 @@
 #include <ArborX_DetailsSortUtils.hpp>  // sortObjects
 #include <ArborX_DetailsUtils.hpp>      // iota, exclusivePrefixSum, lastElement
 #include <ArborX_Macros.hpp>
+#include <ArborX_Predicates.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Parallel.hpp>

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -51,7 +51,7 @@ struct DistributedSearchTreeImpl
                             Kokkos::View<int *, DeviceType> &ranks);
 
   // nearest neighbors queries
-  template <typename Query>
+  template <typename Query, typename T = double>
   static void
   queryDispatch(Details::NearestPredicateTag,
                 DistributedSearchTree<DeviceType> const &tree,
@@ -59,33 +59,33 @@ struct DistributedSearchTreeImpl
                 Kokkos::View<int *, DeviceType> &indices,
                 Kokkos::View<int *, DeviceType> &offset,
                 Kokkos::View<int *, DeviceType> &ranks,
-                Kokkos::View<double *, DeviceType> *distances_ptr = nullptr);
+                Kokkos::View<T *, DeviceType> *distances_ptr = nullptr);
 
-  template <typename Query>
+  template <typename Query, typename T = double>
   static void queryDispatch(Details::NearestPredicateTag tag,
                             DistributedSearchTree<DeviceType> const &tree,
                             Kokkos::View<Query *, DeviceType> queries,
                             Kokkos::View<int *, DeviceType> &indices,
                             Kokkos::View<int *, DeviceType> &offset,
                             Kokkos::View<int *, DeviceType> &ranks,
-                            Kokkos::View<double *, DeviceType> &distances)
+                            Kokkos::View<T *, DeviceType> &distances)
   {
     queryDispatch(tag, tree, queries, indices, offset, ranks, &distances);
   }
 
-  template <typename Query>
+  template <typename Query, typename T>
   static void deviseStrategy(Kokkos::View<Query *, DeviceType> queries,
                              DistributedSearchTree<DeviceType> const &tree,
                              Kokkos::View<int *, DeviceType> &indices,
                              Kokkos::View<int *, DeviceType> &offset,
-                             Kokkos::View<double *, DeviceType> &);
+                             Kokkos::View<T *, DeviceType> &);
 
-  template <typename Query>
+  template <typename Query, typename T>
   static void reassessStrategy(Kokkos::View<Query *, DeviceType> queries,
                                DistributedSearchTree<DeviceType> const &tree,
                                Kokkos::View<int *, DeviceType> &indices,
                                Kokkos::View<int *, DeviceType> &offset,
-                               Kokkos::View<double *, DeviceType> &distances);
+                               Kokkos::View<T *, DeviceType> &distances);
 
   template <typename Query>
   static void forwardQueries(MPI_Comm comm,
@@ -96,16 +96,17 @@ struct DistributedSearchTreeImpl
                              Kokkos::View<int *, DeviceType> &fwd_ids,
                              Kokkos::View<int *, DeviceType> &fwd_ranks);
 
+  template <typename T = double>
   static void communicateResultsBack(
       MPI_Comm comm, Kokkos::View<int *, DeviceType> &indices,
       Kokkos::View<int *, DeviceType> offset,
       Kokkos::View<int *, DeviceType> &ranks,
       Kokkos::View<int *, DeviceType> &ids,
-      Kokkos::View<double *, DeviceType> *distances_ptr = nullptr);
+      Kokkos::View<T *, DeviceType> *distances_ptr = nullptr);
 
-  template <typename Query>
+  template <typename Query, typename T>
   static void filterResults(Kokkos::View<Query *, DeviceType> queries,
-                            Kokkos::View<double *, DeviceType> distances,
+                            Kokkos::View<T *, DeviceType> distances,
                             Kokkos::View<int *, DeviceType> &indices,
                             Kokkos::View<int *, DeviceType> &offset,
                             Kokkos::View<int *, DeviceType> &ranks);
@@ -233,13 +234,12 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Query, typename T>
 void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
     Kokkos::View<Query *, DeviceType> queries,
     DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<int *, DeviceType> &indices,
-    Kokkos::View<int *, DeviceType> &offset,
-    Kokkos::View<double *, DeviceType> &)
+    Kokkos::View<int *, DeviceType> &offset, Kokkos::View<T *, DeviceType> &)
 {
   auto const &top_tree = tree._top_tree;
   auto const &bottom_tree_sizes = tree._bottom_tree_sizes;
@@ -289,19 +289,19 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Query, typename T>
 void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
     Kokkos::View<Query *, DeviceType> queries,
     DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
-    Kokkos::View<double *, DeviceType> &distances)
+    Kokkos::View<T *, DeviceType> &distances)
 {
   auto const &top_tree = tree._top_tree;
   auto const n_queries = queries.extent(0);
 
   // Determine distance to the farthest neighbor found so far.
-  Kokkos::View<double *, DeviceType> farthest_distances("distances", n_queries);
+  Kokkos::View<T *, DeviceType> farthest_distances("distances", n_queries);
   Kokkos::deep_copy(farthest_distances, 0.);
   // NOTE: in principle distances( j ) are arranged in ascending order for
   // offset( i ) <= j < offset( i + 1 ) so max() is not necessary.
@@ -329,19 +329,19 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Query, typename T>
 void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     Details::NearestPredicateTag, DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<Query *, DeviceType> queries,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
     Kokkos::View<int *, DeviceType> &ranks,
-    Kokkos::View<double *, DeviceType> *distances_ptr)
+    Kokkos::View<T *, DeviceType> *distances_ptr)
 {
   auto const &bottom_tree = tree._bottom_tree;
   auto comm = tree._comm;
 
-  Kokkos::View<double *, DeviceType> distances("distances", 0);
+  Kokkos::View<T *, DeviceType> distances("distances", 0);
   if (distances_ptr)
     distances = *distances_ptr;
 
@@ -572,12 +572,13 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
 }
 
 template <typename DeviceType>
+template <typename T>
 void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
     MPI_Comm comm, Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> offset,
     Kokkos::View<int *, DeviceType> &ranks,
     Kokkos::View<int *, DeviceType> &ids,
-    Kokkos::View<double *, DeviceType> *distances_ptr)
+    Kokkos::View<T *, DeviceType> *distances_ptr)
 {
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -627,20 +628,20 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
 
   if (distances_ptr)
   {
-    Kokkos::View<double *, DeviceType> &distances = *distances_ptr;
-    Kokkos::View<double *, DeviceType> export_distances = distances;
-    Kokkos::View<double *, DeviceType> import_distances(distances.label(),
-                                                        n_imports);
+    Kokkos::View<T *, DeviceType> &distances = *distances_ptr;
+    Kokkos::View<T *, DeviceType> export_distances = distances;
+    Kokkos::View<T *, DeviceType> import_distances(distances.label(),
+                                                   n_imports);
     sendAcrossNetwork(distributor, export_distances, import_distances);
     distances = import_distances;
   }
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Query, typename T>
 void DistributedSearchTreeImpl<DeviceType>::filterResults(
     Kokkos::View<Query *, DeviceType> queries,
-    Kokkos::View<double *, DeviceType> distances,
+    Kokkos::View<T *, DeviceType> distances,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
     Kokkos::View<int *, DeviceType> &ranks)

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -111,9 +111,10 @@ public:
     // Nodes with a distance that exceed that radius can safely be
     // discarded. Initialize the radius to infinity and tighten it once k
     // neighbors have been found.
-    double radius = KokkosExt::ArithmeticTraits::infinity<double>::value;
+    DistanceReturnType radius(
+        KokkosExt::ArithmeticTraits::infinity<double>::value);
 
-    using PairIndexDistance = Kokkos::pair<int, double>;
+    using PairIndexDistance = Kokkos::pair<int, DistanceReturnType>;
     static_assert(
         std::is_same<typename Buffer::value_type, PairIndexDistance>::value,
         "Type of the elements stored in the buffer passed as argument to "
@@ -136,16 +137,16 @@ public:
         heap(UnmanagedStaticVector<PairIndexDistance>(buffer.data(),
                                                       buffer.size()));
 
-    using PairNodePtrDistance = Kokkos::pair<Node const *, double>;
+    using PairNodePtrDistance = Kokkos::pair<Node const *, DistanceReturnType>;
     Stack<PairNodePtrDistance> stack;
     // Do not bother computing the distance to the root node since it is
     // immediately popped out of the stack and processed.
-    stack.emplace(bvh.getRoot(), 0.);
+    stack.emplace(bvh.getRoot(), DistanceReturnType(0.));
 
     while (!stack.empty())
     {
       Node const *node = stack.top().first;
-      double const node_distance = stack.top().second;
+      DistanceReturnType const node_distance = stack.top().second;
       stack.pop();
 
       if (node_distance < radius)
@@ -153,7 +154,7 @@ public:
         if (bvh.isLeaf(node))
         {
           int const leaf_index = bvh.getLeafPermutationIndex(node);
-          double const leaf_distance = node_distance;
+          auto const leaf_distance = node_distance;
           if (heap.size() < k)
           {
             // Insert leaf node and update radius if it was the kth
@@ -175,8 +176,8 @@ public:
           // closest one ends on top.
           Node const *left_child = node->children.first;
           Node const *right_child = node->children.second;
-          double const left_child_distance = distance(left_child);
-          double const right_child_distance = distance(right_child);
+          auto const left_child_distance = distance(left_child);
+          auto const right_child_distance = distance(right_child);
           if (left_child_distance < right_child_distance)
           {
             // NOTE not really sure why but it performed better with
@@ -206,7 +207,7 @@ public:
     for (decltype(heap.size()) i = 0; i < heap.size(); ++i)
     {
       int const leaf_index = (heap.data() + i)->first;
-      double const leaf_distance = (heap.data() + i)->second;
+      DistanceReturnType const leaf_distance = (heap.data() + i)->second;
       insert(leaf_index, leaf_distance);
     }
     return heap.size();
@@ -231,7 +232,8 @@ public:
         return 1;
       }
 
-      using PairNodePtrDistance = Kokkos::pair<Node const *, double>;
+      using PairNodePtrDistance =
+          Kokkos::pair<Node const *, DistanceReturnType>;
       struct CompareDistance
       {
         KOKKOS_INLINE_FUNCTION bool
@@ -248,7 +250,7 @@ public:
 
       // Do not bother computing the distance to the root node since it is
       // immediately popped out of the stack and processed.
-      queue.emplace(bvh.getRoot(), 0.);
+      queue.emplace(bvh.getRoot(), DistanceReturnType(0.));
       decltype(k) count = 0;
 
       while (!queue.empty() && count < k)
@@ -256,7 +258,7 @@ public:
         // Get the node that is on top of the priority list (i.e. the
         // one that is closest to the query point)
         Node const *node = queue.top().first;
-        double const node_distance = queue.top().second;
+        DistanceReturnType const node_distance = queue.top().second;
 
         if (bvh.isLeaf(node))
         {
@@ -269,8 +271,8 @@ public:
           // Insert children into the priority queue
           Node const *left_child = node->children.first;
           Node const *right_child = node->children.second;
-          double const left_child_distance = distance(left_child);
-          double const right_child_distance = distance(right_child);
+          DistanceReturnType const left_child_distance = distance(left_child);
+          DistanceReturnType const right_child_distance = distance(right_child);
           queue.popPush(left_child, left_child_distance);
           queue.emplace(right_child, right_child_distance);
         }

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -216,7 +216,7 @@ struct TreeVisualization
           visitor.visit(node, tree);
           return distance(geometry, TreeAccess::getBoundingVolume(node, tree));
         },
-        k, [](int, double) {}, buffer);
+        k, [](int, DistanceReturnType) {}, buffer);
     return count;
 #endif
   }

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -208,7 +208,8 @@ struct TreeVisualization
 #else
     auto const geometry = pred._geometry;
     auto const k = pred._k;
-    Kokkos::View<Kokkos::pair<int, double> *, DeviceType> buffer("buffer", k);
+    Kokkos::View<Kokkos::pair<int, DistanceReturnType> *, DeviceType> buffer(
+        "buffer", k);
     int const count = TreeTraversal<DeviceType>::nearestQuery(
         tree,
         [geometry, &visitor, &tree](Node const *node) {

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -153,11 +153,10 @@ struct UnaryPredicate
   Function _pred;
 };
 
-template <typename Value>
-static auto translate(ArborX::Intersects<ArborX::Sphere> const &query)
-    -> decltype(boost::geometry::index::intersects(ArborX::Box()) &&
-                boost::geometry::index::satisfies(
-                    UnaryPredicate<Value>::makeAlwaysFalse()))
+template <typename Value, typename Sphere>
+static auto translate(ArborX::Intersects<Sphere> const &query) -> decltype(
+    boost::geometry::index::intersects(ArborX::Box()) &&
+    boost::geometry::index::satisfies(UnaryPredicate<Value>::makeAlwaysFalse()))
 {
   auto const sphere = query._geometry;
   auto const radius = sphere.radius();

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -139,13 +139,19 @@ void checkResults(ArborX::DistributedSearchTree<DeviceType> const &tree,
 
   BOOST_TEST(offset_host == offset_ref, tt::per_element());
   auto const m = offset_host.extent_int(0) - 1;
+  BOOST_TEST(ranks_host.extent_int(0) == offset_ref[m]);
+  std::cout << ranks_host.extent_int(0) << " should be " << offset_ref[m]
+            << std::endl;
   for (int i = 0; i < m; ++i)
   {
     std::vector<std::tuple<int, int>> l;
     std::vector<std::tuple<int, int>> r;
     for (int j = offset_ref[i]; j < offset_ref[i + 1]; ++j)
     {
-      l.push_back(std::make_tuple(ranks_host[j], indices_host[j]));
+      auto bla = ranks_host[j];
+      auto blabla = indices_host[j];
+      auto foo = std::make_tuple(bla, blabla);
+      l.push_back(foo);
       r.push_back(std::make_tuple(ranks_ref[j], indices_ref[j]));
     }
     sort(l.begin(), l.end());

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -75,7 +75,9 @@ BOOST_AUTO_TEST_CASE(distance)
 
   std::tie(a, b) = std::make_pair<details::Point, details::Point>(
       {{0., 0., 0.}}, {{1., 1., 1.}});
-  BOOST_TEST(details::distance(a, b) == std::sqrt(3.));
+  double error = details::distance(a, b) - std::sqrt(3.);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance(a, b) == std::sqrt(3.));
   BOOST_TEST(bg::distance(a, b) == std::sqrt(3.));
 
   BOOST_TEST(details::distance(a, a) == 0.);
@@ -90,11 +92,16 @@ BOOST_AUTO_TEST_CASE(distance)
   BOOST_TEST(bg::distance(unit_box, p) == 0.);
 
   p = {{-1., -1., -1.}};
-  BOOST_TEST(details::distance(p, unit_box) == std::sqrt(3.));
+
+  error = details::distance(a, b) - std::sqrt(3.);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance(p, unit_box) == std::sqrt(3.));
   BOOST_TEST(bg::distance(p, unit_box) == std::sqrt(3.));
 
   p = {{-1., .5, -1.}};
-  BOOST_TEST(details::distance(p, unit_box) == std::sqrt(2.));
+  error = details::distance(a, b) - std::sqrt(3.);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance(p, unit_box) == std::sqrt(2.));
   BOOST_TEST(bg::distance(p, unit_box) == std::sqrt(2.));
 
   p = {{-1., .5, .5}};

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -70,42 +70,36 @@ BOOST_AUTO_TEST_CASE(distance)
   // NOTE unsure if should test for floating point equality here
   details::Point a = {{0., 0., 0.}};
   details::Point b = {{0., 1., 0.}};
-  BOOST_TEST(details::distance(a, b) == 1.);
+  BOOST_TEST(details::distance(a, b).to_double() == 1.);
   BOOST_TEST(bg::distance(a, b) == 1.);
 
   std::tie(a, b) = std::make_pair<details::Point, details::Point>(
       {{0., 0., 0.}}, {{1., 1., 1.}});
-  double error = details::distance(a, b) - std::sqrt(3.);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance(a, b) == std::sqrt(3.));
+  BOOST_TEST(details::distance(a, b).to_double() == std::sqrt(3.));
   BOOST_TEST(bg::distance(a, b) == std::sqrt(3.));
 
-  BOOST_TEST(details::distance(a, a) == 0.);
+  BOOST_TEST(details::distance(a, a).to_double() == 0.);
   BOOST_TEST(bg::distance(a, a) == 0.);
 
   details::Box unit_box = {{{0., 0., 0.}}, {{1., 1., 1.}}};
   details::Point p = {{.5, .5, .5}};
   // NOTE ArborX has no overload distance( Box, Point )
-  BOOST_TEST(details::distance(p, unit_box) == 0.);
+  BOOST_TEST(details::distance(p, unit_box).to_double() == 0.);
   // BOOST_TEST( details::distance( unit_box, p ) == 0. );
   BOOST_TEST(bg::distance(p, unit_box) == 0.);
   BOOST_TEST(bg::distance(unit_box, p) == 0.);
 
   p = {{-1., -1., -1.}};
 
-  error = details::distance(a, b) - std::sqrt(3.);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance(p, unit_box) == std::sqrt(3.));
+  BOOST_TEST(details::distance(p, unit_box).to_double() == std::sqrt(3.));
   BOOST_TEST(bg::distance(p, unit_box) == std::sqrt(3.));
 
   p = {{-1., .5, -1.}};
-  error = details::distance(a, b) - std::sqrt(3.);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance(p, unit_box) == std::sqrt(2.));
+  BOOST_TEST(details::distance(p, unit_box).to_double() == std::sqrt(2.));
   BOOST_TEST(bg::distance(p, unit_box) == std::sqrt(2.));
 
   p = {{-1., .5, .5}};
-  BOOST_TEST(details::distance(p, unit_box) == 1.);
+  BOOST_TEST(details::distance(p, unit_box).to_double() == 1.);
   BOOST_TEST(bg::distance(p, unit_box) == 1.);
 }
 

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -18,39 +18,34 @@ namespace details = ArborX::Details;
 
 BOOST_AUTO_TEST_CASE(distance)
 {
-  double error =
-      details::distance({{1.0, 2.0, 3.0}}, {{1.0, 1.0, 1.0}}) - std::sqrt(5.0);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance({{1.0, 2.0, 3.0}}, {{1.0, 1.0, 1.0}}) ==
-               std::sqrt(5.0));
+  BOOST_TEST(
+      details::distance({{1.0, 2.0, 3.0}}, {{1.0, 1.0, 1.0}}).to_double() ==
+      std::sqrt(5.0));
 
   // box is unit cube
   ArborX::Box box = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
 
   // distance is zero if the point is inside the box
-  BOOST_TEST(details::distance({{0.5, 0.5, 0.5}}, box) == 0.0);
+  BOOST_TEST(details::distance({{0.5, 0.5, 0.5}}, box).to_double() == 0.0);
   // or anywhere on the boundary
-  BOOST_TEST(details::distance({{0.0, 0.0, 0.5}}, box) == 0.0);
+  BOOST_TEST(details::distance({{0.0, 0.0, 0.5}}, box).to_double() == 0.0);
   // normal projection onto center of one face
-  BOOST_TEST(details::distance({{2.0, 0.5, 0.5}}, box) == 1.0);
+  BOOST_TEST(details::distance({{2.0, 0.5, 0.5}}, box).to_double() == 1.0);
   // projection onto edge
-  error = details::distance({{2.0, 0.75, -1.0}}, box) - std::sqrt(2.0);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance({{2.0, 0.75, -1.0}}, box) == std::sqrt(2.0));
+  BOOST_TEST(details::distance({{2.0, 0.75, -1.0}}, box).to_double() ==
+             std::sqrt(2.0));
   // projection onto corner node
-  error = details::distance({{-1.0, 2.0, 2.0}}, box) - std::sqrt(3.0);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance({{-1.0, 2.0, 2.0}}, box) == std::sqrt(3.0));
+  BOOST_TEST(details::distance({{-1.0, 2.0, 2.0}}, box).to_double() ==
+             std::sqrt(3.0));
 
   // unit sphere
   ArborX::Sphere sphere = {{{0., 0., 0.}}, 1.};
-  BOOST_TEST(details::distance({{.5, .5, .5}}, sphere) == 0.);
-  error = details::distance({{2.0, 0., 0.}}, box) - std::sqrt(3.0);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance({{2., 0., 0.}}, sphere) == 1.);
-  error = details::distance({{1., 1., 1.}}, box) - std::sqrt(3.0);
-  if (std::abs(error) > 1.e-7)
-    BOOST_TEST(details::distance({{1., 1., 1.}}, sphere) == std::sqrt(3.) - 1.);
+  BOOST_TEST(details::distance({{.5, .5, .5}}, sphere).to_double() == 0.);
+
+  BOOST_TEST(details::distance({{2., 0., 0.}}, sphere).to_double() == 1.);
+
+  BOOST_TEST(details::distance({{1., 1., 1.}}, sphere).to_double() ==
+             std::sqrt(3.) - 1.);
 }
 
 BOOST_AUTO_TEST_CASE(overlaps)

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -18,8 +18,11 @@ namespace details = ArborX::Details;
 
 BOOST_AUTO_TEST_CASE(distance)
 {
-  BOOST_TEST(details::distance({{1.0, 2.0, 3.0}}, {{1.0, 1.0, 1.0}}) ==
-             std::sqrt(5.0));
+  double error =
+      details::distance({{1.0, 2.0, 3.0}}, {{1.0, 1.0, 1.0}}) - std::sqrt(5.0);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance({{1.0, 2.0, 3.0}}, {{1.0, 1.0, 1.0}}) ==
+               std::sqrt(5.0));
 
   // box is unit cube
   ArborX::Box box = {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}};
@@ -31,15 +34,23 @@ BOOST_AUTO_TEST_CASE(distance)
   // normal projection onto center of one face
   BOOST_TEST(details::distance({{2.0, 0.5, 0.5}}, box) == 1.0);
   // projection onto edge
-  BOOST_TEST(details::distance({{2.0, 0.75, -1.0}}, box) == std::sqrt(2.0));
+  error = details::distance({{2.0, 0.75, -1.0}}, box) - std::sqrt(2.0);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance({{2.0, 0.75, -1.0}}, box) == std::sqrt(2.0));
   // projection onto corner node
-  BOOST_TEST(details::distance({{-1.0, 2.0, 2.0}}, box) == std::sqrt(3.0));
+  error = details::distance({{-1.0, 2.0, 2.0}}, box) - std::sqrt(3.0);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance({{-1.0, 2.0, 2.0}}, box) == std::sqrt(3.0));
 
   // unit sphere
   ArborX::Sphere sphere = {{{0., 0., 0.}}, 1.};
   BOOST_TEST(details::distance({{.5, .5, .5}}, sphere) == 0.);
-  BOOST_TEST(details::distance({{2., 0., 0.}}, sphere) == 1.);
-  BOOST_TEST(details::distance({{1., 1., 1.}}, sphere) == std::sqrt(3.) - 1.);
+  error = details::distance({{2.0, 0., 0.}}, box) - std::sqrt(3.0);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance({{2., 0., 0.}}, sphere) == 1.);
+  error = details::distance({{1., 1., 1.}}, box) - std::sqrt(3.0);
+  if (std::abs(error) > 1.e-7)
+    BOOST_TEST(details::distance({{1., 1., 1.}}, sphere) == std::sqrt(3.) - 1.);
 }
 
 BOOST_AUTO_TEST_CASE(overlaps)

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -13,6 +13,7 @@
 #include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
 #include "ArborX_EnableViewComparison.hpp"
 #include <ArborX_LinearBVH.hpp>
+#include <details/ArborX_DetailsAlgorithms.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -344,8 +345,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(miscellaneous, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
   Kokkos::View<int *, DeviceType> zeros("zeros", 3);
   Kokkos::deep_copy(zeros, 255);
-  Kokkos::View<Kokkos::pair<int, double> *, DeviceType> empty_buffer(
-      "empty_buffer", 0);
+  Kokkos::View<Kokkos::pair<int, ArborX::Details::DistanceReturnType> *,
+               DeviceType>
+      empty_buffer("empty_buffer", 0);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, 1), KOKKOS_LAMBDA(int) {
         ArborX::Point p = {{0., 0., 0.}};


### PR DESCRIPTION
This is taken from https://github.com/ORNL-CEES/DataTransferKit/pull/394.

Currently, I see (averaging 10 runs):

| Benchmark | old mean | old stddev | new mean | new stddev |
| -------------- | -----------: | -------------: | ------------: | --------------: |
|**Serial** | | | | |
|  BM_construction     | 21076407 us (1)| 2664624 us | 20103764 us (1)| 2525733 us |
|  BM_knn_search      | 32912082 us (1)|   941523 us | 34858289 us (1)|   279593 us |
|  BM_radius_search  | 23637181 us (1)|   600557 us | 25678812 us (1)| 1603964 us |
|**OpenMP** | | | | |
|  BM_construction     |   3039773 us (1)|     92358 us |    2945699 us (1)|    43125 us |
|  BM_knn_search      |   4748715 us (1)|     65100 us |    4725199 us (1)|    11450 us |
|  BM_radius_search  |   3407838 us (1)|     47874 us |    3473879 us (1)|    14737 us |
|**Cuda** | | | | |
|  BM_construction      |      65105 us (10)|       2286 us |        47515 us (15)|        362 us |
|  BM_knn_search       |      280529 us (4)|   113970 us |      124167 us (6)|    13079 us |
|  BM_radius_search   |      80107 us (10)|     14712 us |      101948 us (16)|    23370 us |
|**CudaUVM** | | | | |
|  BM_construction      |     207800 us (3)|       3815 us |      235075 us (3)|    24216 us |
|  BM_knn_search       |    234587 us  (3)|        1728 us |      386437 us (3)|  123214 us |
|  BM_radius_search   |   106868 us (10)|     15303 us |    112937 us (10)|    21000 us |

with `--values=10000000 --queries=1000000`. I also made sure that there are no implicit conversion via aborting in the conversion operator.
