### PR TITLE
Use ExecutionSpace::fence() as (non-static) member function

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -95,7 +95,7 @@ makeNearestQueries(int n_values, int n_queries, int n_neighbors,
         queries(i) =
             ArborX::nearest<ArborX::Point>(random_points(i), n_neighbors);
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   return queries;
 }
 
@@ -123,7 +123,7 @@ makeSpatialQueries(int n_values, int n_queries, int n_neighbors,
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries), KOKKOS_LAMBDA(int i) {
         queries(i) = ArborX::intersects(ArborX::Sphere{random_points(i), r});
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   return queries;
 }
 

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -318,7 +318,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
                          bounding_boxes(i) = {{{x - 1., y - 1., z - 1.}},
                                               {{x + 1., y + 1., z + 1.}}};
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   auto construction = time_monitor.getNewTimer("construction");
   MPI_Barrier(comm);
@@ -341,7 +341,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
                            queries(i) = ArborX::nearest<ArborX::Point>(
                                random_points(i), n_neighbors);
                          });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
 
     Kokkos::View<int *, DeviceType> offset("offset", 0);
     Kokkos::View<int *, DeviceType> indices("indices", 0);
@@ -374,7 +374,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
         KOKKOS_LAMBDA(int i) {
           queries(i) = ArborX::intersects(ArborX::Sphere{random_points(i), r});
         });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
 
     Kokkos::View<int *, DeviceType> offset("offset", 0);
     Kokkos::View<int *, DeviceType> indices("indices", 0);

--- a/examples/viz/tree_visualization.cpp
+++ b/examples/viz/tree_visualization.cpp
@@ -99,7 +99,7 @@ void viz(std::string const &prefix, std::string const &infile, int n_neighbors)
                        KOKKOS_LAMBDA(int i) {
                          queries(i) = ArborX::nearest(points(i), n_neighbors);
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   auto performQueries = [&bvh, &queries](std::string const &p,
                                          std::string const &s) {

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -79,7 +79,7 @@ public:
                            translateAndScale(xyz, xyz, bounds());
                            morton_codes(i) = morton3D(xyz[0], xyz[1], xyz[2]);
                          });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
 
     return sortObjects(morton_codes);
   }
@@ -108,7 +108,7 @@ public:
         ARBORX_MARK_REGION("permute_entries"),
         Kokkos::RangePolicy<ExecutionSpace>(0, n),
         KOKKOS_LAMBDA(int i) { w(i) = Access::get(v, permute(i)); });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
 
     return w;
   }
@@ -126,7 +126,7 @@ public:
         Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
           tmp_offset(permute(i)) = offset(i + 1) - offset(i);
         });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
 
     exclusivePrefixSum(tmp_offset);
 
@@ -156,7 +156,7 @@ public:
             tmp_indices(tmp_offset(permute(q)) + i) = indices(offset(q) + i);
           }
         });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
     return tmp_indices;
   }
 

--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -116,7 +116,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
       ARBORX_MARK_REGION("scan_queries_for_numbers_of_nearest_neighbors"),
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
       KOKKOS_LAMBDA(int i) { offset(permute(i)) = queries(i)._k; });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   exclusivePrefixSum(offset);
   int const n_results = lastElement(offset);
@@ -152,7 +152,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                   count++;
                 });
           });
-      ExecutionSpace::fence();
+      ExecutionSpace().fence();
     }
     else
     {
@@ -181,7 +181,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                                 Kokkos::make_pair(offset(permute(i)),
                                                   offset(permute(i) + 1))));
           });
-      ExecutionSpace::fence();
+      ExecutionSpace().fence();
     }
   }
   else
@@ -199,7 +199,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                   indices(offset(permute(i)) + count++) = index;
                 });
           });
-      ExecutionSpace::fence();
+      ExecutionSpace().fence();
     }
     else
     {
@@ -220,7 +220,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                                 Kokkos::make_pair(offset(permute(i)),
                                                   offset(permute(i) + 1))));
           });
-      ExecutionSpace::fence();
+      ExecutionSpace().fence();
     }
   }
 
@@ -242,7 +242,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                              break;
                            }
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   exclusivePrefixSum(tmp_offset);
   int const n_invalid_indices = lastElement(tmp_offset);
   if (n_invalid_indices > 0)
@@ -251,7 +251,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
         ARBORX_MARK_REGION("subtract_invalid_entries_from_offset"),
         Kokkos::RangePolicy<ExecutionSpace>(0, n_queries + 1),
         KOKKOS_LAMBDA(int q) { tmp_offset(q) = offset(q) - tmp_offset(q); });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
 
     int const n_valid_indices = n_results - n_invalid_indices;
     Kokkos::View<int *, DeviceType> tmp_indices(
@@ -267,7 +267,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
             tmp_indices(tmp_offset(q) + i) = indices(offset(q) + i);
           }
         });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
     indices = tmp_indices;
     if (distances_ptr)
     {
@@ -284,7 +284,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
               tmp_distances(tmp_offset(q) + i) = distances(offset(q) + i);
             }
           });
-      ExecutionSpace::fence();
+      ExecutionSpace().fence();
       distances = tmp_distances;
     }
     offset = tmp_offset;
@@ -381,7 +381,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
           offset(permute(i)) = Details::TreeTraversal<DeviceType>::query(
               bvh, queries(i), [](int) {});
         });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   // NOTE max() internally calls Kokkos::parallel_reduce.  Only pay for it if
   // actually trying buffer optimization.  In principle, any strictly
@@ -430,7 +430,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                 indices(offset(permute(i)) + count++) = index;
               });
         });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
 
     Kokkos::Profiling::popRegion();
   }
@@ -451,7 +451,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                                  indices(q * buffer_size + i);
                            }
                          });
-    ExecutionSpace::fence();
+    ExecutionSpace().fence();
     indices = tmp_indices;
 
     Kokkos::Profiling::popRegion();

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -268,7 +268,7 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
           ++new_offset(i);
         }
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   exclusivePrefixSum(new_offset);
 
@@ -282,7 +282,7 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
         for (int j = 0; j < new_offset(i + 1) - new_offset(i); ++j)
           new_indices(new_offset(i) + j) = indices(offset(i) + j);
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   offset = new_offset;
   indices = new_indices;
@@ -312,7 +312,7 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
         for (int j = offset(i); j < offset(i + 1); ++j)
           farthest_distances(i) = max(farthest_distances(i), distances(j));
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   // Identify what ranks may have leaves that are within that distance.
   Kokkos::View<decltype(intersects(Sphere{})) *, DeviceType> radius_searches(
@@ -323,7 +323,7 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
         radius_searches(i) =
             intersects(Sphere{queries(i)._geometry, farthest_distances(i)});
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   top_tree.query(radius_searches, indices, offset);
   // NOTE: in principle, we could perform radius searches on the bottom_tree
@@ -492,7 +492,7 @@ void DistributedSearchTreeImpl<DeviceType>::sortResults(
       keys, Comp(n / 2, result.min_val, result.max_val), true);
   bin_sort.create_permute_vector();
   applyPermutations(bin_sort, other_views...);
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 template <typename DeviceType>
@@ -510,7 +510,7 @@ void DistributedSearchTreeImpl<DeviceType>::countResults(
                        KOKKOS_LAMBDA(int i) {
                          Kokkos::atomic_increment(&offset(query_ids(i)));
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   exclusivePrefixSum(offset);
 }
@@ -543,7 +543,7 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
                            exports(i) = queries(q);
                          }
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   Kokkos::View<int *, DeviceType> export_ranks("export_ranks", n_exports);
   Kokkos::deep_copy(export_ranks, comm_rank);
@@ -560,7 +560,7 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
                            export_ids(i) = q;
                          }
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   Kokkos::View<int *, DeviceType> import_ids("import_ids", n_imports);
   sendAcrossNetwork(distributor, export_ids, import_ids);
 
@@ -595,7 +595,7 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
                            export_ranks(i) = ranks(q);
                          }
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   Distributor distributor(comm);
   int const n_imports = distributor.createFromSends(export_ranks);
@@ -613,7 +613,7 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
                            export_ids(i) = ids(q);
                          }
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   Kokkos::View<int *, DeviceType> export_indices = indices;
 
   Kokkos::View<int *, DeviceType> import_indices(indices.label(), n_imports);
@@ -658,7 +658,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
         using KokkosExt::min;
         new_offset(q) = min(offset(q + 1) - offset(q), queries(q)._k);
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   exclusivePrefixSum(new_offset);
 
@@ -710,7 +710,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
           }
         }
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   indices = new_indices;
   ranks = new_ranks;
   offset = new_offset;

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -60,7 +60,7 @@ sortObjects(Kokkos::View<unsigned int *, DeviceType> view)
       view, CompType(n / 2, result.min_val, result.max_val), true);
   bin_sort.create_permute_vector();
   bin_sort.sort(view);
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   return bin_sort.get_permute_vector();
 }

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -212,7 +212,7 @@ inline void TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
       Kokkos::RangePolicy<ExecutionSpace>(0, n),
       CalculateBoundingBoxOfTheSceneFunctor<Primitives>(primitives),
       scene_bounding_box);
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 template <typename Primitives, typename MortonCodes>
@@ -231,7 +231,7 @@ inline void assignMortonCodesDispatch(BoxTag, Primitives const &primitives,
                          translateAndScale(xyz, xyz, scene_bounding_box);
                          morton_codes(i) = morton3D(xyz[0], xyz[1], xyz[2]);
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 template <typename Primitives, typename MortonCodes>
@@ -249,7 +249,7 @@ inline void assignMortonCodesDispatch(PointTag, Primitives const &primitives,
         translateAndScale(Access::get(primitives, i), xyz, scene_bounding_box);
         morton_codes(i) = morton3D(xyz[0], xyz[1], xyz[2]);
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 template <typename DeviceType>
@@ -284,7 +284,7 @@ inline void initializeLeafNodesDispatch(BoxTag, Primitives const &primitives,
             {nullptr, reinterpret_cast<Node *>(permutation_indices(i))},
             Access::get(primitives, permutation_indices(i))};
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 template <typename Primitives, typename Indices, typename Nodes>
@@ -303,7 +303,7 @@ inline void initializeLeafNodesDispatch(PointTag, Primitives const &primitives,
             {Access::get(primitives, permutation_indices(i)),
              Access::get(primitives, permutation_indices(i))}};
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 template <typename DeviceType>
@@ -413,7 +413,7 @@ Node *TreeConstruction<DeviceType>::generateHierarchy(
       Kokkos::RangePolicy<ExecutionSpace>(0, n - 1),
       GenerateHierarchyFunctor<DeviceType>(sorted_morton_codes, leaf_nodes,
                                            internal_nodes, parents));
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   // returns a pointer to the root node of the tree
   return internal_nodes.data();
 }
@@ -486,7 +486,7 @@ void TreeConstruction<DeviceType>::calculateInternalNodesBoundingVolumes(
                        Kokkos::RangePolicy<ExecutionSpace>(first, last),
                        CalculateInternalNodesBoundingVolumesFunctor<DeviceType>(
                            root, parents, first));
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 } // namespace Details

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -86,7 +86,7 @@ void exclusivePrefixSum(Kokkos::View<ST, SP...> const &src,
   Kokkos::parallel_scan(
       "exclusive_scan", Kokkos::RangePolicy<ExecutionSpace>(0, n),
       Details::ExclusiveScanFunctor<ValueType, ExecutionSpace>(src, dst));
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 /** \brief In-place exclusive scan.
@@ -150,7 +150,7 @@ void iota(Kokkos::View<T, P...> const &v,
   auto const n = v.extent(0);
   Kokkos::parallel_for("iota", Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        KOKKOS_LAMBDA(int i) { v(i) = value + (ValueType)i; });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 /** \brief Returns the smallest and the greatest element in the view
@@ -292,7 +292,7 @@ void adjacentDifference(SrcViewType const &src, DstViewType const &dst)
                          else
                            dst(i) = src(i);
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 // FIXME split this into one for STL-like algorithms and another one for view

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(indirect_sort, DeviceType, ARBORX_DEVICE_TYPES)
   FillK<DeviceType> fill_k_functor(k);
   Kokkos::parallel_for("fill_k", Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        fill_k_functor);
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   std::vector<size_t> ref = {3, 2, 1, 0};
   // sort morton codes and object ids
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_prefix, DeviceType, ARBORX_DEVICE_TYPES)
   FillFi<DeviceType> fill_fi_functor(fi);
   Kokkos::parallel_for("fill_fi", Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        fill_fi_functor);
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   int const n_tests = 10;
   Kokkos::View<int *, DeviceType> results("results", n_tests);
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_prefix, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::parallel_for("compute_results",
                        Kokkos::RangePolicy<ExecutionSpace>(0, n_tests),
                        compute_results_functor);
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   auto results_host = Kokkos::create_mirror_view(results);
   Kokkos::deep_copy(results_host, results);

--- a/test/tstDistributedSearchTree.cpp
+++ b/test/tstDistributedSearchTree.cpp
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
             {{point_coords(i, 0), point_coords(i, 1), point_coords(i, 2)}},
             radii(i)});
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   // Perform the search
   Kokkos::View<int *, DeviceType> indices("indices", 0);

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(miscellaneous, DeviceType, ARBORX_DEVICE_TYPES)
         zeros(2) = ArborX::Details::TreeTraversal<DeviceType>::query(
             bvh, ArborX::nearest(p, 0), [](int, double) {}, empty_buffer);
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   auto zeros_host = Kokkos::create_mirror_view(zeros);
   Kokkos::deep_copy(zeros_host, zeros);
   std::vector<int> zeros_ref = {0, 0, 0};
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
                                  {{x, y, z}}, {{x, y, z}}};
                            }
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   ArborX::BVH<DeviceType> bvh(bounding_boxes);
 
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
                        KOKKOS_LAMBDA(int i) {
                          queries(i) = ArborX::intersects(bounding_boxes(i));
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 
   Kokkos::View<int *, DeviceType> indices("indices", n);
   Kokkos::View<int *, DeviceType> offset("offset", n);
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
                        KOKKOS_LAMBDA(int i) {
                          queries[i] = ArborX::intersects(bounding_boxes[i]);
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   bvh.query(queries, indices, offset);
   indices_host = Kokkos::create_mirror_view(indices);
   Kokkos::deep_copy(indices_host, indices);
@@ -612,7 +612,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
                        KOKKOS_LAMBDA(int i) {
                          queries[i] = ArborX::intersects(bounding_boxes[i]);
                        });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   bvh.query(queries, indices, offset);
   indices_host = Kokkos::create_mirror_view(indices);
   Kokkos::deep_copy(indices_host, indices);
@@ -743,7 +743,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
             {{point_coords(i, 0), point_coords(i, 1), point_coords(i, 2)}},
             k(i));
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   auto nearest_queries_host = Kokkos::create_mirror_view(nearest_queries);
   Kokkos::deep_copy(nearest_queries_host, nearest_queries);
 
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
             {{point_coords(i, 0), point_coords(i, 1), point_coords(i, 2)}},
             radii(i)});
       });
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
   auto within_queries_host = Kokkos::create_mirror_view(within_queries);
   Kokkos::deep_copy(within_queries_host, within_queries);
 


### PR DESCRIPTION
`ExecutionSpace::fence()` is non-static anymore, see https://github.com/kokkos/kokkos/issues/2140.