### PR TITLE
Refactor access traits

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -125,7 +125,7 @@ template <typename DeviceType>
 template <typename Primitives>
 BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
     Primitives const &primitives)
-    : _size(Traits::Access<Primitives>::size(primitives))
+    : _size(Traits::Access<Primitives, Traits::PrimitivesTag>::size(primitives))
     , _internal_and_leaf_nodes(
           Kokkos::ViewAllocateWithoutInitializing("internal_and_leaf_nodes"),
           _size > 0 ? 2 * _size - 1 : 0)

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -172,7 +172,7 @@ template <typename Primitives>
 class CalculateBoundingBoxOfTheSceneFunctor
 {
 public:
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
 
   CalculateBoundingBoxOfTheSceneFunctor(Primitives const &primitives)
       : _primitives(primitives)
@@ -203,7 +203,7 @@ template <typename Primitives>
 inline void TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
     Primitives const &primitives, Box &scene_bounding_box)
 {
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
   auto const n = Access::size(primitives);
   Kokkos::parallel_reduce(
       ARBORX_MARK_REGION("calculate_bounding_box_of_the_scene"),
@@ -218,7 +218,7 @@ inline void assignMortonCodesDispatch(BoxTag, Primitives const &primitives,
                                       MortonCodes morton_codes,
                                       Box const &scene_bounding_box)
 {
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
   using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(ARBORX_MARK_REGION("assign_morton_codes"),
@@ -237,7 +237,7 @@ inline void assignMortonCodesDispatch(PointTag, Primitives const &primitives,
                                       MortonCodes morton_codes,
                                       Box const &scene_bounding_box)
 {
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
   using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
@@ -257,7 +257,7 @@ inline void TreeConstruction<DeviceType>::assignMortonCodes(
     Kokkos::View<unsigned int *, DeviceType> morton_codes,
     Box const &scene_bounding_box)
 {
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
 
   auto const n = Access::size(primitives);
   ARBORX_ASSERT(morton_codes.extent(0) == n);
@@ -272,7 +272,7 @@ inline void initializeLeafNodesDispatch(BoxTag, Primitives const &primitives,
                                         Indices permutation_indices,
                                         Nodes leaf_nodes)
 {
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
   using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
@@ -290,7 +290,7 @@ inline void initializeLeafNodesDispatch(PointTag, Primitives const &primitives,
                                         Indices permutation_indices,
                                         Nodes leaf_nodes)
 {
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
   using ExecutionSpace = typename Access::MemorySpace::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
@@ -311,7 +311,7 @@ inline void TreeConstruction<DeviceType>::initializeLeafNodes(
     Kokkos::View<size_t const *, DeviceType> permutation_indices,
     Kokkos::View<Node *, DeviceType> leaf_nodes)
 {
-  using Access = typename Traits::Access<Primitives>;
+  using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
 
   auto const n = Access::size(primitives);
   ARBORX_ASSERT(permutation_indices.extent(0) == n);

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -219,7 +219,7 @@ inline void assignMortonCodesDispatch(BoxTag, Primitives const &primitives,
                                       Box const &scene_bounding_box)
 {
   using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
-  using ExecutionSpace = typename Access::MemorySpace::execution_space;
+  using ExecutionSpace = typename Access::memory_space::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(ARBORX_MARK_REGION("assign_morton_codes"),
                        Kokkos::RangePolicy<ExecutionSpace>(0, n),
@@ -238,7 +238,7 @@ inline void assignMortonCodesDispatch(PointTag, Primitives const &primitives,
                                       Box const &scene_bounding_box)
 {
   using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
-  using ExecutionSpace = typename Access::MemorySpace::execution_space;
+  using ExecutionSpace = typename Access::memory_space::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("assign_morton_codes"),
@@ -273,7 +273,7 @@ inline void initializeLeafNodesDispatch(BoxTag, Primitives const &primitives,
                                         Nodes leaf_nodes)
 {
   using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
-  using ExecutionSpace = typename Access::MemorySpace::execution_space;
+  using ExecutionSpace = typename Access::memory_space::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("initialize_leaf_nodes"),
@@ -291,7 +291,7 @@ inline void initializeLeafNodesDispatch(PointTag, Primitives const &primitives,
                                         Nodes leaf_nodes)
 {
   using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
-  using ExecutionSpace = typename Access::MemorySpace::execution_space;
+  using ExecutionSpace = typename Access::memory_space::execution_space;
   auto const n = Access::size(primitives);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("initialize_leaf_nodes"),

--- a/src/details/ArborX_Traits.hpp
+++ b/src/details/ArborX_Traits.hpp
@@ -36,8 +36,8 @@ struct Access
 {
 };
 
-template <typename View, typename TTag>
-struct Access<View, TTag,
+template <typename View, typename Tag>
+struct Access<View, Tag,
               typename std::enable_if<Kokkos::is_view<View>::value &&
                                       View::rank == 1>::type>
 {
@@ -50,12 +50,11 @@ struct Access<View, TTag,
 
   static typename View::size_type size(View const &v) { return v.extent(0); }
 
-  using Tag = typename Details::Tag<typename View::value_type>::type;
   using memory_space = typename View::memory_space;
 };
 
-template <typename View, typename TTag>
-struct Access<View, TTag,
+template <typename View, typename Tag>
+struct Access<View, Tag,
               typename std::enable_if<Kokkos::is_view<View>::value &&
                                       View::rank == 2>::type>
 {
@@ -67,7 +66,6 @@ struct Access<View, TTag,
 
   static typename View::size_type size(View const &v) { return v.extent(0); }
 
-  using Tag = Details::PointTag;
   using memory_space = typename View::memory_space;
 };
 

--- a/src/details/ArborX_Traits.hpp
+++ b/src/details/ArborX_Traits.hpp
@@ -51,7 +51,7 @@ struct Access<View, TTag,
   static typename View::size_type size(View const &v) { return v.extent(0); }
 
   using Tag = typename Details::Tag<typename View::value_type>::type;
-  using MemorySpace = typename View::memory_space;
+  using memory_space = typename View::memory_space;
 };
 
 template <typename View, typename TTag>
@@ -68,7 +68,7 @@ struct Access<View, TTag,
   static typename View::size_type size(View const &v) { return v.extent(0); }
 
   using Tag = Details::PointTag;
-  using MemorySpace = typename View::memory_space;
+  using memory_space = typename View::memory_space;
 };
 
 } // namespace Traits

--- a/src/details/ArborX_Traits.hpp
+++ b/src/details/ArborX_Traits.hpp
@@ -23,14 +23,23 @@ namespace ArborX
 namespace Traits
 {
 
-template <typename T, typename Enable = void>
+struct PrimitivesTag
+{
+};
+
+struct PredicatesTag
+{
+};
+
+template <typename T, typename Tag, typename Enable = void>
 struct Access
 {
 };
 
-template <typename View>
-struct Access<View, typename std::enable_if<Kokkos::is_view<View>::value &&
-                                            View::rank == 1>::type>
+template <typename View, typename TTag>
+struct Access<View, TTag,
+              typename std::enable_if<Kokkos::is_view<View>::value &&
+                                      View::rank == 1>::type>
 {
   // Returns a const reference
   KOKKOS_FUNCTION static typename View::const_value_type &get(View const &v,
@@ -45,9 +54,10 @@ struct Access<View, typename std::enable_if<Kokkos::is_view<View>::value &&
   using MemorySpace = typename View::memory_space;
 };
 
-template <typename View>
-struct Access<View, typename std::enable_if<Kokkos::is_view<View>::value &&
-                                            View::rank == 2>::type>
+template <typename View, typename TTag>
+struct Access<View, TTag,
+              typename std::enable_if<Kokkos::is_view<View>::value &&
+                                      View::rank == 2>::type>
 {
   // Returns by value
   KOKKOS_FUNCTION static Point get(View const &v, int i)


### PR DESCRIPTION
* Added 2nd template argument to indicate that access traits are for the BVH constructor
* Geometry tag is deduced from the return type of `Traits::Access::<Primitives,PrimitivesTag>::get()`