### PR TITLE
Template unit tests on search tree type

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -33,6 +33,7 @@ template <typename DeviceType>
 class DistributedSearchTree
 {
 public:
+  using device_type = DeviceType;
   using bounding_volume_type = typename BVH<DeviceType>::bounding_volume_type;
   using size_type = typename BVH<DeviceType>::size_type;
 

--- a/test/ArborX_EnableDeviceTypes.hpp.in
+++ b/test/ArborX_EnableDeviceTypes.hpp.in
@@ -5,15 +5,9 @@
 
 #include <boost/utility/identity_type.hpp>
 
-#if defined( KOKKOS_COMPILER_CLANG )
-#include <boost/mpl/list.hpp>
-#define WORKAROUND_SEQUENCE_OF_TYPES boost::mpl::list
-#else
 #include <tuple>
-#define WORKAROUND_SEQUENCE_OF_TYPES std::tuple
-#endif
 
 // clang-format off
-#cmakedefine ARBORX_DEVICE_TYPES BOOST_IDENTITY_TYPE((WORKAROUND_SEQUENCE_OF_TYPES<@ARBORX_DEVICE_TYPES@>))
+#cmakedefine ARBORX_DEVICE_TYPES BOOST_IDENTITY_TYPE((std::tuple<@ARBORX_DEVICE_TYPES@>))
 
 #endif

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -79,6 +79,11 @@ void validateResults(T1 const &reference, T2 const &other)
 
 namespace tt = boost::test_tools;
 
+template <typename T>
+struct is_distributed : std::false_type
+{
+};
+
 template <typename Query, typename DeviceType>
 void checkResults(ArborX::BVH<DeviceType> const &bvh,
                   Kokkos::View<Query *, DeviceType> const &queries,
@@ -125,6 +130,11 @@ void checkResults(ArborX::BVH<DeviceType> const &bvh,
 }
 
 #ifdef ARBORX_ENABLE_MPI
+template <typename D>
+struct is_distributed<ArborX::DistributedSearchTree<D>> : std::true_type
+{
+};
+
 template <typename Query, typename DeviceType>
 void checkResults(ArborX::DistributedSearchTree<DeviceType> const &tree,
                   Kokkos::View<Query *, DeviceType> const &queries,

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -191,16 +191,16 @@ void checkResults(Tree const &tree, Queries const &queries,
 }
 #endif
 
-template <typename DeviceType>
-ArborX::BVH<DeviceType> makeBvh(std::vector<ArborX::Box> const &b)
+template <typename Tree>
+auto make(std::vector<ArborX::Box> const &b)
 {
   int const n = b.size();
-  Kokkos::View<ArborX::Box *, DeviceType> boxes("boxes", n);
+  Kokkos::View<ArborX::Box *, typename Tree::device_type> boxes("boxes", n);
   auto boxes_host = Kokkos::create_mirror_view(boxes);
   for (int i = 0; i < n; ++i)
     boxes_host(i) = b[i];
   Kokkos::deep_copy(boxes, boxes_host);
-  return ArborX::BVH<DeviceType>(boxes);
+  return Tree(boxes);
 }
 
 #ifdef ARBORX_ENABLE_MPI

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -36,6 +36,14 @@ struct TreeTypeTraits<WORKAROUND_SEQUENCE_OF_TYPES<DeviceTypes...>>
   using type = WORKAROUND_SEQUENCE_OF_TYPES<ArborX::BVH<DeviceTypes>...>;
 };
 
+template <typename... DeviceTypes>
+struct TreeTypeTraits<
+    WORKAROUND_SEQUENCE_OF_TYPES<DeviceTypes..., boost::mpl::na>>
+{
+  using type = typename TreeTypeTraits<
+      WORKAROUND_SEQUENCE_OF_TYPES<DeviceTypes...>>::type;
+};
+
 using TreeTypes = typename TreeTypeTraits<ARBORX_DEVICE_TYPES>::type;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, Tree, TreeTypes)

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -30,10 +30,10 @@ namespace tt = boost::test_tools;
 template <typename T>
 struct TreeTypeTraits;
 
-template <typename... Ds>
-struct TreeTypeTraits<WORKAROUND_SEQUENCE_OF_TYPES<Ds...>>
+template <typename... DeviceTypes>
+struct TreeTypeTraits<WORKAROUND_SEQUENCE_OF_TYPES<DeviceTypes...>>
 {
-  using type = WORKAROUND_SEQUENCE_OF_TYPES<ArborX::BVH<Ds>...>;
+  using type = WORKAROUND_SEQUENCE_OF_TYPES<ArborX::BVH<DeviceTypes>...>;
 };
 
 using TreeTypes = typename TreeTypeTraits<ARBORX_DEVICE_TYPES>::type;

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -31,17 +31,9 @@ template <typename T>
 struct TreeTypeTraits;
 
 template <typename... DeviceTypes>
-struct TreeTypeTraits<WORKAROUND_SEQUENCE_OF_TYPES<DeviceTypes...>>
+struct TreeTypeTraits<std::tuple<DeviceTypes...>>
 {
-  using type = WORKAROUND_SEQUENCE_OF_TYPES<ArborX::BVH<DeviceTypes>...>;
-};
-
-template <typename... DeviceTypes>
-struct TreeTypeTraits<
-    WORKAROUND_SEQUENCE_OF_TYPES<DeviceTypes..., boost::mpl::na>>
-{
-  using type = typename TreeTypeTraits<
-      WORKAROUND_SEQUENCE_OF_TYPES<DeviceTypes...>>::type;
+  using type = std::tuple<ArborX::BVH<DeviceTypes>...>;
 };
 
 using TreeTypes = typename TreeTypeTraits<ARBORX_DEVICE_TYPES>::type;

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -31,9 +31,9 @@ template <typename T>
 struct TreeTypeTraits;
 
 template <typename... Ds>
-struct TreeTypeTraits<std::tuple<Ds...>>
+struct TreeTypeTraits<WORKAROUND_SEQUENCE_OF_TYPES<Ds...>>
 {
-  using type = std::tuple<ArborX::BVH<Ds>...>;
+  using type = WORKAROUND_SEQUENCE_OF_TYPES<ArborX::BVH<Ds>...>;
 };
 
 using TreeTypes = typename TreeTypeTraits<ARBORX_DEVICE_TYPES>::type;

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -27,61 +27,73 @@
 
 namespace tt = boost::test_tools;
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
+template <typename T>
+struct TreeTypeTraits;
+
+template <typename... Ds>
+struct TreeTypeTraits<std::tuple<Ds...>>
 {
+  using type = std::tuple<ArborX::BVH<Ds>...>;
+};
+
+using TreeTypes = typename TreeTypeTraits<ARBORX_DEVICE_TYPES>::type;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, Tree, TreeTypes)
+{
+  using device_type = typename Tree::device_type;
   // tree is empty, it has no leaves.
-  for (auto const &empty_bvh : {
-           ArborX::BVH<DeviceType>{}, // default constructed
-           makeBvh<DeviceType>({}),   // constructed with empty view of boxes
+  for (auto const &empty_tree : {
+           Tree{},         // default constructed
+           make<Tree>({}), // constructed with empty view of boxes
        })
   {
-    BOOST_TEST(empty_bvh.empty());
-    BOOST_TEST(empty_bvh.size() == 0);
-    // BVH::bounds() returns an invalid box when the tree is empty.
-    BOOST_TEST(ArborX::Details::equals(empty_bvh.bounds(), {}));
+    BOOST_TEST(empty_tree.empty());
+    BOOST_TEST(empty_tree.size() == 0);
+    // Tree::bounds() returns an invalid box when the tree is empty.
+    BOOST_TEST(ArborX::Details::equals(empty_tree.bounds(), {}));
 
     // Passing a view with no query does seem a bit silly but we still need
     // to support it. And since the tag dispatching yields different tree
     // traversals for nearest and spatial predicates, we do have to check
     // the results for various type of queries.
-    checkResults(empty_bvh, makeOverlapQueries<DeviceType>({}), {}, {0});
+    checkResults(empty_tree, makeOverlapQueries<device_type>({}), {}, {0});
 
     // NOTE: Admittedly testing for both overlap and within queries might be
     // a bit overkill but I'd rather test for all the queries we plan on
     // using.
-    checkResults(empty_bvh, makeWithinQueries<DeviceType>({}), {}, {0});
+    checkResults(empty_tree, makeWithinQueries<device_type>({}), {}, {0});
 
-    checkResults(empty_bvh, makeNearestQueries<DeviceType>({}), {}, {0});
+    checkResults(empty_tree, makeNearestQueries<device_type>({}), {}, {0});
 
     // Passing an empty distance vector.
-    checkResults(empty_bvh, makeNearestQueries<DeviceType>({}), {}, {0});
+    checkResults(empty_tree, makeNearestQueries<device_type>({}), {}, {0});
 
     // Now passing a couple queries of various type and checking the
     // results.
     checkResults(
-        empty_bvh,
-        makeOverlapQueries<DeviceType>({
+        empty_tree,
+        makeOverlapQueries<device_type>({
             {}, // Did not bother giving a valid box here but that's fine.
             {},
         }),
         {}, {0, 0, 0});
 
-    checkResults(empty_bvh,
-                 makeWithinQueries<DeviceType>({
+    checkResults(empty_tree,
+                 makeWithinQueries<device_type>({
                      {{{0., 0., 0.}}, 1.},
                      {{{1., 1., 1.}}, 2.},
                  }),
                  {}, {0, 0, 0});
 
-    checkResults(empty_bvh,
-                 makeNearestQueries<DeviceType>({
+    checkResults(empty_tree,
+                 makeNearestQueries<device_type>({
                      {{{0., 0., 0.}}, 1},
                      {{{1., 1., 1.}}, 2},
                  }),
                  {}, {0, 0, 0});
 
-    checkResults(empty_bvh,
-                 makeNearestQueries<DeviceType>({
+    checkResults(empty_tree,
+                 makeNearestQueries<device_type>({
                      {{{0., 0., 0.}}, 1},
                      {{{1., 1., 1.}}, 2},
                  }),
@@ -89,56 +101,58 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
   }
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, DeviceType, ARBORX_DEVICE_TYPES)
+BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, Tree, TreeTypes)
 {
+  using device_type = typename Tree::device_type;
   // tree has a single leaf (unit box)
-  auto const bvh = makeBvh<DeviceType>({
+  auto const single_leaf_tree = make<Tree>({
       {{{0., 0., 0.}}, {{1., 1., 1.}}},
   });
 
-  BOOST_TEST(!bvh.empty());
-  BOOST_TEST(bvh.size() == 1);
-  BOOST_TEST(
-      ArborX::Details::equals(bvh.bounds(), {{{0., 0., 0.}}, {{1., 1., 1.}}}));
+  BOOST_TEST(!single_leaf_tree.empty());
+  BOOST_TEST(single_leaf_tree.size() == 1);
+  BOOST_TEST(ArborX::Details::equals(single_leaf_tree.bounds(),
+                                     {{{0., 0., 0.}}, {{1., 1., 1.}}}));
 
-  checkResults(bvh, makeOverlapQueries<DeviceType>({}), {}, {0});
+  checkResults(single_leaf_tree, makeOverlapQueries<device_type>({}), {}, {0});
 
-  checkResults(bvh, makeWithinQueries<DeviceType>({}), {}, {0});
+  checkResults(single_leaf_tree, makeWithinQueries<device_type>({}), {}, {0});
 
-  checkResults(bvh, makeNearestQueries<DeviceType>({}), {}, {0});
+  checkResults(single_leaf_tree, makeNearestQueries<device_type>({}), {}, {0});
 
-  checkResults(bvh, makeNearestQueries<DeviceType>({}), {}, {0}, {});
+  checkResults(single_leaf_tree, makeNearestQueries<device_type>({}), {}, {0},
+               {});
 
   checkResults(
-      bvh,
-      makeNearestQueries<DeviceType>({{{0., 0., 0.}, 3}, {{4., 5., 1.}, 1}}),
+      single_leaf_tree,
+      makeNearestQueries<device_type>({{{0., 0., 0.}, 3}, {{4., 5., 1.}, 1}}),
       {0, 0}, {0, 1, 2}, {0., 5.});
 
-  checkResults(bvh,
-               makeOverlapQueries<DeviceType>({
+  checkResults(single_leaf_tree,
+               makeOverlapQueries<device_type>({
                    {{{5., 5., 5.}}, {{5., 5., 5.}}},
                    {{{.5, .5, .5}}, {{.5, .5, .5}}},
                }),
                {0}, {0, 0, 1});
 
-  checkResults(bvh,
-               makeWithinQueries<DeviceType>({
+  checkResults(single_leaf_tree,
+               makeWithinQueries<device_type>({
                    {{{0., 0., 0.}}, 1.},
                    {{{1., 1., 1.}}, 3.},
                    {{{5., 5., 5.}}, 2.},
                }),
                {0, 0}, {0, 1, 2, 2});
 
-  checkResults(bvh,
-               makeNearestQueries<DeviceType>({
+  checkResults(single_leaf_tree,
+               makeNearestQueries<device_type>({
                    {{{0., 0., 0.}}, 1},
                    {{{1., 1., 1.}}, 2},
                    {{{2., 2., 2.}}, 3},
                }),
                {0, 0, 0}, {0, 1, 2, 3});
 
-  checkResults(bvh,
-               makeNearestQueries<DeviceType>({
+  checkResults(single_leaf_tree,
+               makeNearestQueries<device_type>({
                    {{{1., 0., 0.}}, 1},
                    {{{0., 2., 0.}}, 2},
                    {{{0., 0., 3.}}, 3},
@@ -146,61 +160,63 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, DeviceType, ARBORX_DEVICE_TYPES)
                {0, 0, 0}, {0, 1, 2, 3}, {0., 1., 2.});
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, DeviceType,
-                              ARBORX_DEVICE_TYPES)
+BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, Tree, TreeTypes)
 {
-  auto const bvh = makeBvh<DeviceType>({
+  using device_type = typename Tree::device_type;
+
+  auto const couple_leaves_tree = make<Tree>({
       {{{0., 0., 0.}}, {{0., 0., 0.}}},
       {{{1., 1., 1.}}, {{1., 1., 1.}}},
   });
 
-  BOOST_TEST(!bvh.empty());
-  BOOST_TEST(bvh.size() == 2);
-  BOOST_TEST(
-      ArborX::Details::equals(bvh.bounds(), {{{0., 0., 0.}}, {{1., 1., 1.}}}));
+  BOOST_TEST(!couple_leaves_tree.empty());
+  BOOST_TEST(couple_leaves_tree.size() == 2);
+  BOOST_TEST(ArborX::Details::equals(couple_leaves_tree.bounds(),
+                                     {{{0., 0., 0.}}, {{1., 1., 1.}}}));
 
   // single query overlap with nothing
-  checkResults(bvh,
-               makeOverlapQueries<DeviceType>({
+  checkResults(couple_leaves_tree,
+               makeOverlapQueries<device_type>({
                    {},
                }),
                {}, {0, 0});
 
   // single query overlap with both
-  checkResults(bvh,
-               makeOverlapQueries<DeviceType>({
+  checkResults(couple_leaves_tree,
+               makeOverlapQueries<device_type>({
                    {{{0., 0., 0.}}, {{1., 1., 1.}}},
                }),
                {1, 0}, {0, 2});
 
   // single query overlap with only one
-  checkResults(bvh,
-               makeOverlapQueries<DeviceType>({
+  checkResults(couple_leaves_tree,
+               makeOverlapQueries<device_type>({
                    {{{0.5, 0.5, 0.5}}, {{1.5, 1.5, 1.5}}},
                }),
                {1}, {0, 1});
 
   // a couple queries both overlap with nothing
-  checkResults(bvh,
-               makeOverlapQueries<DeviceType>({
+  checkResults(couple_leaves_tree,
+               makeOverlapQueries<device_type>({
                    {},
                    {},
                }),
                {}, {0, 0, 0});
 
   // a couple queries first overlap with nothing second with only one
-  checkResults(bvh,
-               makeOverlapQueries<DeviceType>({
+  checkResults(couple_leaves_tree,
+               makeOverlapQueries<device_type>({
                    {},
                    {{{0., 0., 0.}}, {{0., 0., 0.}}},
                }),
                {0}, {0, 0, 1});
 
   // no query
-  checkResults(bvh, makeOverlapQueries<DeviceType>({}), {}, {0});
+  checkResults(couple_leaves_tree, makeOverlapQueries<device_type>({}), {},
+               {0});
 
-  checkResults(bvh,
-               makeNearestQueries<DeviceType>({
+  checkResults(couple_leaves_tree,
+               makeNearestQueries<device_type>({
                    {{{0., 0., 0.}}, 2},
                    {{{1., 0., 0.}}, 4},
                }),
@@ -215,7 +231,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(duplicated_leaves, DeviceType,
   // when building trees over ~10M indexable values.  The hierarchy generated
   // at construction had leaves with no parent which yielded a segfault later
   // when computing bounding boxes and walking the hierarchy toward the root.
-  auto const bvh = makeBvh<DeviceType>({
+  auto const bvh = make<ArborX::BVH<DeviceType>>({
       {{{0., 0., 0.}}, {{0., 0., 0.}}},
       {{{1., 1., 1.}}, {{1., 1., 1.}}},
       {{{1., 1., 1.}}, {{1., 1., 1.}}},
@@ -234,7 +250,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(duplicated_leaves, DeviceType,
 BOOST_AUTO_TEST_CASE_TEMPLATE(buffer_optimization, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  auto const bvh = makeBvh<DeviceType>({
+  auto const bvh = make<ArborX::BVH<DeviceType>>({
       {{{0., 0., 0.}}, {{0., 0., 0.}}},
       {{{1., 0., 0.}}, {{1., 0., 0.}}},
       {{{2., 0., 0.}}, {{2., 0., 0.}}},
@@ -309,7 +325,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity, DeviceType,
     double const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
-  auto const bvh = makeBvh<DeviceType>(boxes);
+  auto const bvh = make<ArborX::BVH<DeviceType>>(boxes);
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> offset("offset", 0);
@@ -332,10 +348,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity, DeviceType,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(miscellaneous, DeviceType, ARBORX_DEVICE_TYPES)
 {
-  auto const bvh = makeBvh<DeviceType>({
+  auto const bvh = make<ArborX::BVH<DeviceType>>({
       {{{1., 3., 5.}}, {{2., 4., 6.}}},
   });
-  auto const empty_bvh = makeBvh<DeviceType>({});
+  auto const empty_bvh = make<ArborX::BVH<DeviceType>>({});
 
   // Batched queries BVH::query( Kokkos::View<Query *, ...>, ... ) returns
   // early if the tree is empty.  Below we ensure that a direct call to the


### PR DESCRIPTION
The motivation for these changes is to be able to instantiate these same unit tests for the "brute force tree" as well.  This PR provides the necessary changes to the helper functions to check results and construct trees.

You may notice I did not bother pushing the changes to all unit tests.  I am still unsure on whether/how to split the file.  Some of the tests (https://github.com/arborx/ArborX/blob/5935ea40b51dd66488f82027d72c1e2a55bf3ae8/test/tstLinearBVH.cpp#L333-L368 in particular) are specifically written for `BVH` and would not make sense for the brute force tree.  Also in my current working version I commented out https://github.com/arborx/ArborX/blob/5935ea40b51dd66488f82027d72c1e2a55bf3ae8/test/tstLinearBVH.cpp#L756-L763.  Anyway my point here is I plan on cleaning these things out later.