### PR TITLE
Improve benchmark for distributed tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(ArborX_ENABLE_MPI)
   find_package(MPI REQUIRED)
   target_link_libraries(ArborX	INTERFACE MPI::MPI_CXX)
 endif()
-#target_compile_features(ArborX INTERFACE cxx_std_14)
+target_compile_features(ArborX INTERFACE cxx_std_14)
 
 target_include_directories(ArborX INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(ArborX_ENABLE_MPI)
   find_package(MPI REQUIRED)
   target_link_libraries(ArborX	INTERFACE MPI::MPI_CXX)
 endif()
-target_compile_features(ArborX INTERFACE cxx_std_14)
+#target_compile_features(ArborX INTERFACE cxx_std_14)
 
 target_include_directories(ArborX INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -94,8 +94,9 @@ public:
     os << std::left << std::scientific;
 
     // Initialize with length of "Timer Name"
+    std::string const timer_name = "Timer Name";
     std::size_t const max_section_length = std::accumulate(
-        _data.begin(), _data.end(), std::string("Timer Name").size(),
+        _data.begin(), _data.end(), timer_name.size(),
         [](std::size_t current_max, entry_reference_type section) {
           return std::max(current_max, section.first.size());
         });
@@ -112,7 +113,7 @@ public:
 
       os << std::string(header_width, '=') << "\n\n";
       os << "TimeMonitor results over 1 processor\n\n";
-      os << std::setw(max_section_length) << "Timer Name"
+      os << std::setw(max_section_length) << timer_name
          << header_without_timer_name << '\n';
       os << std::string(header_width, '-') << '\n';
       for (int i = 0; i < n_timers; ++i)
@@ -138,7 +139,7 @@ public:
                         '=')
          << "\n\n";
       os << "TimeMonitor results over " << comm_size << " processors\n";
-      os << std::setw(max_section_length) << "Timer Name"
+      os << std::setw(max_section_length) << timer_name
          << header_without_timer_name << '\n';
       os << std::string(max_section_length + header_without_timer_name.size(),
                         '-')

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -20,7 +20,6 @@
 #include <chrono>
 #include <cmath> // cbrt
 #include <iomanip>
-#include <memory>
 #include <numeric>
 #include <random>
 #include <utility>
@@ -81,7 +80,7 @@ public:
     // FIXME Consider searching whether there already is an entry with the
     // same name.
     _data.emplace_back(std::move(name), 0.);
-    return std::make_unique<Timer>(_data.back());
+    return std::unique_ptr<Timer>(new Timer(_data.back()));
   }
   void summarize(MPI_Comm comm, std::ostream &os = std::cout)
   {

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -400,7 +400,7 @@ int main(int argc, char *argv[])
                                 });
     if (help_it != kokkos_argv + kokkos_argc)
     {
-      std::rotate(kokkos_argv, help_it + 1, kokkos_argv + kokkos_argc);
+      std::swap(*help_it, *(kokkos_argv + kokkos_argc - 1));
       --kokkos_argc;
     }
   }

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -32,7 +32,8 @@ struct HelpPrinted
 };
 
 // The TimeMonitor class can be used to measure for a series of events, i.e. it
-// represents a set of timers of type Timer.
+// represents a set of timers of type Timer. It is a poor man's drop-in
+// replacement for Teuchos::TimeMonitor
 class TimeMonitor
 {
   using container_type = std::vector<std::pair<std::string, double>>;
@@ -94,7 +95,7 @@ public:
 
     // Initialize with length of "Timer Name"
     std::size_t const max_section_length = std::accumulate(
-        _data.begin(), _data.end(), std::size_t(10),
+        _data.begin(), _data.end(), std::string("Timer Name").size(),
         [](std::size_t current_max, entry_reference_type section) {
           return std::max(current_max, section.first.size());
         });
@@ -102,9 +103,12 @@ public:
     if (comm_size == 1)
     {
       std::string const header_without_timer_name = " | GlobalTime";
+      std::stringstream dummy_string_stream;
+      dummy_string_stream << std::setprecision(os.precision())
+                          << std::scientific << " | " << 1.;
       int const header_width =
           max_section_length + std::max<int>(header_without_timer_name.size(),
-                                             std::cout.precision() + 9);
+                                             dummy_string_stream.str().size());
 
       os << std::string(header_width, '=') << "\n\n";
       os << "TimeMonitor results over 1 processor\n\n";


### PR DESCRIPTION
Changes:
- Properly align output, 
- Only print information on MPI rank 0, 
- Print relevant run parameters. 
- Replace `overlap` by `shift` such that values different from one and zero have a more intuitive meaning.