### PR TITLE
Store indices of children nodes rather than pointer in the bounding volume hierarchy

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -114,6 +114,9 @@ private:
   Node *getRoot() { return _internal_and_leaf_nodes.data(); }
 
   KOKKOS_INLINE_FUNCTION
+  Node const *getNodePtr(int i) const { return &_internal_and_leaf_nodes(i); }
+
+  KOKKOS_INLINE_FUNCTION
   bounding_volume_type const &getBoundingVolume(Node const *node) const
   {
     return node->bounding_box;

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -17,6 +17,7 @@
 #include <Kokkos_Pair.hpp>
 
 #include <cassert>
+#include <cstddef>
 
 namespace ArborX
 {
@@ -29,24 +30,23 @@ struct Node
 
   KOKKOS_INLINE_FUNCTION constexpr bool isLeaf() const noexcept
   {
-    return children.first == nullptr;
+    return children.first == -1;
   }
 
   KOKKOS_INLINE_FUNCTION std::size_t getLeafPermutationIndex() const noexcept
   {
     assert(isLeaf());
-    return reinterpret_cast<std::size_t>(children.second);
+    return children.second;
   }
 
-  Kokkos::pair<Node *, Node *> children = {nullptr, nullptr};
+  Kokkos::pair<std::ptrdiff_t, std::ptrdiff_t> children = {-1, -1};
   Box bounding_box;
 };
 
 KOKKOS_INLINE_FUNCTION Node makeLeafNode(std::size_t permutation_index,
                                          Box box) noexcept
 {
-  return {{nullptr, reinterpret_cast<Node *>(permutation_index)},
-          std::move(box)};
+  return {{-1, static_cast<std::ptrdiff_t>(permutation_index)}, std::move(box)};
 }
 } // namespace Details
 } // namespace ArborX

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -33,7 +33,8 @@ struct Node
     return children.first == -1;
   }
 
-  KOKKOS_INLINE_FUNCTION std::size_t getLeafPermutationIndex() const noexcept
+  KOKKOS_INLINE_FUNCTION constexpr std::size_t getLeafPermutationIndex() const
+      noexcept
   {
     assert(isLeaf());
     return children.second;
@@ -43,8 +44,8 @@ struct Node
   Box bounding_box;
 };
 
-KOKKOS_INLINE_FUNCTION Node makeLeafNode(std::size_t permutation_index,
-                                         Box box) noexcept
+KOKKOS_INLINE_FUNCTION constexpr Node
+makeLeafNode(std::size_t permutation_index, Box box) noexcept
 {
   return {{-1, static_cast<std::ptrdiff_t>(permutation_index)}, std::move(box)};
 }

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -364,12 +364,12 @@ public:
 
     if (split == first)
     {
-      _internal_nodes(i).children.first = &_leaf_nodes(split);
+      _internal_nodes(i).children.first = split + _shift;
       _parents(split + _shift) = i;
     }
     else
     {
-      _internal_nodes(i).children.first = &_internal_nodes(split);
+      _internal_nodes(i).children.first = split;
       _parents(split) = i;
     }
 
@@ -377,12 +377,12 @@ public:
 
     if (split + 1 == last)
     {
-      _internal_nodes(i).children.second = &_leaf_nodes(split + 1);
+      _internal_nodes(i).children.second = split + 1 + _shift;
       _parents(split + 1 + _shift) = i;
     }
     else
     {
-      _internal_nodes(i).children.second = &_internal_nodes(split + 1);
+      _internal_nodes(i).children.second = split + 1;
       _parents(split + 1) = i;
     }
   }
@@ -448,8 +448,8 @@ public:
       // FIXME: accessing Node::bounding_box is not ideal but I was
       // reluctant to pass the bounding volume hierarchy to
       // generateHierarchy()
-      node->bounding_box = (node->children.first)->bounding_box;
-      expand(node->bounding_box, (node->children.second)->bounding_box);
+      node->bounding_box = (_root + node->children.first)->bounding_box;
+      expand(node->bounding_box, (_root + node->children.second)->bounding_box);
       if (node == _root)
         break;
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -332,7 +332,7 @@ public:
       , _leaf_nodes(leaf_nodes)
       , _internal_nodes(internal_nodes)
       , _parents(parents)
-      , _shift(internal_nodes.extent(0))
+      , _leaf_nodes_shift(internal_nodes.extent(0))
   {
   }
 
@@ -359,8 +359,8 @@ public:
 
     if (split == first)
     {
-      _internal_nodes(i).children.first = split + _shift;
-      _parents(split + _shift) = i;
+      _internal_nodes(i).children.first = split + _leaf_nodes_shift;
+      _parents(split + _leaf_nodes_shift) = i;
     }
     else
     {
@@ -372,8 +372,8 @@ public:
 
     if (split + 1 == last)
     {
-      _internal_nodes(i).children.second = split + 1 + _shift;
-      _parents(split + 1 + _shift) = i;
+      _internal_nodes(i).children.second = split + 1 + _leaf_nodes_shift;
+      _parents(split + 1 + _leaf_nodes_shift) = i;
     }
     else
     {
@@ -387,7 +387,7 @@ private:
   Kokkos::View<Node *, DeviceType> _leaf_nodes;
   Kokkos::View<Node *, DeviceType> _internal_nodes;
   Kokkos::View<int *, DeviceType> _parents;
-  int _shift;
+  int _leaf_nodes_shift;
 };
 
 template <typename DeviceType>

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -314,11 +314,6 @@ inline void TreeConstruction<DeviceType>::initializeLeafNodes(
   ARBORX_ASSERT(permutation_indices.extent(0) == n);
   ARBORX_ASSERT(leaf_nodes.extent(0) == n);
 
-  static_assert(sizeof(typename decltype(permutation_indices)::value_type) ==
-                    sizeof(Node *),
-                "Encoding leaf index in pointer to child is not safe if the "
-                "index and pointer types do not have the same size");
-
   using Tag = typename Tag<decay_result_of_get_t<Access>>::type;
   initializeLeafNodesDispatch(Tag{}, primitives, permutation_indices,
                               leaf_nodes);

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -80,9 +80,9 @@ public:
       }
       else
       {
-        auto const root = bvh.getRoot();
+        auto const &nodes = bvh._internal_and_leaf_nodes;
         for (Node const *child :
-             {root + node->children.first, root + node->children.second})
+             {&nodes(node->children.first), &nodes(node->children.second)})
         {
           if (predicate(bvh.getBoundingVolume(child)))
           {
@@ -175,9 +175,9 @@ public:
         {
           // Insert children into the stack and make sure that the
           // closest one ends on top.
-          auto const root = bvh.getRoot();
-          Node const *left_child = root + node->children.first;
-          Node const *right_child = root + node->children.second;
+          auto const &nodes = bvh._internal_and_leaf_nodes;
+          Node const *left_child = &nodes(node->children.first);
+          Node const *right_child = &nodes(node->children.second);
           double const left_child_distance = distance(left_child);
           double const right_child_distance = distance(right_child);
           if (left_child_distance < right_child_distance)
@@ -270,9 +270,9 @@ public:
         else
         {
           // Insert children into the priority queue
-          auto const root = bvh.getRoot();
-          Node const *left_child = root + node->children.first;
-          Node const *right_child = root + node->children.second;
+          auto const &nodes = bvh._internal_and_leaf_nodes;
+          Node const *left_child = &nodes(node->children.first);
+          Node const *right_child = &nodes(node->children.second);
           double const left_child_distance = distance(left_child);
           double const right_child_distance = distance(right_child);
           queue.popPush(left_child, left_child_distance);

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -80,9 +80,8 @@ public:
       }
       else
       {
-        auto const &nodes = bvh._internal_and_leaf_nodes;
-        for (Node const *child :
-             {&nodes(node->children.first), &nodes(node->children.second)})
+        for (Node const *child : {bvh.getNodePtr(node->children.first),
+                                  bvh.getNodePtr(node->children.second)})
         {
           if (predicate(bvh.getBoundingVolume(child)))
           {
@@ -175,9 +174,8 @@ public:
         {
           // Insert children into the stack and make sure that the
           // closest one ends on top.
-          auto const &nodes = bvh._internal_and_leaf_nodes;
-          Node const *left_child = &nodes(node->children.first);
-          Node const *right_child = &nodes(node->children.second);
+          Node const *left_child = bvh.getNodePtr(node->children.first);
+          Node const *right_child = bvh.getNodePtr(node->children.second);
           double const left_child_distance = distance(left_child);
           double const right_child_distance = distance(right_child);
           if (left_child_distance < right_child_distance)
@@ -270,9 +268,8 @@ public:
         else
         {
           // Insert children into the priority queue
-          auto const &nodes = bvh._internal_and_leaf_nodes;
-          Node const *left_child = &nodes(node->children.first);
-          Node const *right_child = &nodes(node->children.second);
+          Node const *left_child = bvh.getNodePtr(node->children.first);
+          Node const *right_child = bvh.getNodePtr(node->children.second);
           double const left_child_distance = distance(left_child);
           double const right_child_distance = distance(right_child);
           queue.popPush(left_child, left_child_distance);

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -80,7 +80,9 @@ public:
       }
       else
       {
-        for (Node const *child : {node->children.first, node->children.second})
+        auto const root = bvh.getRoot();
+        for (Node const *child :
+             {root + node->children.first, root + node->children.second})
         {
           if (predicate(bvh.getBoundingVolume(child)))
           {
@@ -173,8 +175,9 @@ public:
         {
           // Insert children into the stack and make sure that the
           // closest one ends on top.
-          Node const *left_child = node->children.first;
-          Node const *right_child = node->children.second;
+          auto const root = bvh.getRoot();
+          Node const *left_child = root + node->children.first;
+          Node const *right_child = root + node->children.second;
           double const left_child_distance = distance(left_child);
           double const right_child_distance = distance(right_child);
           if (left_child_distance < right_child_distance)
@@ -267,8 +270,9 @@ public:
         else
         {
           // Insert children into the priority queue
-          Node const *left_child = node->children.first;
-          Node const *right_child = node->children.second;
+          auto const root = bvh.getRoot();
+          Node const *left_child = root + node->children.first;
+          Node const *right_child = root + node->children.second;
           double const left_child_distance = distance(left_child);
           double const right_child_distance = distance(right_child);
           queue.popPush(left_child, left_child_distance);

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -136,9 +136,11 @@ struct TreeVisualization
     {
       auto const node_label = getNodeLabel(node, tree);
       auto const node_is_internal = !node->isLeaf();
+      auto const root = TreeAccess::getRoot(tree);
 
       if (node_is_internal)
-        for (Node const *child : {node->children.first, node->children.second})
+        for (Node const *child :
+             {root + node->children.first, root + node->children.second})
         {
           auto const child_label = getNodeLabel(child, tree);
           auto const edge_attributes = getEdgeAttributes(node, child, tree);
@@ -178,6 +180,7 @@ struct TreeVisualization
   {
     Stack<Node const *> stack;
     stack.emplace(TreeAccess::getRoot(tree));
+    auto const root = TreeAccess::getRoot(tree);
     while (!stack.empty())
     {
       Node const *node = stack.top();
@@ -186,7 +189,8 @@ struct TreeVisualization
       visitor.visit(node, tree);
 
       if (!node->isLeaf())
-        for (Node const *child : {node->children.first, node->children.second})
+        for (Node const *child :
+             {root + node->children.first, root + node->children.second})
           stack.push(child);
     }
   }

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -300,8 +300,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
     }
     else
     {
+      Node const *root = internal_nodes.data();
       os << "I" << node - internal_nodes.data();
-      for (Node const *child : {node->children.first, node->children.second})
+      for (Node const *child :
+           {root + node->children.first, root + node->children.second})
         traverseRecursive(child, os);
     }
   };

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -293,8 +293,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   for (int i = 0; i < n; ++i)
     leaf_nodes(i) = makeLeafNode(i, Box{});
   auto getNodePtr = [n, &leaf_nodes, &internal_nodes](int i) {
-    return i < n - 1 ? internal_nodes.data() + i
-                     : leaf_nodes.data() + i - n + 1;
+    return i < n - 1 ? &internal_nodes(i) : &leaf_nodes(i - n + 1);
   };
   std::function<void(Node const *, std::ostream &)> traverseRecursive;
   traverseRecursive = [&leaf_nodes, &internal_nodes, &traverseRecursive,
@@ -305,7 +304,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
     }
     else
     {
-      Node const *root = internal_nodes.data();
       os << "I" << node - internal_nodes.data();
       for (Node const *child : {getNodePtr(node->children.first),
                                 getNodePtr(node->children.second)})

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   Kokkos::View<Node *, DeviceType> internal_nodes("internal_nodes", n - 1);
   for (int i = 0; i < n; ++i)
     leaf_nodes(i) = makeLeafNode(i, Box{});
-  auto getNodePtr = [n, &leaf_nodes, &internal_nodes](int i) {
+  auto getNodePtr = [&leaf_nodes, &internal_nodes](int i) {
     return i < n - 1 ? &internal_nodes(i) : &leaf_nodes(i - n + 1);
   };
   std::function<void(Node const *, std::ostream &)> traverseRecursive;


### PR DESCRIPTION
Motivation:  this will let us copy trees between host and device and enable checkpoint/restart if that's something we want to get into.

Note that indices are store as `ptrdiff_t` that has the same size as a pointer so that we do not change the alignment.