### PR TITLE
Use MPI_Comm_dup to separate ArborX comm context from user's

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -105,9 +105,10 @@ template <typename DeviceType>
 template <typename Primitives>
 DistributedSearchTree<DeviceType>::DistributedSearchTree(
     MPI_Comm comm, Primitives const &primitives)
-    : _comm(comm)
-    , _bottom_tree(primitives)
+    : _bottom_tree(primitives)
 {
+  MPI_Comm_dup(comm, &_comm);
+
   int comm_rank;
   MPI_Comm_rank(_comm, &comm_rank);
   int comm_size;

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -40,6 +40,8 @@ public:
   template <typename Primitives>
   DistributedSearchTree(MPI_Comm comm, Primitives const &primitives);
 
+  ~DistributedSearchTree() { MPI_Comm_free(&_comm); }
+
   /** Returns the smallest axis-aligned box able to contain all the objects
    *  stored in the tree or an invalid box if the tree is empty.
    */
@@ -107,6 +109,8 @@ DistributedSearchTree<DeviceType>::DistributedSearchTree(
     MPI_Comm comm, Primitives const &primitives)
     : _bottom_tree(primitives)
 {
+  // Create new context for the library to isolate library's communication from
+  // user's
   MPI_Comm_dup(comm, &_comm);
 
   int comm_rank;


### PR DESCRIPTION
This call should normally not involve any communication.