### PR TITLE
Remove distances from the interface

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -81,8 +81,6 @@ public:
    *     - \c offset Array of predicate offsets for one-dimensional
    *       storage.
    *     - \c ranks Process ranks that own objects.
-   *     - \c distances Computed distances (optional and only for nearest
-   *       predicates).
    */
   template <typename Predicates, typename... Args>
   void query(Predicates const &predicates, Args &&... args) const

--- a/test/tstDistributedSearchTree.cpp
+++ b/test/tstDistributedSearchTree.cpp
@@ -140,9 +140,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
   checkResults(emptry_dist_tree, makeNearestQueries<DeviceType>({}), {}, {0},
                {});
 
-  checkResults(emptry_dist_tree, makeNearestQueries<DeviceType>({}), {}, {0},
-               {}, {});
-
   // Only rank 0 has a couple spatial queries with a spatial predicate
   if (comm_rank == 0)
     checkResults(emptry_dist_tree,
@@ -177,13 +174,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
                  }),
                  {}, {0, 0}, {});
 
-  // All ranks have a single query with a nearest predicate (this version
-  // returns distances as well)
+  // All ranks have a single query with a nearest predicate
   checkResults(emptry_dist_tree,
                makeNearestQueries<DeviceType>({
                    {{{0., 0., 0.}}, comm_size},
                }),
-               {}, {0, 0}, {}, {});
+               {}, {0, 0}, {});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
@@ -215,8 +211,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
   checkResults(tree, makeIntersectsSphereQueries<DeviceType>({}), {}, {0}, {});
 
   checkResults(tree, makeNearestQueries<DeviceType>({}), {}, {0}, {});
-
-  checkResults(tree, makeNearestQueries<DeviceType>({}), {}, {0}, {}, {});
 
   // Querying for more neighbors than there are leaves in the tree
   checkResults(tree,

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -93,13 +93,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, Tree, TreeTypes)
                      {{{1., 1., 1.}}, 2},
                  }),
                  {}, {0, 0, 0});
-
-    checkResults(empty_tree,
-                 makeNearestQueries<device_type>({
-                     {{{0., 0., 0.}}, 1},
-                     {{{1., 1., 1.}}, 2},
-                 }),
-                 {}, {0, 0, 0}, {});
   }
 }
 
@@ -124,13 +117,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, Tree, TreeTypes)
 
   checkResults(single_leaf_tree, makeNearestQueries<device_type>({}), {}, {0});
 
-  checkResults(single_leaf_tree, makeNearestQueries<device_type>({}), {}, {0},
-               {});
-
   checkResults(
       single_leaf_tree,
       makeNearestQueries<device_type>({{{0., 0., 0.}, 3}, {{4., 5., 1.}, 1}}),
-      {0, 0}, {0, 1, 2}, {0., 5.});
+      {0, 0}, {0, 1, 2});
 
   checkResults(single_leaf_tree,
                makeIntersectsBoxQueries<device_type>({
@@ -161,7 +151,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, Tree, TreeTypes)
                    {{{0., 2., 0.}}, 2},
                    {{{0., 0., 3.}}, 3},
                }),
-               {0, 0, 0}, {0, 1, 2, 3}, {0., 1., 2.});
+               {0, 0, 0}, {0, 1, 2, 3});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, Tree, TreeTypes)
@@ -224,7 +214,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, Tree, TreeTypes)
                    {{{0., 0., 0.}}, 2},
                    {{{1., 0., 0.}}, 4},
                }),
-               {0, 1, 0, 1}, {0, 2, 4}, {0., sqrt(3.), 1., sqrt(2.)});
+               {0, 1, 0, 1}, {0, 2, 4});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(duplicated_leaves, DeviceType,


### PR DESCRIPTION
So, computing distances afterwards is actually an issue, as we don't have access to leaf nodes... If one retains the original primitives, or if we provide a function to return leaf nodes view, that's doable.

Other than that, the code is simpler now. I'm making this draft PR so that anybody can follow up on it.

Fix #141.