### PR TITLE
[WIP] Perform user work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(ArborX_ENABLE_MPI)
 endif()
 #target_compile_features(ArborX INTERFACE cxx_std_14)
 
+find_package(Boost REQUIRED COMPONENTS mpi serialization)
+target_link_libraries(ArborX INTERFACE Boost::mpi)
+target_link_libraries(ArborX INTERFACE Boost::serialization)
+
 target_include_directories(ArborX INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/details>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,7 @@ add_test(NAME ArborX_DetailsBatchedQueries COMMAND ./ArborX_DetailsBatchedQuerie
 if(ArborX_ENABLE_MPI)
   add_executable(ArborX_DistributedSearchTree.exe tstDistributedSearchTree.cpp utf_main.cpp)
   target_link_libraries(ArborX_DistributedSearchTree.exe PRIVATE ArborX Boost::unit_test_framework)
+  target_link_libraries(ArborX_DistributedSearchTree.exe PRIVATE ArborX Boost::serialization)
   target_compile_definitions(ArborX_DistributedSearchTree.exe PRIVATE BOOST_TEST_DYN_LINK ARBORX_MPI_UNIT_TEST)
   target_include_directories(ArborX_DistributedSearchTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
   add_test(NAME ArborX_DistributedSearchTree COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ./ArborX_DistributedSearchTree.exe ${MPIEXEC_POSTFLAGS})


### PR DESCRIPTION
This is a first step for #86 There is no point in looking at the implementation yet, it only works in serial and uses boost even if it is not necessary. I just want to discuss about the [interface](https://github.com/arborx/ArborX/compare/master...Rombur:delegate_work?expand=1#diff-103cb0b3c6d4ff80865cc372c70a9c45R65-R71). In particular, do we still want to have `indices`, `offset`, and `ranks` in the interface. They don't need to be there if we don't return them to the user. Personaly I would remove them but I would still provided them to the user's functor so if the user want to save them it would be her job. The other question is how do we want to get the user's data. For now, the user needs to create a vector of `Data` with as many elements as ranks. This allows me to simply do a `all_to_all` and then, the user can just filter the results the way she wants. The advantage is that it's simple for us and for the user. The disadvantage is that if the data is large the memory consumption may be large.