### PR TITLE
Keep permutation on the device

### DIFF
--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -121,7 +121,7 @@ struct DistributedSearchTreeImpl
 
   template <typename View>
   static typename std::enable_if<Kokkos::is_view<View>::value>::type
-  sendAcrossNetwork(Distributor const &distributor, View exports,
+  sendAcrossNetwork(Distributor<DeviceType> const &distributor, View exports,
                     typename View::non_const_type imports);
 };
 
@@ -195,7 +195,7 @@ template <typename DeviceType>
 template <typename View>
 typename std::enable_if<Kokkos::is_view<View>::value>::type
 DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
-    Distributor const &distributor, View exports,
+    Distributor<DeviceType> const &distributor, View exports,
     typename View::non_const_type imports)
 {
   ARBORX_ASSERT((exports.extent(0) == distributor.getTotalSendLength()) &&
@@ -538,7 +538,7 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
 
-  Distributor distributor(comm);
+  Distributor<DeviceType> distributor(comm);
 
   int const n_queries = queries.extent(0);
   int const n_exports = lastElement(offset);
@@ -607,7 +607,7 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
                          }
                        });
 
-  Distributor distributor(comm);
+  Distributor<DeviceType> distributor(comm);
   int const n_imports = distributor.createFromSends(export_ranks);
 
   // export_ranks already has adequate size since it was used as a buffer to

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -105,7 +105,8 @@ class Distributor
 {
 public:
   Distributor(MPI_Comm comm)
-      : _comm(comm)
+      : _comm(comm),
+	_permute{Kokkos::ViewAllocateWithoutInitializing("permute"), 0}
   {
   }
 


### PR DESCRIPTION
The changes here should only affect a CUDA-aware MPI implementation.
- If the `DeviceType`'s memory space is `Kokkos::Host` we, of course, do everything in host memory space. 
- If the `DeviceType`'s memory space is `Kokkos::Cuda` and we enable `KOKKOS_USE_CUDA_AWARE_MPI`, the permutation array now is stored on the device and `Distributor::doPostsAndWaits` doesn't allow memory on the device anymore, but just uses the permutation array directly since the input array is stored on the device. 
- If the `DeviceType`'s memory space is `Kokkos::Cuda` and `KOKKOS_USE_CUDA_AWARE_MPI` is disabled, the input array for `Distributor::doPostsAndWaits` is stored on the host so we should also create the permutation array on the host.