### PR TITLE
Improve error messages in BVH constructor and BVH::query()

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -18,6 +18,7 @@
 #include <ArborX_DetailsKokkosExt.hpp>
 #include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsSortUtils.hpp>
+#include <ArborX_DetailsTags.hpp>
 #include <ArborX_DetailsTreeConstruction.hpp>
 #include <ArborX_Traits.hpp>
 
@@ -59,7 +60,7 @@ public:
     // FIXME placeholder for concept check
 
     using Tag =
-        typename Details::TagHelper<Predicates, Traits::PredicatesTag>::type;
+        typename Details::Tag<Details::decay_result_of_get_t<Access>>::type;
     static_assert(std::is_same<Tag, Details::NearestPredicateTag>::value ||
                       std::is_same<Tag, Details::SpatialPredicateTag>::value,
                   "Invalid tag for the predicates");

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -57,8 +57,28 @@ public:
   template <typename Predicates, typename... Args>
   void query(Predicates const &predicates, Args &&... args) const
   {
-    // FIXME placeholder for concept check
-
+    using Access = Traits::Access<Predicates, Traits::PredicatesTag>;
+    static_assert(
+        Details::is_complete<Access>::value,
+        "Must specialize 'Traits::Access<Predicates,Traits::PredicatesTag>'");
+    static_assert(
+        Details::has_memory_space<Access>::value,
+        "Traits::Access<Predicates,Traits::PredicatesTag> must define "
+        "'memory_space' member type that is a valid Kokkos memory space");
+    static_assert(
+        KokkosExt::is_accessible_from<
+            typename Access::memory_space,
+            typename device_type::execution_space>::value,
+        "Traits::Access<Predicates,Traits::PredicatesTag>::memory_space must "
+        "be accessible from the bounding volume hierarchy execution space");
+    static_assert(
+        Details::has_size<Access>::value,
+        "Traits::Access<Predicates,Traits::PredicatesTag> must define "
+        "'size()' member function");
+    static_assert(
+        Details::has_get<Access>::value,
+        "Traits::Access<Predicates,Traits::PredicatesTag> must define 'get()' "
+        "member function");
     using Tag =
         typename Details::Tag<Details::decay_result_of_get_t<Access>>::type;
     static_assert(std::is_same<Tag, Details::NearestPredicateTag>::value ||
@@ -137,7 +157,31 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
 {
   Kokkos::Profiling::pushRegion("ArborX:BVH:construction");
 
-  // FIXME placeholder for concept check
+  using Access = Traits::Access<Primitives, Traits::PrimitivesTag>;
+  static_assert(
+      Details::is_complete<Access>::value,
+      "Must specialize 'Traits::Access<Primitives,Traits::PrimitivesTag>'");
+  static_assert(
+      Details::has_memory_space<Access>::value,
+      "Traits::Access<Primitives,Traits::PrimitivesTag> must define "
+      "'memory_space' member type that is a valid Kokkos memory space");
+  static_assert(
+      KokkosExt::is_accessible_from<
+          typename Access::memory_space,
+          typename device_type::execution_space>::value,
+      "Traits::Access<Primitives,Traits::PrimitivesTag>::memory_space must be "
+      "accessible from the bounding volume hierarchy execution space");
+  static_assert(Details::has_size<Access>::value,
+                "Traits::Access<Primitives,Traits::PrimitivesTag> must define "
+                "'size()' member function");
+  static_assert(Details::has_get<Access>::value,
+                "Traits::Access<Primitives,Traits::PrimitivesTag> must define "
+                "'get()' member function");
+  static_assert(
+      std::is_same<Details::decay_result_of_get_t<Access>, Point>::value ||
+          std::is_same<Details::decay_result_of_get_t<Access>, Box>::value,
+      "Traits::Access<Primitives,Traits::PrimitivesTag>::get() return type "
+      "must decay to Point or to Box");
 
   if (empty())
   {

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -241,16 +241,6 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   Kokkos::Profiling::popRegion();
 }
 
-// FIXME not sure where to put these
-static_assert(Details::is_expandable<Box, Box>::value, "");
-static_assert(Details::is_expandable<Box, Box const>::value, "");
-static_assert(Details::is_expandable<Box, Point>::value, "");
-static_assert(Details::is_expandable<Box, Point const>::value, "");
-static_assert(Details::has_centroid<Box, Point>::value, "");
-static_assert(Details::has_centroid<Box const, Point>::value, "");
-static_assert(Details::has_centroid<Point, Point>::value, "");
-static_assert(Details::has_centroid<Point const, Point>::value, "");
-
 } // namespace ArborX
 
 #endif

--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -182,6 +182,9 @@ KOKKOS_INLINE_FUNCTION
 void centroid(Point const &point, Point &c) { c = point; }
 
 KOKKOS_INLINE_FUNCTION
+void centroid(Sphere const &sphere, Point &c) { c = sphere.centroid(); }
+
+KOKKOS_INLINE_FUNCTION
 Point returnCentroid(Point const &point) { return point; }
 
 KOKKOS_INLINE_FUNCTION

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -107,6 +107,17 @@ struct first_template_parameter<E<Head, Tail...>>
 template <typename T>
 using first_template_parameter_t = typename first_template_parameter<T>::type;
 
+template <typename Traits>
+struct result_of_get
+{
+  using type = decltype(Traits::get(
+      std::declval<first_template_parameter_t<Traits> const &>(), 0));
+};
+
+template <typename Traits>
+using decay_result_of_get_t =
+    std::decay_t<typename result_of_get<Traits>::type>;
+
 } // namespace Details
 } // namespace ArborX
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -70,6 +70,18 @@ std::false_type is_complete_impl(...);
 template <class T>
 using is_complete = decltype(is_complete_impl(std::declval<T *>()));
 
+template <typename T, typename TTag, typename = void>
+struct has_access_traits : std::false_type
+{
+};
+
+template <typename T, typename TTag>
+struct has_access_traits<
+    T, TTag, std::enable_if_t<is_complete<Traits::Access<T, TTag>>::value>>
+    : std::true_type
+{
+};
+
 } // namespace Details
 } // namespace ArborX
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -118,6 +118,34 @@ template <typename Traits>
 using decay_result_of_get_t =
     std::decay_t<typename result_of_get<Traits>::type>;
 
+template <typename Traits, typename = void>
+struct has_get : std::false_type
+{
+};
+
+template <typename Traits>
+struct has_get<
+    Traits,
+    std::void_t<decltype(Traits::get(
+        std::declval<first_template_parameter_t<Traits> const &>(), 0))>>
+    : std::true_type
+{
+};
+
+template <typename Traits, typename = void>
+struct has_size : std::false_type
+{
+};
+
+template <typename Traits>
+struct has_size<
+    Traits,
+    std::enable_if_t<std::is_integral<decltype(Traits::size(
+        std::declval<first_template_parameter_t<Traits> const &>()))>::value>>
+    : std::true_type
+{
+};
+
 } // namespace Details
 } // namespace ArborX
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -95,6 +95,18 @@ struct has_memory_space<
 {
 };
 
+template <typename T>
+struct first_template_parameter;
+
+template <template <typename...> class E, typename Head, typename... Tail>
+struct first_template_parameter<E<Head, Tail...>>
+{
+  using type = Head;
+};
+
+template <typename T>
+using first_template_parameter_t = typename first_template_parameter<T>::type;
+
 } // namespace Details
 } // namespace ArborX
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -12,6 +12,7 @@
 #define ARBORX_DETAILS_CONCEPTS_HPP
 
 #include <ArborX_DetailsAlgorithms.hpp>
+#include <ArborX_Traits.hpp>
 
 #include <type_traits>
 
@@ -59,6 +60,15 @@ struct has_centroid<
                                   std::declval<Point &>()))>> : std::true_type
 {
 };
+
+// is_complete implementation taken from https://stackoverflow.com/a/44229779
+template <class T, std::size_t = sizeof(T)>
+std::true_type is_complete_impl(T *);
+
+std::false_type is_complete_impl(...);
+
+template <class T>
+using is_complete = decltype(is_complete_impl(std::declval<T *>()));
 
 } // namespace Details
 } // namespace ArborX

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -82,6 +82,19 @@ struct has_access_traits<
 {
 };
 
+template <typename T, typename = void>
+struct has_memory_space : std::false_type
+{
+};
+
+template <typename T>
+struct has_memory_space<
+    T,
+    std::enable_if_t<Kokkos::is_memory_space<typename T::memory_space>::value>>
+    : std::true_type
+{
+};
+
 } // namespace Details
 } // namespace ArborX
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -14,6 +14,7 @@
 
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsAlgorithms.hpp> // expand
+#include <ArborX_DetailsConcepts.hpp>   // decay_result_of_get_t
 #include <ArborX_DetailsKokkosExt.hpp>  // clz, min, max, sgn
 #include <ArborX_DetailsMortonCode.hpp> // morton3D
 #include <ArborX_DetailsNode.hpp>
@@ -36,20 +37,6 @@ namespace ArborX
 {
 namespace Details
 {
-
-// Deduce the tag from the return type of the get() member function in the
-// access traits.
-template <typename T, typename TTag>
-struct TagHelper
-{
-private:
-  using accessor_return_type =
-      std::decay_t<decltype(Traits::Access<T, TTag>::get(
-          std::declval<T const &>(), std::declval<int>()))>;
-
-public:
-  using type = typename Tag<accessor_return_type>::type;
-};
 
 /**
  * This structure contains all the functions used to build the BVH. All the
@@ -277,7 +264,7 @@ inline void TreeConstruction<DeviceType>::assignMortonCodes(
   auto const n = Access::size(primitives);
   ARBORX_ASSERT(morton_codes.extent(0) == n);
 
-  using Tag = typename TagHelper<Primitives, Traits::PrimitivesTag>::type;
+  using Tag = typename Tag<decay_result_of_get_t<Access>>::type;
   assignMortonCodesDispatch(Tag{}, primitives, morton_codes,
                             scene_bounding_box);
 }
@@ -337,7 +324,7 @@ inline void TreeConstruction<DeviceType>::initializeLeafNodes(
                 "Encoding leaf index in pointer to child is not safe if the "
                 "index and pointer types do not have the same size");
 
-  using Tag = typename TagHelper<Primitives, Traits::PrimitivesTag>::type;
+  using Tag = typename Tag<decay_result_of_get_t<Access>>::type;
   initializeLeafNodesDispatch(Tag{}, primitives, permutation_indices,
                               leaf_nodes);
 }

--- a/src/details/ArborX_Traits.hpp
+++ b/src/details/ArborX_Traits.hpp
@@ -31,10 +31,9 @@ struct PredicatesTag
 {
 };
 
+// Only a declaration so that existence of a specialization can be detected
 template <typename T, typename Tag, typename Enable = void>
-struct Access
-{
-};
+struct Access;
 
 template <typename View, typename Tag>
 struct Access<View, Tag,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,10 @@ configure_file(ArborX_EnableDeviceTypes.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/Arbor
 
 find_package(Boost 1.67.0 REQUIRED COMPONENTS unit_test_framework)
 
+# Compile only, nothing to run
+add_executable(ArborX_DetailsConcepts.exe tstDetailsConcepts.cpp)
+target_link_libraries(ArborX_DetailsConcepts.exe PRIVATE ArborX)
+
 add_executable(ArborX_Miscellaneous.exe tstMiscellaneous.cpp tstException.cpp)
 # TODO link Boost::dynamic_linking interface target to enable dynamic linking
 # (adds BOOST_ALL_DYN_LINK)

--- a/test/tstDetailsConcepts.cpp
+++ b/test/tstDetailsConcepts.cpp
@@ -1,0 +1,29 @@
+#include <ArborX_DetailsConcepts.hpp>
+
+using ArborX::Box;
+using ArborX::Point;
+using ArborX::Sphere;
+using ArborX::Details::has_centroid;
+using ArborX::Details::is_expandable;
+
+static_assert(is_expandable<Box, Box>::value, "");
+static_assert(is_expandable<Box, Box const>::value, "");
+static_assert(!is_expandable<Box const, Box>::value, "");
+
+static_assert(is_expandable<Box, Point>::value, "");
+static_assert(is_expandable<Box, Sphere>::value, "");
+
+static_assert(!is_expandable<Point, Point>::value, "");
+static_assert(!is_expandable<Point, Box>::value, "");
+static_assert(!is_expandable<Point, Sphere>::value, "");
+
+// NOTE Possible but not implemented
+static_assert(!is_expandable<Sphere, Point>::value, "");
+static_assert(!is_expandable<Sphere, Box>::value, "");
+static_assert(!is_expandable<Sphere, Sphere>::value, "");
+
+static_assert(has_centroid<Box, Point>::value, "");
+static_assert(has_centroid<Point, Point>::value, "");
+static_assert(has_centroid<Sphere, Point>::value, "");
+
+int main() {}

--- a/test/tstDetailsConcepts.cpp
+++ b/test/tstDetailsConcepts.cpp
@@ -1,5 +1,7 @@
 #include <ArborX_DetailsConcepts.hpp>
 
+#include <Kokkos_Core.hpp>
+
 #include <tuple>
 
 using ArborX::Box;
@@ -44,6 +46,40 @@ static_assert(!is_complete<NotSpecializedForIntegralTypes<int>>::value);
 using ArborX::Details::first_template_parameter_t;
 static_assert(std::is_same<first_template_parameter_t<std::tuple<int, float>>,
                            int>::value,
+              "");
+
+using ArborX::Details::has_access_traits;
+using ArborX::Traits::PredicatesTag;
+using ArborX::Traits::PrimitivesTag;
+struct HasNoAccessTraitsSpecialization
+{
+};
+struct HasEmptySpecialization
+{
+};
+namespace ArborX
+{
+namespace Traits
+{
+template <typename Tag>
+struct Access<HasEmptySpecialization, Tag>
+{
+};
+} // namespace Traits
+} // namespace ArborX
+static_assert(has_access_traits<Kokkos::View<double *>, PrimitivesTag>::value,
+              "");
+static_assert(has_access_traits<Kokkos::View<double *>, PredicatesTag>::value,
+              "");
+static_assert(
+    !has_access_traits<HasNoAccessTraitsSpecialization, PrimitivesTag>::value,
+    "");
+static_assert(
+    !has_access_traits<HasNoAccessTraitsSpecialization, PredicatesTag>::value,
+    "");
+static_assert(has_access_traits<HasEmptySpecialization, PrimitivesTag>::value,
+              "");
+static_assert(has_access_traits<HasEmptySpecialization, PredicatesTag>::value,
               "");
 
 int main() {}

--- a/test/tstDetailsConcepts.cpp
+++ b/test/tstDetailsConcepts.cpp
@@ -26,4 +26,17 @@ static_assert(has_centroid<Box, Point>::value, "");
 static_assert(has_centroid<Point, Point>::value, "");
 static_assert(has_centroid<Sphere, Point>::value, "");
 
+using ArborX::Details::is_complete;
+
+template <typename T, typename Enable = void>
+struct NotSpecializedForIntegralTypes;
+template <typename T>
+struct NotSpecializedForIntegralTypes<
+    T, std::enable_if_t<!std::is_integral<T>::value>>
+{
+};
+
+static_assert(is_complete<NotSpecializedForIntegralTypes<float>>::value);
+static_assert(!is_complete<NotSpecializedForIntegralTypes<int>>::value);
+
 int main() {}

--- a/test/tstDetailsConcepts.cpp
+++ b/test/tstDetailsConcepts.cpp
@@ -1,5 +1,7 @@
 #include <ArborX_DetailsConcepts.hpp>
 
+#include <tuple>
+
 using ArborX::Box;
 using ArborX::Point;
 using ArborX::Sphere;
@@ -38,5 +40,10 @@ struct NotSpecializedForIntegralTypes<
 
 static_assert(is_complete<NotSpecializedForIntegralTypes<float>>::value);
 static_assert(!is_complete<NotSpecializedForIntegralTypes<int>>::value);
+
+using ArborX::Details::first_template_parameter_t;
+static_assert(std::is_same<first_template_parameter_t<std::tuple<int, float>>,
+                           int>::value,
+              "");
 
 int main() {}


### PR DESCRIPTION
As promised here https://github.com/arborx/ArborX/pull/111#issue-321706817
restoring the concept checks.