### PR TITLE
Temporarily remove concept checks in tree construction

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -132,15 +132,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
 {
   Kokkos::Profiling::pushRegion("ArborX:BVH:construction");
 
-  // FIXME can be relaxed
-  static_assert(
-      Kokkos::is_view<Primitives>::value,
-      "Must pass a view to the bounding volume hierarchy constructor");
-  static_assert(KokkosExt::is_accessible_from<
-                    typename Details::Traits::Access<Primitives>::MemorySpace,
-                    typename device_type::execution_space>::value,
-                "Primitives must be accessible from bounding volume hierarchy "
-                "execution space");
+  // FIXME placeholder for concept check
 
   if (empty())
   {

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -203,12 +203,6 @@ template <typename Primitives>
 inline void TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
     Primitives const &primitives, Box &scene_bounding_box)
 {
-  static_assert(Kokkos::is_view<Primitives>::value, "Must pass a view");
-  static_assert(
-      std::is_same<typename Primitives::traits::device_type, DeviceType>::value,
-      "Wrong device type");
-  // TODO static_assert( is_expandable_v<Box, typename
-  // Primitives::value_type), "");
   using Access = typename Traits::Access<Primitives>;
   auto const n = Access::size(primitives);
   Kokkos::parallel_reduce(


### PR DESCRIPTION
Will restore later today or tomorrow.
This simplifies greatly history when cherry-picking changes.