### PR TITLE
Fix memory space for exclusivePrefixSum

### DIFF
--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -80,12 +80,13 @@ void exclusivePrefixSum(Kokkos::View<ST, SP...> const &src,
   using ExecutionSpace =
       typename Kokkos::ViewTraits<DT, DP...>::execution_space;
   using ValueType = typename Kokkos::ViewTraits<DT, DP...>::value_type;
+  using DeviceType = typename Kokkos::ViewTraits<DT, DP...>::device_type;
 
   auto const n = src.extent(0);
   ARBORX_ASSERT(n == dst.extent(0));
   Kokkos::parallel_scan(
       "exclusive_scan", Kokkos::RangePolicy<ExecutionSpace>(0, n),
-      Details::ExclusiveScanFunctor<ValueType, ExecutionSpace>(src, dst));
+      Details::ExclusiveScanFunctor<ValueType, DeviceType>(src, dst));
 }
 
 /** \brief In-place exclusive scan.


### PR DESCRIPTION
Without this patch, we try to assign between a `Kokkos::View` with memory space `CudaSpace` and `CudaUVMSpace` in case `Kokkos` is built with `UVM` support and the original memory space is `CudaSpace`. 

Up to now, we tried to use the default memory space associated with the execution space in `ExclusiveScanFunctor` which turned out to be `CudaUVMSpace` in this case. Hence, the constructor call assigns a `Kokkos::View` with memory space `CudaSpace` to a `KokkosView` with memory space `CudaUVMSpace` which is not allowed.
