### PR TITLE
Use Thrust for GPU sort

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -20,9 +20,32 @@
 #include <Kokkos_View.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)
+#if (KOKKOS_COMPILER_CLANG < 900)
+// Clang of version less than 9.0 cannot compile Thrust, failing with errors
+// like this:
+//    <snip>/thrust/system/cuda/detail/core/agent_launcher.h:557:11:
+//    error: use of undeclared identifier 'va_printf'
+// Defining _CubLog here allows us to avoid that code path, however disabling
+// some debugging diagnostics
+//
+// If _CubLog is already defined, we save it into ARBORX_CubLog_save, and
+// restore it at the end
+#ifdef _CubLog
+#define ARBORX_CubLog_save _CubLog
+#endif
+#define _CubLog
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
+#undef _CubLog
+#ifdef ARBORX_CubLog_save
+#define _CubLog ARBORX_CubLog_save
+#undef ARBORX_CubLog_save
 #endif
+#else // #if (KOKKOS_COMPILER_CLANG < 900)
+#include <thrust/device_ptr.h>
+#include <thrust/sort.h>
+#endif // #if (KOKKOS_COMPILER_CLANG < 900)
+#endif // #if defined(KOKKOS_ENABLE_CUDA)
 
 namespace ArborX
 {

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -67,7 +67,7 @@ sortObjects(Kokkos::View<unsigned int *, DeviceType> view)
   {
     Kokkos::View<size_t *, DeviceType> permute(
         Kokkos::ViewAllocateWithoutInitializing("permutation"), n);
-    iota(permute);
+    ArborX::iota(permute);
 
     auto permute_ptr = thrust::device_ptr<size_t>(permute.data());
     auto begin_ptr = thrust::device_ptr<unsigned int>(view.data());


### PR DESCRIPTION
Draft as I need to run scaling studies from the paper on Summit to compare with original version.

Related to #145.

Note that for now, we don't do the check for Thrust, and assume that if Cuda is available, Thrust is. If we encounter situation in the future when that is not the case, we'll introduce that option.