### PR TITLE
Unify container interface

### DIFF
--- a/src/details/ArborX_DetailsContainers.hpp
+++ b/src/details/ArborX_DetailsContainers.hpp
@@ -44,11 +44,11 @@ class StaticVector
     KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { assert(pos < size()); return _data[pos]; }
     KOKKOS_INLINE_FUNCTION reference back() { assert(size() > 0 ); return _data[_size - 1]; }
     KOKKOS_INLINE_FUNCTION const_reference back() const { assert(size() > 0); return _data[_size - 1]; }
-    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { assert(size() < maxSize()); _data[_size++] = value; }
-    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { assert(size() < maxSize()); _data[_size++] = std::move(value); }
+    KOKKOS_INLINE_FUNCTION void push_back(T const &value) { assert(size() < maxSize()); _data[_size++] = value; }
+    KOKKOS_INLINE_FUNCTION void push_back(T &&value) { assert(size() < maxSize()); _data[_size++] = std::move(value); }
     template<class... Args>
-    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_data + _size++)) T(std::forward<Args>(args)...); }
-    KOKKOS_INLINE_FUNCTION void popBack() { assert(size() > 0); _size--; }
+    KOKKOS_INLINE_FUNCTION void emplace_back(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_data + _size++)) T(std::forward<Args>(args)...); }
+    KOKKOS_INLINE_FUNCTION void pop_back() { assert(size() > 0); _size--; }
     KOKKOS_INLINE_FUNCTION reference front() { assert(size() > 0); return _data[0]; }
     KOKKOS_INLINE_FUNCTION const_reference front() const { assert(size() > 0); return _data[0]; }
     KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }
@@ -82,11 +82,11 @@ class UnmanagedStaticVector
     KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { assert(pos < size()); return *(_ptr + pos); }
     KOKKOS_INLINE_FUNCTION reference back() { assert(size() > 0); return *(_ptr + _size - 1); }
     KOKKOS_INLINE_FUNCTION const_reference back() const { assert(size() > 0); return *(_ptr + _size - 1); }
-    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { assert(size() < maxSize()); *(_ptr + _size++) = value; }
-    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { assert(size() < maxSize()); *(_ptr + _size++) = std::move(value); }
+    KOKKOS_INLINE_FUNCTION void push_back(T const &value) { assert(size() < maxSize()); *(_ptr + _size++) = value; }
+    KOKKOS_INLINE_FUNCTION void push_back(T &&value) { assert(size() < maxSize()); *(_ptr + _size++) = std::move(value); }
     template<class... Args>
-    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_ptr + _size++)) T(std::forward<Args>(args)...); }
-    KOKKOS_INLINE_FUNCTION void popBack() { assert(size() > 0); _size--; }
+    KOKKOS_INLINE_FUNCTION void emplace_back(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_ptr + _size++)) T(std::forward<Args>(args)...); }
+    KOKKOS_INLINE_FUNCTION void pop_back() { assert(size() > 0); _size--; }
     KOKKOS_INLINE_FUNCTION reference front() { assert(size() > 0); return *(_ptr + 0); }
     KOKKOS_INLINE_FUNCTION const_reference front() const { assert(size() > 0); return *(_ptr + 0); }
     KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -80,24 +80,24 @@ public:
   // Modifiers
   KOKKOS_INLINE_FUNCTION void push(value_type const &value)
   {
-    _c.pushBack(value);
+    _c.push_back(value);
     pushHeap(_c.data(), _c.data() + _c.size(), _compare);
   }
   KOKKOS_INLINE_FUNCTION void push(value_type &&value)
   {
-    _c.pushBack(std::move(value));
+    _c.push_back(std::move(value));
     pushHeap(_c.data(), _c.data() + _c.size(), _compare);
   }
   template <class... Args>
   KOKKOS_INLINE_FUNCTION void emplace(Args &&... args)
   {
-    _c.emplaceBack(std::forward<Args>(args)...);
+    _c.emplace_back(std::forward<Args>(args)...);
     pushHeap(_c.data(), _c.data() + _c.size(), _compare);
   }
   KOKKOS_INLINE_FUNCTION void pop()
   {
     popHeap(_c.data(), _c.data() + _c.size(), _compare);
-    _c.popBack();
+    _c.pop_back();
   }
   // in TreeTraversal::nearestQuery, pop() is often followed by push which is
   // an opportunity for doing a single bubble-down operation instead of paying

--- a/src/details/ArborX_DetailsStack.hpp
+++ b/src/details/ArborX_DetailsStack.hpp
@@ -50,18 +50,18 @@ public:
   // Modifiers
   KOKKOS_INLINE_FUNCTION void push(value_type const &value)
   {
-    _c.pushBack(value);
+    _c.push_back(value);
   }
   KOKKOS_INLINE_FUNCTION void push(value_type &&value)
   {
-    _c.pushBack(std::move(value));
+    _c.push_back(std::move(value));
   }
   template <class... Args>
   KOKKOS_INLINE_FUNCTION void emplace(Args &&... args)
   {
-    _c.emplaceBack(std::forward<Args>(args)...);
+    _c.emplace_back(std::forward<Args>(args)...);
   }
-  KOKKOS_INLINE_FUNCTION void pop() { _c.popBack(); }
+  KOKKOS_INLINE_FUNCTION void pop() { _c.pop_back(); }
 
 private:
   Container _c;

--- a/test/tstSequenceContainers.cpp
+++ b/test/tstSequenceContainers.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(dynamic_array_with_fixed_maximum_size)
   BOOST_TEST(a.maxSize() == 4);
   BOOST_TEST(a.capacity() == 4);
 
-  a.pushBack(255);
+  a.push_back(255);
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 1);
   BOOST_TEST(a.maxSize() == 4);
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(dynamic_array_with_fixed_maximum_size)
   BOOST_TEST(a[0] == 255);
   BOOST_TEST(a.back() == 255);
 
-  a.pushBack(-1);
+  a.push_back(-1);
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 2);
   BOOST_TEST(a.maxSize() == 4);
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(dynamic_array_with_fixed_maximum_size)
   BOOST_TEST(a.back() == -1);
   BOOST_TEST(a[1] == -1);
 
-  a.pushBack(33);
+  a.push_back(33);
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 3);
   BOOST_TEST(a.maxSize() == 4);
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(dynamic_array_with_fixed_maximum_size)
   BOOST_TEST(a.back() == 33);
   BOOST_TEST(a[2] == 33);
 
-  a.popBack();
+  a.pop_back();
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 2);
   BOOST_TEST(a.maxSize() == 4);
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(dynamic_array_with_fixed_maximum_size)
   BOOST_TEST(a.front() == 255);
   BOOST_TEST(a.back() == -1);
 
-  a.popBack();
+  a.pop_back();
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 1);
   BOOST_TEST(a.maxSize() == 4);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(dynamic_array_with_fixed_maximum_size)
   BOOST_TEST(a.front() == 255);
   BOOST_TEST(a.back() == 255);
 
-  a.popBack();
+  a.pop_back();
   BOOST_TEST(a.empty());
   BOOST_TEST(a.size() == 0);
   BOOST_TEST(a.maxSize() == 4);
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(non_owning_view_over_dynamic_array)
   BOOST_TEST(a.maxSize() == 3);
   BOOST_TEST(a.capacity() == 3);
 
-  a.pushBack(0);
+  a.push_back(0);
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 1);
   BOOST_TEST(a.maxSize() == 3);
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(non_owning_view_over_dynamic_array)
   BOOST_TEST(a.back() == 0);
   BOOST_TEST(a[0] == 0);
 
-  a.pushBack(1);
+  a.push_back(1);
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 2);
   BOOST_TEST(a.maxSize() == 3);
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(non_owning_view_over_dynamic_array)
   BOOST_TEST(a.back() == 1);
   BOOST_TEST(a[1] == 1);
 
-  a.pushBack(2);
+  a.push_back(2);
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 3);
   BOOST_TEST(a.maxSize() == 3);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(non_owning_view_over_dynamic_array)
   BOOST_TEST(a.back() == 2);
   BOOST_TEST(a[2] == 2);
 
-  a.popBack();
+  a.pop_back();
   BOOST_TEST(!a.empty());
   BOOST_TEST(a.size() == 2);
   BOOST_TEST(a.maxSize() == 3);


### PR DESCRIPTION
I am running into problems with the size of the `StaticArray` in `PriorityQueue` when running with 160 neighbors. Hence, I wanted to play with some other containers to see if there are alternatives to allow for dynamic memory allocation in case the static size is too small. While doing that I noticed that there are member functions with unusual capitalization. This pull request unifies them.

What was the reasoning for introducing them with this capitalization in the first place?