### PR TITLE
Mark BVH::{size,empty,bounds} as noexcept

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -43,15 +43,15 @@ public:
   /** Returns the smallest axis-aligned box able to contain all the objects
    *  stored in the tree or an invalid box if the tree is empty.
    */
-  bounding_volume_type bounds() const { return _top_tree.bounds(); }
+  bounding_volume_type bounds() const noexcept { return _top_tree.bounds(); }
 
   /** Returns the global number of objects stored in the tree.
    */
-  size_type size() const { return _top_tree_size; }
+  size_type size() const noexcept { return _top_tree_size; }
 
   /** Indicates whether the tree is empty on all processes.
    */
-  bool empty() const { return size() == 0; }
+  bool empty() const noexcept { return size() == 0; }
 
   /** \brief Finds object satisfying the passed predicates (e.g. nearest to
    *  some point or overlaping with some box)

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -46,12 +46,12 @@ public:
   BoundingVolumeHierarchy(Primitives const &primitives);
 
   KOKKOS_INLINE_FUNCTION
-  size_type size() const { return _size; }
+  size_type size() const noexcept { return _size; }
 
   KOKKOS_INLINE_FUNCTION
-  bool empty() const { return size() == 0; }
+  bool empty() const noexcept { return size() == 0; }
 
-  bounding_volume_type bounds() const { return _bounds; }
+  bounding_volume_type bounds() const noexcept { return _bounds; }
 
   template <typename Predicates, typename... Args>
   void query(Predicates const &predicates, Args &&... args) const


### PR DESCRIPTION
I started working on the documentation of `ArborX::BVH` and realized this was trivial to guarantee.
I cannot think of any reasonable changes in the code that would break that.  (Yes I thought of lazy-construction of the tree and no I do not consider as something worth doing.)