### PR TITLE
Revert "Only add the link path for clang"

### DIFF
--- a/cmake/FindKokkos.cmake
+++ b/cmake/FindKokkos.cmake
@@ -93,7 +93,7 @@ endforeach()
 
 # For clang we need to add the cudart library explicitly
 # since Kokkos doesn't do that for us.
-if(Kokkos_DEVICES MATCHES "Cuda" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(Kokkos_DEVICES MATCHES "Cuda")
   find_package(CUDA REQUIRED)
   get_filename_component(Kokkos_CUDA_LIBRARY_DIR ${CUDA_cudadevrt_LIBRARY} DIRECTORY)
   set(PC_Kokkos_LDFLAGS "-L${Kokkos_CUDA_LIBRARY_DIR} ${PC_Kokkos_LDFLAGS}")


### PR DESCRIPTION
This reverts commit 1564b746b428153028f42178e7a9b74bd41000a2.

The compiler identification breaks downstream gfortran builds. The pull
request #49 does not have any information why this modification was
suggested in the first place.