### PR TITLE
Compute confidence intervals in DistributedTreeDriver

### DIFF
--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -108,8 +108,9 @@ class PerformanceMonitor
       double const current_stddev = std::sqrt(
           ba::variance(_statistics) * (n_measurements / (n_measurements - 1.)));
       double const current_mean = ba::mean(_statistics);
-      return static_cast<int>(std::ceil(
-          z * current_stddev / (relative_error_margin * current_mean / 2.)));
+      auto const tmp =
+          z * current_stddev / (relative_error_margin * current_mean / 2.);
+      return static_cast<int>(std::ceil(tmp * tmp));
     }
   };
 

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -81,11 +81,8 @@ class TimeMonitor
   container_type _data;
 
 public:
-  // NOTE Original code had the pointer semantics.  Can change in the future.
-  // The smart pointer is a distraction. The main problem here is that the
-  // reference stored by the timer is invalidated if the time monitor gets
-  // out of scope.
   Timer &getTimer(std::string name) { return _data[name]; }
+
   void summarize(MPI_Comm comm, std::ostream &os = std::cout)
   {
     int comm_size;
@@ -121,8 +118,11 @@ public:
       os << std::string(header_width, '-') << '\n';
       for (auto const &timer : _data)
       {
+        auto const &statistics = timer.second.get_statistics();
+
         os << std::setw(max_section_length) << timer.first << " | "
-           << mean(timer.second.get_statistics()) << '\n';
+           << mean(statistics) << ", " << count(statistics) << ", "
+           << mean(statistics) << ", " << variance(statistics) << '\n';
       }
       os << std::string(header_width, '=') << '\n';
       return;
@@ -248,153 +248,156 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
               << '\n';
   }
 
-  Kokkos::View<ArborX::Point *, DeviceType> random_points("random_points", 0);
+  for (unsigned int i = 0; i < 10; ++i)
   {
-    // Random points are "reused" between building the tree and performing
-    // queries. Note that this means that for the points in the middle of
-    // the local domains there won't be any communication.
-    auto n = std::max(n_values, n_queries);
-    Kokkos::resize(random_points, n);
-
-    auto random_points_host = Kokkos::create_mirror_view(random_points);
-
-    // Generate random points uniformly distributed within a box.
-    auto const a = std::cbrt(n_values);
-    std::uniform_real_distribution<double> distribution(-a, +a);
-    std::default_random_engine generator;
-    auto random = [&distribution, &generator]() {
-      return distribution(generator);
-    };
-
-    double offset_x = 0.;
-    double offset_y = 0.;
-    double offset_z = 0.;
-    // Change the geometry of the problem. In 1D, all the point clouds are
-    // aligned on a line. In 2D, the point clouds create a board and in 3D,
-    // they create a box.
-    switch (partition_dim)
+    Kokkos::View<ArborX::Point *, DeviceType> random_points("random_points", 0);
     {
-    case 1:
-    {
-      offset_x = 2 * a * shift * comm_rank;
+      // Random points are "reused" between building the tree and performing
+      // queries. Note that this means that for the points in the middle of
+      // the local domains there won't be any communication.
+      auto n = std::max(n_values, n_queries);
+      Kokkos::resize(random_points, n);
 
-      break;
+      auto random_points_host = Kokkos::create_mirror_view(random_points);
+
+      // Generate random points uniformly distributed within a box.
+      auto const a = std::cbrt(n_values);
+      std::uniform_real_distribution<double> distribution(-a, +a);
+      std::default_random_engine generator;
+      auto random = [&distribution, &generator]() {
+        return distribution(generator);
+      };
+
+      double offset_x = 0.;
+      double offset_y = 0.;
+      double offset_z = 0.;
+      // Change the geometry of the problem. In 1D, all the point clouds are
+      // aligned on a line. In 2D, the point clouds create a board and in 3D,
+      // they create a box.
+      switch (partition_dim)
+      {
+      case 1:
+      {
+        offset_x = 2 * a * shift * comm_rank;
+
+        break;
+      }
+      case 2:
+      {
+        int i_max = std::ceil(std::sqrt(comm_size));
+        int i = comm_rank % i_max;
+        int j = comm_rank / i_max;
+        offset_x = 2 * a * shift * i;
+        offset_y = 2 * a * shift * j;
+
+        break;
+      }
+      case 3:
+      {
+        int i_max = std::ceil(std::cbrt(comm_size));
+        int j_max = i_max;
+        int i = comm_rank % i_max;
+        int j = (comm_rank / i_max) % j_max;
+        int k = comm_rank / (i_max * j_max);
+        offset_x = 2 * a * shift * i;
+        offset_y = 2 * a * shift * j;
+        offset_z = 2 * a * shift * k;
+
+        break;
+      }
+      default:
+      {
+        throw std::runtime_error("partition_dim should be 1, 2, or 3");
+      }
+      }
+
+      for (int i = 0; i < n; ++i)
+        random_points_host(i) = {
+            {offset_x + random(), offset_y + random(), offset_z + random()}};
+      Kokkos::deep_copy(random_points, random_points_host);
     }
-    case 2:
-    {
-      int i_max = std::ceil(std::sqrt(comm_size));
-      int i = comm_rank % i_max;
-      int j = comm_rank / i_max;
-      offset_x = 2 * a * shift * i;
-      offset_y = 2 * a * shift * j;
 
-      break;
-    }
-    case 3:
-    {
-      int i_max = std::ceil(std::cbrt(comm_size));
-      int j_max = i_max;
-      int i = comm_rank % i_max;
-      int j = (comm_rank / i_max) % j_max;
-      int k = comm_rank / (i_max * j_max);
-      offset_x = 2 * a * shift * i;
-      offset_y = 2 * a * shift * j;
-      offset_z = 2 * a * shift * k;
-
-      break;
-    }
-    default:
-    {
-      throw std::runtime_error("partition_dim should be 1, 2, or 3");
-    }
-    }
-
-    for (int i = 0; i < n; ++i)
-      random_points_host(i) = {
-          {offset_x + random(), offset_y + random(), offset_z + random()}};
-    Kokkos::deep_copy(random_points, random_points_host);
-  }
-
-  Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes(
-      Kokkos::ViewAllocateWithoutInitializing("bounding_boxes"), n_values);
-  Kokkos::parallel_for("bvh_driver:construct_bounding_boxes",
-                       Kokkos::RangePolicy<ExecutionSpace>(0, n_values),
-                       KOKKOS_LAMBDA(int i) {
-                         double const x = random_points(i)[0];
-                         double const y = random_points(i)[1];
-                         double const z = random_points(i)[2];
-                         bounding_boxes(i) = {{{x - 1., y - 1., z - 1.}},
-                                              {{x + 1., y + 1., z + 1.}}};
-                       });
-  Kokkos::fence();
-
-  auto &construction = time_monitor.getTimer("construction");
-  MPI_Barrier(comm);
-  construction.start();
-  ArborX::DistributedSearchTree<DeviceType> distributed_tree(comm,
-                                                             bounding_boxes);
-  construction.stop();
-
-  std::ostream &os = std::cout;
-  if (comm_rank == 0)
-    os << "contruction done\n";
-
-  if (perform_knn_search)
-  {
-    Kokkos::View<ArborX::Nearest<ArborX::Point> *, DeviceType> queries(
-        Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
-    Kokkos::parallel_for("bvh_driver:setup_knn_search_queries",
-                         Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
+    Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes(
+        Kokkos::ViewAllocateWithoutInitializing("bounding_boxes"), n_values);
+    Kokkos::parallel_for("bvh_driver:construct_bounding_boxes",
+                         Kokkos::RangePolicy<ExecutionSpace>(0, n_values),
                          KOKKOS_LAMBDA(int i) {
-                           queries(i) = ArborX::nearest<ArborX::Point>(
-                               random_points(i), n_neighbors);
+                           double const x = random_points(i)[0];
+                           double const y = random_points(i)[1];
+                           double const z = random_points(i)[2];
+                           bounding_boxes(i) = {{{x - 1., y - 1., z - 1.}},
+                                                {{x + 1., y + 1., z + 1.}}};
                          });
     Kokkos::fence();
 
-    Kokkos::View<int *, DeviceType> offset("offset", 0);
-    Kokkos::View<int *, DeviceType> indices("indices", 0);
-    Kokkos::View<int *, DeviceType> ranks("ranks", 0);
-
-    auto &knn = time_monitor.getTimer("knn");
+    auto &construction = time_monitor.getTimer("construction");
     MPI_Barrier(comm);
-    knn.start();
-    distributed_tree.query(queries, indices, offset, ranks);
-    knn.stop();
+    construction.start();
+    ArborX::DistributedSearchTree<DeviceType> distributed_tree(comm,
+                                                               bounding_boxes);
+    construction.stop();
 
+    std::ostream &os = std::cout;
     if (comm_rank == 0)
-      os << "knn done\n";
-  }
+      os << "contruction done\n";
 
-  if (perform_radius_search)
-  {
-    Kokkos::View<ArborX::Within *, DeviceType> queries(
-        Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
-    // radius chosen in order to control the number of results per query
-    // NOTE: minus "1+sqrt(3)/2 \approx 1.37" matches the size of the boxes
-    // inserted into the tree (mid-point between half-edge and
-    // half-diagonal)
-    double const r =
-        2. * std::cbrt(static_cast<double>(n_neighbors) * 3. / (4. * M_PI)) -
-        (1. + std::sqrt(3.)) / 2.;
-    Kokkos::parallel_for("bvh_driver:setup_radius_search_queries",
-                         Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
-                         KOKKOS_LAMBDA(int i) {
-                           queries(i) = ArborX::within(random_points(i), r);
-                         });
-    Kokkos::fence();
+    if (perform_knn_search)
+    {
+      Kokkos::View<ArborX::Nearest<ArborX::Point> *, DeviceType> queries(
+          Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
+      Kokkos::parallel_for("bvh_driver:setup_knn_search_queries",
+                           Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
+                           KOKKOS_LAMBDA(int i) {
+                             queries(i) = ArborX::nearest<ArborX::Point>(
+                                 random_points(i), n_neighbors);
+                           });
+      Kokkos::fence();
 
-    Kokkos::View<int *, DeviceType> offset("offset", 0);
-    Kokkos::View<int *, DeviceType> indices("indices", 0);
-    Kokkos::View<int *, DeviceType> ranks("ranks", 0);
+      Kokkos::View<int *, DeviceType> offset("offset", 0);
+      Kokkos::View<int *, DeviceType> indices("indices", 0);
+      Kokkos::View<int *, DeviceType> ranks("ranks", 0);
 
-    auto &radius = time_monitor.getTimer("radius");
-    MPI_Barrier(comm);
-    radius.start();
-    distributed_tree.query(queries, indices, offset, ranks);
-    radius.stop();
+      auto &knn = time_monitor.getTimer("knn");
+      MPI_Barrier(comm);
+      knn.start();
+      distributed_tree.query(queries, indices, offset, ranks);
+      knn.stop();
 
-    if (comm_rank == 0)
-      os << "radius done\n";
+      if (comm_rank == 0)
+        os << "knn done\n";
+    }
+
+    if (perform_radius_search)
+    {
+      Kokkos::View<ArborX::Within *, DeviceType> queries(
+          Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
+      // radius chosen in order to control the number of results per query
+      // NOTE: minus "1+sqrt(3)/2 \approx 1.37" matches the size of the boxes
+      // inserted into the tree (mid-point between half-edge and
+      // half-diagonal)
+      double const r =
+          2. * std::cbrt(static_cast<double>(n_neighbors) * 3. / (4. * M_PI)) -
+          (1. + std::sqrt(3.)) / 2.;
+      Kokkos::parallel_for("bvh_driver:setup_radius_search_queries",
+                           Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
+                           KOKKOS_LAMBDA(int i) {
+                             queries(i) = ArborX::within(random_points(i), r);
+                           });
+      Kokkos::fence();
+
+      Kokkos::View<int *, DeviceType> offset("offset", 0);
+      Kokkos::View<int *, DeviceType> indices("indices", 0);
+      Kokkos::View<int *, DeviceType> ranks("ranks", 0);
+
+      auto &radius = time_monitor.getTimer("radius");
+      MPI_Barrier(comm);
+      radius.start();
+      distributed_tree.query(queries, indices, offset, ranks);
+      radius.stop();
+
+      if (comm_rank == 0)
+        os << "radius done\n";
+    }
   }
   time_monitor.summarize(comm);
 

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -575,6 +575,8 @@ int main(int argc, char *argv[])
                                      .allow_unregistered()
                                      .run();
     bpo::store(parsed, vm);
+    bpo::notify(vm);
+
     std::vector<std::string> pass_further =
         bpo::collect_unrecognized(parsed.options, bpo::include_positional);
 
@@ -588,6 +590,7 @@ int main(int argc, char *argv[])
 
     PerformanceMonitor performance_monitor;
 
+    std::cout << "node type               : " << node << std::endl;
     if (node == "serial")
     {
 #ifdef KOKKOS_ENABLE_SERIAL

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -237,20 +237,18 @@ struct Arguments
   bool perform_radius_search = true;
   bool performance_regression_run = false;
 
-  void print (std::ostream &os = std::cout) const
+  void print(std::ostream &os = std::cout) const
   {
- os << std::boolalpha;
+    os << std::boolalpha;
     os << "\nRunning with arguments:\n"
-              << "perform knn search      : " << perform_knn_search
-              << '\n'
-              << "perform radius search   : " << perform_radius_search
-              << '\n'
-              << "#points/MPI process     : " << n_values << '\n'
-              << "#queries/MPI process    : " << n_queries << '\n'
-              << "size of shift           : " << shift << '\n'
-              << "dimension               : " << partition_dim << '\n'
-	      << "performance regression  : " << performance_regression_run << '\n'
-              << '\n'; 
+       << "perform knn search      : " << perform_knn_search << '\n'
+       << "perform radius search   : " << perform_radius_search << '\n'
+       << "#points/MPI process     : " << n_values << '\n'
+       << "#queries/MPI process    : " << n_queries << '\n'
+       << "size of shift           : " << shift << '\n'
+       << "dimension               : " << partition_dim << '\n'
+       << "performance regression  : " << performance_regression_run << '\n'
+       << '\n';
   }
 };
 
@@ -466,7 +464,7 @@ void run(std::vector<std::string> const &args,
 
   if (comm_rank == 0)
   {
-	   arguments.print();
+    arguments.print();
   }
 
   const unsigned int n_sample = 10;

--- a/examples/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/examples/distributed_tree_driver/distributed_tree_driver.cpp
@@ -396,8 +396,8 @@ void main_(Arguments const &args, const MPI_Comm comm,
 }
 
 template <class NO>
-int run(std::vector<std::string> const &args, TimeMonitor &time_monitor,
-        MPI_Comm comm)
+void run(std::vector<std::string> const &args, TimeMonitor &time_monitor,
+         MPI_Comm comm)
 {
   Arguments arguments;
 
@@ -561,7 +561,7 @@ int main(int argc, char *argv[])
     {
 #ifdef KOKKOS_ENABLE_OPENMP
       typedef Kokkos::OpenMP Node;
-      run<Node>(pass_further, time_monitor, comm
+      run<Node>(pass_further, time_monitor, comm);
 #else
       throw std::runtime_error("OpenMP node type is disabled");
 #endif


### PR DESCRIPTION
Based on #78, this pull requests improves `DistributedTreeDriver` further. The idea is as follows:
- We first run the test a couple of time to have an estimate for mean and variance of the runtime for the individual sections (`construction`, `knn`, `radius`). (We take the maximum over all MPI processes in each iteration).
- These statistics are used to estimate for each section the number of total iterations needed to get a confidence interval of specified width.
- We run the maximum of these estimates number iterations (additionally) and output mean, variance and a new confidence interval at the end.

All this is based on `CppCon 2015: Bryce Adelstein-Lelbach “Benchmarking C++ Code` and `Boost.Accumulators`.

Sample output:
```
$ mpiexec -np 2 ./ArborX_DistributedTree.exe
ArborX version: 0.9 (dev)
ArborX hash   : 829b702

Running with arguments:
perform knn search      : true
perform radius search   : true
#points/MPI process     : 50000
#queries/MPI process    : 20000
size of shift           : 1
dimension               : 3


Sample lap 0:
contruction done
knn done
radius done

[...]

Sample lap 9:
contruction done
knn done
radius done

estimated 11 iterations

Total lap 10:
contruction done
knn done
radius done

[...]

Total lap 20:
contruction done
knn done
radius done
=========================================================================

TimeMonitor results over 2 processors

Timer Name   | mean         | variance     | confidence interval         
-------------------------------------------------------------------------
construction | 5.052878e-02 | 2.047170e-05 | [4.841836e-02, 5.263920e-02]
knn          | 1.172640e+00 | 2.565172e-02 | [1.097935e+00, 1.247345e+00]
radius       | 6.593428e-01 | 6.237161e-03 | [6.225057e-01, 6.961799e-01]
=========================================================================
```