### PR TITLE
Disable errors on warnings until figure it out

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -219,7 +219,7 @@ pipeline {
                 recordIssues(
                     enabledForFailure: true,
                     tools: [cmake(), gcc(), clang(), clangTidy()],
-                    qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                    qualityGates: [[threshold: 0, type: 'TOTAL', unstable: true]],
                     filters: [excludeFile('/usr/local/cuda.*')]
                 )
             }

--- a/.jenkins
+++ b/.jenkins
@@ -219,7 +219,7 @@ pipeline {
                 recordIssues(
                     enabledForFailure: true,
                     tools: [cmake(), gcc(), clang(), clangTidy()],
-                    qualityGates: [[threshold: 0, type: 'TOTAL', unstable: true]],
+                    // qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
                     filters: [excludeFile('/usr/local/cuda.*')]
                 )
             }


### PR DESCRIPTION
Right now, the results on any CI build are unpredictable. It may produce
no errors, or it may fail with hundreds of unrelated ones coming from
the system libraries.

I have not had time to investigate it. However, it holds up the process
of merging other PRs. Thus, I'm disabling it for now. It will still
report the warnings, just not fail on them.