### PR TITLE
Enable C++14 when building Kokkos in automated CI builds on Jenkins

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -15,7 +15,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:10.1-devel --build-arg KOKKOS_OPTIONS="--with-serial --with-openmp --with-cuda --with-cuda-options=enable_lambda --arch=SNB,Volta70"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:10.1-devel --build-arg KOKKOS_OPTIONS="--with-serial --with-openmp --with-cuda --with-cuda-options=enable_lambda --arch=SNB,Volta70 --cxxstandard=c++14"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -40,7 +40,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=ubuntu:18.04 --build-arg KOKKOS_OPTIONS="--with-serial --with-openmp --arch=AMD --compiler=clang++"'
+                            additionalBuildArgs '--build-arg BASE=ubuntu:18.04 --build-arg KOKKOS_OPTIONS="--with-serial --with-openmp --arch=AMD --compiler=clang++ --cxxstandard=c++14"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'cathode'
                         }

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -78,7 +78,7 @@ public:
     // FIXME Consider searching whether there already is an entry with the
     // same name.
     _data.emplace_back(std::move(name), 0.);
-    return std::unique_ptr<Timer>(new Timer(_data.back()));
+    return std::make_unique<Timer>(_data.back());
   }
   void summarize(MPI_Comm comm, std::ostream &os = std::cout)
   {

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -145,10 +145,6 @@ struct UnaryPredicate
   {
   }
   inline bool operator()(Value const &val) const { return _pred(val); }
-  static UnaryPredicate makeAlwaysFalse()
-  {
-    return UnaryPredicate([](Value const &) { return false; });
-  }
   Function _pred;
 };
 

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -136,7 +136,6 @@ static ParallelRTree<typename View::value_type> makeRTree(MPI_Comm comm,
 }
 #endif
 
-// NOTE: The trailing return type is required with C++11 :(
 template <typename Value>
 struct UnaryPredicate
 {
@@ -155,9 +154,6 @@ struct UnaryPredicate
 
 template <typename Value>
 static auto translate(ArborX::Intersects<ArborX::Sphere> const &query)
-    -> decltype(boost::geometry::index::intersects(ArborX::Box()) &&
-                boost::geometry::index::satisfies(
-                    UnaryPredicate<Value>::makeAlwaysFalse()))
 {
   auto const sphere = query._geometry;
   auto const radius = sphere.radius();
@@ -175,7 +171,6 @@ static auto translate(ArborX::Intersects<ArborX::Sphere> const &query)
 
 template <typename Value, typename Geometry>
 static auto translate(ArborX::Nearest<Geometry> const &query)
-    -> decltype(boost::geometry::index::nearest(Geometry(), 0))
 {
   auto const geometry = query._geometry;
   auto const k = query._k;


### PR DESCRIPTION
We require C++14 standard but we rely on Kokkos to get the proper compiler flags.
This PR ensures that the `-std=c++14` flag will be present on the compile line in the automated builds on Jenkins.