### PR TITLE
Exploit batched input in createFromSends

### DIFF
--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -223,7 +223,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   Kokkos::Profiling::pushRegion("ArborX:BVH:filter_out_invalid_entries");
 
   // Find out if they are any invalid entries in the indices (i.e. at least
-  // one query asked for more neighbors that they are leaves in the tree) and
+  // one query asked for more neighbors than there are leaves in the tree) and
   // eliminate them if necessary.
   auto tmp_offset = cloneWithoutInitializingNorCopying(offset);
   Kokkos::deep_copy(tmp_offset, 0);


### PR DESCRIPTION
When calling `createFromSends` in `DistributedSearchTreeImpl::communicateResultsBack` the input is already batched, but we currently don't try to benefit from that. Given that even for examples that only require very few communication most of the time related to MPI communication is spent in `createFromSends` (and for communication heavy applications even more so), it might be worth exploiting this.
The new overload for `sortAndDetermienBufferLayout` essentials just computes the correct permutation for the batched ranks and reconstructs the total permutation from that.

~~I still need to run benchmarks.~~