### PR TITLE
Print enabled Kokkos devices during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(ArborX CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 find_package(Kokkos REQUIRED)
+message(STATUS "Kokkos devices: ${Kokkos_DEVICES}")
 
 add_library(ArborX INTERFACE)
 target_link_libraries(ArborX INTERFACE Kokkos::Kokkos)


### PR DESCRIPTION
It is helpful to know what devices are enabled when building ArborX without having to go to CMakeCache.txt.