### PR TITLE
Use sortObjects in sortResults.

### DIFF
--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -452,21 +452,24 @@ void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
   ////////////////////////////////////////////////////////////////////////////
 }
 
-// FIXME: for some reason Kokkos::BinSort::sort() was not const.
-// If https://github.com/kokkos/kokkos/pull/1310 makes it into master in
-// Trilinos, we might want to pass bin_sort by const reference.
-template <typename BinSort>
-void applyPermutations(BinSort &)
+template <typename PermutationView>
+void applyPermutations(PermutationView const &)
 {
   // do nothing
 }
 
-template <typename BinSort, typename View, typename... OtherViews>
-void applyPermutations(BinSort &bin_sort, View view, OtherViews... other_views)
+template <typename PermutationView, typename View, typename... OtherViews>
+void applyPermutations(PermutationView const &permutation, View view,
+                       OtherViews... other_views)
 {
-  ARBORX_ASSERT(bin_sort.get_permute_vector().extent(0) == view.extent(0));
-  bin_sort.sort(view);
-  applyPermutations(bin_sort, other_views...);
+  ARBORX_ASSERT(permutation.extent(0) == view.extent(0));
+  View scratch(Kokkos::ViewAllocateWithoutInitializing("scratch"), view.size());
+  Kokkos::parallel_for(
+      "permute",
+      Kokkos::RangePolicy<typename View::execution_space>(0, view.size()),
+      KOKKOS_LAMBDA(int i) { scratch(i) = view(permutation(i)); });
+  Kokkos::deep_copy(view, scratch);
+  applyPermutations(permutation, other_views...);
 }
 
 template <typename DeviceType>
@@ -481,7 +484,6 @@ void DistributedSearchTreeImpl<DeviceType>::sortResults(
   if (n == 0)
     return;
 
-  using Comp = Kokkos::BinOp1D<View>;
   using Value = typename View::non_const_value_type;
 
   Kokkos::MinMaxScalar<Value> result;
@@ -490,10 +492,12 @@ void DistributedSearchTreeImpl<DeviceType>::sortResults(
                   Kokkos::Impl::min_max_functor<View>(keys), reducer);
   if (result.min_val == result.max_val)
     return;
-  Kokkos::BinSort<View, Comp> bin_sort(
-      keys, Comp(n / 2, result.min_val, result.max_val), true);
-  bin_sort.create_permute_vector();
-  applyPermutations(bin_sort, other_views...);
+
+  View keys_clone(Kokkos::ViewAllocateWithoutInitializing("keys"), keys.size());
+  Kokkos::deep_copy(keys_clone, keys);
+  auto const permutation = ArborX::Details::sortObjects(keys_clone);
+
+  applyPermutations(permutation, other_views...);
 }
 
 template <typename DeviceType>

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -56,9 +56,9 @@ namespace Details
 {
 
 // NOTE returns the permutation indices **and** sorts the morton codes
-template <typename DeviceType>
+template <typename NumberType, typename DeviceType>
 Kokkos::View<size_t *, DeviceType>
-sortObjects(Kokkos::View<unsigned int *, DeviceType> view)
+sortObjects(Kokkos::View<NumberType *, DeviceType> view)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
@@ -97,10 +97,9 @@ sortObjects(Kokkos::View<unsigned int *, DeviceType> view)
 
 #if defined(KOKKOS_ENABLE_CUDA)
 // NOTE returns the permutation indices **and** sorts the morton codes
-template <typename MemorySpace>
+template <typename NumberType, typename MemorySpace>
 Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> sortObjects(
-    Kokkos::View<unsigned int *, Kokkos::Device<Kokkos::Cuda, MemorySpace>>
-        view)
+    Kokkos::View<NumberType *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> view)
 {
   int const n = view.extent(0);
 
@@ -109,8 +108,8 @@ Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> sortObjects(
   ArborX::iota(permute);
 
   auto permute_ptr = thrust::device_ptr<size_t>(permute.data());
-  auto begin_ptr = thrust::device_ptr<unsigned int>(view.data());
-  auto end_ptr = thrust::device_ptr<unsigned int>(view.data() + n);
+  auto begin_ptr = thrust::device_ptr<NumberType>(view.data());
+  auto end_ptr = thrust::device_ptr<NumberType>(view.data() + n);
   thrust::sort_by_key(begin_ptr, end_ptr, permute_ptr);
 
   return permute;

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -56,15 +56,14 @@ namespace Details
 {
 
 // NOTE returns the permutation indices **and** sorts the morton codes
-template <typename NumberType, typename DeviceType>
-Kokkos::View<size_t *, DeviceType>
-sortObjects(Kokkos::View<NumberType *, DeviceType> view)
+template <typename ViewType>
+Kokkos::View<size_t *, typename ViewType::device_type>
+sortObjects(ViewType &view)
 {
-  using ExecutionSpace = typename DeviceType::execution_space;
+  using ExecutionSpace = typename ViewType::execution_space;
 
   int const n = view.extent(0);
 
-  using ViewType = decltype(view);
   using ValueType = typename ViewType::value_type;
   using CompType = Kokkos::BinOp1D<ViewType>;
 
@@ -75,7 +74,7 @@ sortObjects(Kokkos::View<NumberType *, DeviceType> view)
                   Kokkos::Impl::min_max_functor<ViewType>(view), reducer);
   if (result.min_val == result.max_val)
   {
-    Kokkos::View<size_t *, DeviceType> permute(
+    Kokkos::View<size_t *, typename ViewType::device_type> permute(
         Kokkos::ViewAllocateWithoutInitializing("permute"), n);
     iota(permute);
     return permute;
@@ -87,8 +86,8 @@ sortObjects(Kokkos::View<NumberType *, DeviceType> view)
   // better choice here because its size is guaranteed to coincide with the
   // pointer size which is a good thing for converting with reinterpret_cast
   // (when leaf indices are encoded into the pointer to one of their children)
-  Kokkos::BinSort<ViewType, CompType, DeviceType, size_t> bin_sort(
-      view, CompType(n / 2, result.min_val, result.max_val), true);
+  Kokkos::BinSort<ViewType, CompType, typename ViewType::device_type, size_t>
+      bin_sort(view, CompType(n / 2, result.min_val, result.max_val), true);
   bin_sort.create_permute_vector();
   bin_sort.sort(view);
 
@@ -97,9 +96,9 @@ sortObjects(Kokkos::View<NumberType *, DeviceType> view)
 
 #if defined(KOKKOS_ENABLE_CUDA)
 // NOTE returns the permutation indices **and** sorts the morton codes
-template <typename NumberType, typename MemorySpace>
+template <typename ValueType, typename MemorySpace>
 Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> sortObjects(
-    Kokkos::View<NumberType *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> view)
+    Kokkos::View<ValueType *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> view)
 {
   int const n = view.extent(0);
 
@@ -108,8 +107,8 @@ Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> sortObjects(
   ArborX::iota(permute);
 
   auto permute_ptr = thrust::device_ptr<size_t>(permute.data());
-  auto begin_ptr = thrust::device_ptr<NumberType>(view.data());
-  auto end_ptr = thrust::device_ptr<NumberType>(view.data() + n);
+  auto begin_ptr = thrust::device_ptr<ValueType>(view.data());
+  auto end_ptr = thrust::device_ptr<ValueType>(view.data() + n);
   thrust::sort_by_key(begin_ptr, end_ptr, permute_ptr);
 
   return permute;


### PR DESCRIPTION
On top of #172, this gives using
- 60 MPI processes, 
- 10^7 points/MPI process,
- 10^6 queries/MPI process,
- and a varying number of neighbors for the knn search,
- and CUDA
and the `distributed_tree_driver` benchmark.

|  neighbors | old   |  new   |
|------------|-------|--------|
|  20         | 8.51e0 | 7.23e0 |
| 40          | 2.06e1 | 1.16e1 |
| 80          | 7.38e1 | 2.10e1 |
| 100        | 1.08e2 | 2.54e1 |
| 120        | 1.51e2 | 2.98e1 |
| 140        | 1.97e2 | 3.43e1 |

`Kokkos::BinSort::create_permute_vector` was just ridiculously slow here.

`sortObjects` currently requires us to copy `keys` and we could possibly reuse `scratch` but currently this doesn't show up in the profiling at all.