### PR TITLE
Fix for distributed searches with large count of results per que…

### DIFF
--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -686,21 +686,26 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("truncate_results"),
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries), KOKKOS_LAMBDA(int q) {
-        auto local_buffer = Kokkos::subview(
-            buffer, Kokkos::make_pair(offset(q), offset(q + 1)));
-        PriorityQueue queue(UnmanagedStaticVector<PairIndexDistance>(
-            local_buffer.data(), local_buffer.size()));
-        for (int i = offset(q); i < offset(q + 1); ++i)
-          queue.emplace(Kokkos::Array<int, 2>{{indices(i), ranks(i)}},
-                        distances(i));
-
-        int count = 0;
-        while (!queue.empty() && count < queries(q)._k)
+        if (offset(q + 1) > offset(q))
         {
-          new_indices(new_offset(q) + count) = queue.top().first[0];
-          new_ranks(new_offset(q) + count) = queue.top().first[1];
-          queue.pop();
-          ++count;
+          auto local_buffer = Kokkos::subview(
+              buffer, Kokkos::make_pair(offset(q), offset(q + 1)));
+          PriorityQueue queue(UnmanagedStaticVector<PairIndexDistance>(
+              local_buffer.data(), local_buffer.size()));
+          for (int i = offset(q); i < offset(q + 1); ++i)
+          {
+            queue.emplace(Kokkos::Array<int, 2>{{indices(i), ranks(i)}},
+                          distances(i));
+          }
+
+          int count = 0;
+          while (!queue.empty() && count < queries(q)._k)
+          {
+            new_indices(new_offset(q) + count) = queue.top().first[0];
+            new_ranks(new_offset(q) + count) = queue.top().first[1];
+            queue.pop();
+            ++count;
+          }
         }
       });
   Kokkos::fence();


### PR DESCRIPTION
Tentative solution for https://github.com/arborx/ArborX/pull/126#issuecomment-538410096

This is a legit bug.  The is no reasonable upper bound at compile time for the number of results gathered for a single query.