### PR TITLE
Add LinearBVH single_leaf_tree test

### DIFF
--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -109,6 +109,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, DeviceType, ARBORX_DEVICE_TYPES)
 
   checkResults(bvh, makeNearestQueries<DeviceType>({}), {}, {0}, {});
 
+  checkResults(
+      bvh,
+      makeNearestQueries<DeviceType>({{{0., 0., 0.}, 3}, {{4., 5., 1.}, 1}}),
+      {0, 0}, {0, 1, 2}, {0., 5.});
+
   checkResults(bvh,
                makeOverlapQueries<DeviceType>({
                    {{{5., 5., 5.}}, {{5., 5., 5.}}},


### PR DESCRIPTION
Fixes #75. Since we are now testing the respective `checkResults` function with a positive number of queries, the test would not succeed with the wrong comparison.