### PR TITLE
Enable predicates access traits in distributed search tree

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -170,6 +170,34 @@ public:
   }
 };
 
+template <typename DeviceType>
+struct RadiusSearches
+{
+  Kokkos::View<ArborX::Point *, DeviceType> points;
+  double radius;
+};
+
+namespace ArborX
+{
+namespace Traits
+{
+template <typename DeviceType>
+struct Access<RadiusSearches<DeviceType>, PredicatesTag>
+{
+  using memory_space = typename DeviceType::memory_space;
+  static std::size_t size(RadiusSearches<DeviceType> const &pred)
+  {
+    return pred.points.extent(0);
+  }
+  static KOKKOS_FUNCTION auto get(RadiusSearches<DeviceType> const &pred,
+                                  std::size_t i)
+  {
+    return intersects(Sphere{pred.points(i), pred.radius});
+  }
+};
+} // namespace Traits
+} // namespace ArborX
+
 namespace bpo = boost::program_options;
 
 template <class NO>
@@ -357,8 +385,6 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
 
   if (perform_radius_search)
   {
-    Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
-        queries(Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
     // radius chosen in order to control the number of results per query
     // NOTE: minus "1+sqrt(3)/2 \approx 1.37" matches the size of the boxes
     // inserted into the tree (mid-point between half-edge and
@@ -366,12 +392,6 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     double const r =
         2. * std::cbrt(static_cast<double>(n_neighbors) * 3. / (4. * M_PI)) -
         (1. + std::sqrt(3.)) / 2.;
-    Kokkos::parallel_for(
-        "bvh_driver:setup_radius_search_queries",
-        Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
-        KOKKOS_LAMBDA(int i) {
-          queries(i) = ArborX::intersects(ArborX::Sphere{random_points(i), r});
-        });
 
     Kokkos::View<int *, DeviceType> offset("offset", 0);
     Kokkos::View<int *, DeviceType> indices("indices", 0);
@@ -380,7 +400,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     auto radius = time_monitor.getNewTimer("radius");
     MPI_Barrier(comm);
     radius->start();
-    distributed_tree.query(queries, indices, offset, ranks);
+    distributed_tree.query(RadiusSearches<DeviceType>{random_points, r},
+                           indices, offset, ranks);
     radius->stop();
 
     if (comm_rank == 0)

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -87,9 +87,9 @@ public:
   template <typename Predicates, typename... Args>
   void query(Predicates const &predicates, Args &&... args) const
   {
-    // FIXME lame placeholder for concept check
-    static_assert(Kokkos::is_view<Predicates>::value, "must pass a view");
-    using Tag = typename Predicates::value_type::Tag;
+    using Access = Traits::Access<Predicates, Traits::PredicatesTag>;
+    using Tag =
+        typename Details::Tag<Details::decay_result_of_get_t<Access>>::type;
     Details::DistributedSearchTreeImpl<DeviceType>::queryDispatch(
         Tag{}, *this, predicates, std::forward<Args>(args)...);
   }

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -45,7 +45,7 @@ struct DistributedSearchTreeImpl
 
   // spatial queries
   template <typename Query>
-  static void queryDispatch(Details::SpatialPredicateTag,
+  static void queryDispatch(SpatialPredicateTag,
                             DistributedSearchTree<DeviceType> const &tree,
                             Kokkos::View<Query *, DeviceType> queries,
                             Kokkos::View<int *, DeviceType> &indices,
@@ -55,7 +55,7 @@ struct DistributedSearchTreeImpl
   // nearest neighbors queries
   template <typename Query>
   static void
-  queryDispatch(Details::NearestPredicateTag,
+  queryDispatch(NearestPredicateTag,
                 DistributedSearchTree<DeviceType> const &tree,
                 Kokkos::View<Query *, DeviceType> queries,
                 Kokkos::View<int *, DeviceType> &indices,
@@ -333,7 +333,7 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
 template <typename DeviceType>
 template <typename Query>
 void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-    Details::NearestPredicateTag, DistributedSearchTree<DeviceType> const &tree,
+    NearestPredicateTag, DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<Query *, DeviceType> queries,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
@@ -406,7 +406,7 @@ void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
 template <typename DeviceType>
 template <typename Query>
 void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
-    Details::SpatialPredicateTag, DistributedSearchTree<DeviceType> const &tree,
+    SpatialPredicateTag, DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<Query *, DeviceType> queries,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -53,20 +53,18 @@ struct DistributedSearchTreeImpl
                             Kokkos::View<int *, DeviceType> &ranks);
 
   // nearest neighbors queries
-  template <typename Query>
-  static void
-  queryDispatch(NearestPredicateTag,
-                DistributedSearchTree<DeviceType> const &tree,
-                Kokkos::View<Query *, DeviceType> queries,
-                Kokkos::View<int *, DeviceType> &indices,
-                Kokkos::View<int *, DeviceType> &offset,
-                Kokkos::View<int *, DeviceType> &ranks,
-                Kokkos::View<double *, DeviceType> *distances_ptr = nullptr);
+  template <typename Predicates>
+  static void queryDispatch(
+      NearestPredicateTag, DistributedSearchTree<DeviceType> const &tree,
+      Predicates const &queries, Kokkos::View<int *, DeviceType> &indices,
+      Kokkos::View<int *, DeviceType> &offset,
+      Kokkos::View<int *, DeviceType> &ranks,
+      Kokkos::View<double *, DeviceType> *distances_ptr = nullptr);
 
-  template <typename Query>
+  template <typename Predicates>
   static void queryDispatch(Details::NearestPredicateTag tag,
                             DistributedSearchTree<DeviceType> const &tree,
-                            Kokkos::View<Query *, DeviceType> queries,
+                            Predicates const &queries,
                             Kokkos::View<int *, DeviceType> &indices,
                             Kokkos::View<int *, DeviceType> &offset,
                             Kokkos::View<int *, DeviceType> &ranks,
@@ -75,15 +73,15 @@ struct DistributedSearchTreeImpl
     queryDispatch(tag, tree, queries, indices, offset, ranks, &distances);
   }
 
-  template <typename Query>
-  static void deviseStrategy(Kokkos::View<Query *, DeviceType> queries,
+  template <typename Predicates>
+  static void deviseStrategy(Predicates const &queries,
                              DistributedSearchTree<DeviceType> const &tree,
                              Kokkos::View<int *, DeviceType> &indices,
                              Kokkos::View<int *, DeviceType> &offset,
                              Kokkos::View<double *, DeviceType> &);
 
-  template <typename Query>
-  static void reassessStrategy(Kokkos::View<Query *, DeviceType> queries,
+  template <typename Predicates>
+  static void reassessStrategy(Predicates const &queries,
                                DistributedSearchTree<DeviceType> const &tree,
                                Kokkos::View<int *, DeviceType> &indices,
                                Kokkos::View<int *, DeviceType> &offset,
@@ -104,8 +102,8 @@ struct DistributedSearchTreeImpl
       Kokkos::View<int *, DeviceType> &ids,
       Kokkos::View<double *, DeviceType> *distances_ptr = nullptr);
 
-  template <typename Query>
-  static void filterResults(Kokkos::View<Query *, DeviceType> queries,
+  template <typename Predicates>
+  static void filterResults(Predicates const &queries,
                             Kokkos::View<double *, DeviceType> distances,
                             Kokkos::View<int *, DeviceType> &indices,
                             Kokkos::View<int *, DeviceType> &offset,
@@ -238,10 +236,9 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Predicates>
 void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
-    Kokkos::View<Query *, DeviceType> queries,
-    DistributedSearchTree<DeviceType> const &tree,
+    Predicates const &queries, DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
     Kokkos::View<double *, DeviceType> &)
@@ -256,13 +253,14 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
   // is the number of neighbors queried for.  Stop if local trees get
   // empty because it means that they are no more leaves and there is no point
   // on forwarding queries to leafless trees.
-  auto const n_queries = queries.extent(0);
+  using Access = Traits::Access<Predicates, Traits::PredicatesTag>;
+  auto const n_queries = Access::size(queries);
   Kokkos::View<int *, DeviceType> new_offset(offset.label(), n_queries + 1);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("bottom_trees_with_required_cumulated_leaves_count"),
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries), KOKKOS_LAMBDA(int i) {
         int leaves_count = 0;
-        int const n_nearest_neighbors = queries(i)._k;
+        int const n_nearest_neighbors = Access::get(queries, i)._k;
         for (int j = offset(i); j < offset(i + 1); ++j)
         {
           int const bottom_tree_size = bottom_tree_sizes(indices(j));
@@ -291,16 +289,16 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Predicates>
 void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
-    Kokkos::View<Query *, DeviceType> queries,
-    DistributedSearchTree<DeviceType> const &tree,
+    Predicates const &queries, DistributedSearchTree<DeviceType> const &tree,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
     Kokkos::View<double *, DeviceType> &distances)
 {
   auto const &top_tree = tree._top_tree;
-  auto const n_queries = queries.extent(0);
+  using Access = Traits::Access<Predicates, Traits::PredicatesTag>;
+  auto const n_queries = Access::size(queries);
 
   // Determine distance to the farthest neighbor found so far.
   Kokkos::View<double *, DeviceType> farthest_distances("distances", n_queries);
@@ -320,8 +318,8 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("bottom_trees_within_that_distance"),
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries), KOKKOS_LAMBDA(int i) {
-        radius_searches(i) =
-            intersects(Sphere{queries(i)._geometry, farthest_distances(i)});
+        radius_searches(i) = intersects(
+            Sphere{Access::get(queries, i)._geometry, farthest_distances(i)});
       });
 
   top_tree.query(radius_searches, indices, offset);
@@ -330,11 +328,10 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Predicates>
 void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     NearestPredicateTag, DistributedSearchTree<DeviceType> const &tree,
-    Kokkos::View<Query *, DeviceType> queries,
-    Kokkos::View<int *, DeviceType> &indices,
+    Predicates const &queries, Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
     Kokkos::View<int *, DeviceType> &ranks,
     Kokkos::View<double *, DeviceType> *distances_ptr)
@@ -358,11 +355,10 @@ void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
 
   // NOTE: compiler would not deduce __range for the braced-init-list but I
   // got it to work with the static_cast to function pointers.
-  using Strategy = void (*)(Kokkos::View<Query *, DeviceType>,
-                            DistributedSearchTree<DeviceType> const &,
-                            Kokkos::View<int *, DeviceType> &,
-                            Kokkos::View<int *, DeviceType> &,
-                            Kokkos::View<double *, DeviceType> &);
+  using Strategy = void (*)(
+      Predicates const &, DistributedSearchTree<DeviceType> const &,
+      Kokkos::View<int *, DeviceType> &, Kokkos::View<int *, DeviceType> &,
+      Kokkos::View<double *, DeviceType> &);
   for (auto implementStrategy :
        {static_cast<Strategy>(
             DistributedSearchTreeImpl<DeviceType>::deviseStrategy),
@@ -374,6 +370,8 @@ void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     ////////////////////////////////////////////////////////////////////////////
     // Forward queries
     ////////////////////////////////////////////////////////////////////////////
+    using Access = Traits::Access<Predicates, Traits::PredicatesTag>;
+    using Query = decay_result_of_get_t<Access>;
     Kokkos::View<int *, DeviceType> ids("query_ids", 0);
     Kokkos::View<Query *, DeviceType> fwd_queries("fwd_queries", 0);
     forwardQueries(comm, queries, indices, offset, fwd_queries, ids, ranks);
@@ -394,7 +392,7 @@ void DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     ////////////////////////////////////////////////////////////////////////////
     // Merge results
     ////////////////////////////////////////////////////////////////////////////
-    int const n_queries = queries.extent_int(0);
+    int const n_queries = Access::size(queries);
     countResults(n_queries, ids, offset);
     sortResults(ids, indices, ranks, distances);
     filterResults(queries, distances, indices, offset, ranks);
@@ -653,24 +651,25 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
 }
 
 template <typename DeviceType>
-template <typename Query>
+template <typename Predicates>
 void DistributedSearchTreeImpl<DeviceType>::filterResults(
-    Kokkos::View<Query *, DeviceType> queries,
-    Kokkos::View<double *, DeviceType> distances,
+    Predicates const &queries, Kokkos::View<double *, DeviceType> distances,
     Kokkos::View<int *, DeviceType> &indices,
     Kokkos::View<int *, DeviceType> &offset,
     Kokkos::View<int *, DeviceType> &ranks)
 {
-  int const n_queries = queries.extent_int(0);
+  using Access = Traits::Access<Predicates, Traits::PredicatesTag>;
+  int const n_queries = Access::size(queries);
   // truncated views are prefixed with an underscore
   Kokkos::View<int *, DeviceType> new_offset(offset.label(), n_queries + 1);
 
-  Kokkos::parallel_for(
-      ARBORX_MARK_REGION("discard_results"),
-      Kokkos::RangePolicy<ExecutionSpace>(0, n_queries), KOKKOS_LAMBDA(int q) {
-        using KokkosExt::min;
-        new_offset(q) = min(offset(q + 1) - offset(q), queries(q)._k);
-      });
+  Kokkos::parallel_for(ARBORX_MARK_REGION("discard_results"),
+                       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
+                       KOKKOS_LAMBDA(int q) {
+                         using KokkosExt::min;
+                         new_offset(q) = min(offset(q + 1) - offset(q),
+                                             Access::get(queries, q)._k);
+                       });
 
   exclusivePrefixSum(new_offset);
 
@@ -713,7 +712,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
           }
 
           int count = 0;
-          while (!queue.empty() && count < queries(q)._k)
+          while (!queue.empty() && count < Access::get(queries, q)._k)
           {
             new_indices(new_offset(q) + count) = queue.top().first[0];
             new_ranks(new_offset(q) + count) = queue.top().first[1];


### PR DESCRIPTION
Using access traits in the benchmark to demonstrate that it works.