### PR TITLE
Fixup for primitives access traits

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -125,7 +125,7 @@ template <typename DeviceType>
 template <typename Primitives>
 BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
     Primitives const &primitives)
-    : _size(primitives.extent(0))
+    : _size(Details::Traits::Access<Primitives>::size(primitives))
     , _internal_and_leaf_nodes(
           Kokkos::ViewAllocateWithoutInitializing("internal_and_leaf_nodes"),
           _size > 0 ? 2 * _size - 1 : 0)

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -224,8 +224,8 @@ inline void assignMortonCodesDispatch(BoxTag, Primitives const &primitives,
                                       MortonCodes morton_codes,
                                       Box const &scene_bounding_box)
 {
-  using ExecutionSpace = typename Primitives::execution_space;
   using Access = typename Traits::Access<Primitives>;
+  using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(ARBORX_MARK_REGION("assign_morton_codes"),
                        Kokkos::RangePolicy<ExecutionSpace>(0, n),
@@ -243,8 +243,8 @@ inline void assignMortonCodesDispatch(PointTag, Primitives const &primitives,
                                       MortonCodes morton_codes,
                                       Box const &scene_bounding_box)
 {
-  using ExecutionSpace = typename Primitives::execution_space;
   using Access = typename Traits::Access<Primitives>;
+  using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("assign_morton_codes"),
@@ -278,8 +278,8 @@ inline void initializeLeafNodesDispatch(BoxTag, Primitives const &primitives,
                                         Indices permutation_indices,
                                         Nodes leaf_nodes)
 {
-  using ExecutionSpace = typename Primitives::execution_space;
   using Access = typename Traits::Access<Primitives>;
+  using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("initialize_leaf_nodes"),
@@ -296,8 +296,8 @@ inline void initializeLeafNodesDispatch(PointTag, Primitives const &primitives,
                                         Indices permutation_indices,
                                         Nodes leaf_nodes)
 {
-  using ExecutionSpace = typename Primitives::execution_space;
   using Access = typename Traits::Access<Primitives>;
+  using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("initialize_leaf_nodes"),


### PR DESCRIPTION
We were accidentally still making assumptions about the primitives.  This PR makes sure that we always go through the access traits to get information about the argument passed to the bvh constructor.  Admittedly we might want to get the execution space some other way in the future but this falls outside the scope of this PR.