### PR TITLE
Avoid nvcc warning in sortObjects

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -60,9 +60,6 @@ sortObjects(Kokkos::View<unsigned int *, DeviceType> view)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  static_assert(!std::is_same<ExecutionSpace, Kokkos::Cuda>::value,
-                "The CUDA overload should have been selected.");
-
   int const n = view.extent(0);
 
   using ViewType = decltype(view);
@@ -98,15 +95,15 @@ sortObjects(Kokkos::View<unsigned int *, DeviceType> view)
 
 #if defined(KOKKOS_ENABLE_CUDA)
 // NOTE returns the permutation indices **and** sorts the morton codes
-inline Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>>
-sortObjects(Kokkos::View<unsigned int *,
-                         Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>>
-                view)
+template <typename MemorySpace>
+Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> sortObjects(
+    Kokkos::View<unsigned int *, Kokkos::Device<Kokkos::Cuda, MemorySpace>>
+        view)
 {
   int const n = view.extent(0);
 
-  Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>>
-      permute(Kokkos::ViewAllocateWithoutInitializing("permutation"), n);
+  Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> permute(
+      Kokkos::ViewAllocateWithoutInitializing("permutation"), n);
   ArborX::iota(permute);
 
   auto permute_ptr = thrust::device_ptr<size_t>(permute.data());


### PR DESCRIPTION
This avoids an annoying "dynamic initialization in unreachable code" warning in `sortObjects`.