### PR TITLE
Allow queries in benchmark to differ from local points

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -253,10 +253,9 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
                                                                               "local clouds form a board, 3 -> local clouds form a box." )
         ( "do-not-perform-knn-search", "skip kNN search" )
         ( "do-not-perform-radius-search", "skip radius search" )
-        ( "shift-queries" , "Shift the the local box queries are created in from the point cloud. "
-                            "By default, points are reused for the queries. "
-                            "Enabling this option shrinks this box to a third of its size and moves it to the center of the global box. "
-                            "The result is a huge inbalance for the number of queries that need to be processed by each processor.")
+        ( "shift-queries" , "By default, points are reused for the queries. Enabling this option shrinks the local box queries are created "
+                            "in to a third of its size and moves it to the center of the global box. The result is a huge inbalance for the "
+                            "number of queries that need to be processed by each processor.")
         ;
   // clang-format on
   bpo::variables_map vm;
@@ -299,9 +298,9 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   Kokkos::View<ArborX::Point *, DeviceType> random_points("random_points", 0);
   Kokkos::View<ArborX::Point *, DeviceType> random_queries("random_queries", 0);
   {
-    // Random points are "reused" between building the tree and performing
-    // queries. Note that this means that for the points in the middle of
-    // the local domains there won't be any communication.
+    // By default, random points are "reused" between building the tree and
+    // performing queries. Note that this means that for the points in the
+    // middle of the local domains there won't be any communication.
     Kokkos::resize(random_points, n_values);
     Kokkos::resize(random_queries, n_queries);
 

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -361,8 +361,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     auto random_points_host = Kokkos::create_mirror_view(random_points);
 
     // The boxes in which the points are placed have side length two, centered
-    // around offset_[xyz] 2 and scaled by a_values.
-    for (int i = 0; i < n_values; ++i)
+    // around offset_[xyz] and scaled by a_values.
+    for (int i = 0; i < n_construction_values; ++i)
       random_points_host(i) = {{a_values * (offset_x + random()),
                                 a_values * (offset_y + random()),
                                 a_values * (offset_z + random())}};
@@ -386,9 +386,10 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     else
     {
       // Reuse constructed points both for values and queries.
-      Kokkos::resize(random_queries, n_construction_values);
-      Kokkos::deep_copy(random_queries, random_points_host);
       Kokkos::resize(random_queries, n_queries);
+      Kokkos::deep_copy(random_queries,
+                        Kokkos::subview(random_points_host,
+                                        Kokkos::pair<int, int>(0, n_queries)));
       Kokkos::resize(random_points, n_values);
     }
   }

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -253,9 +253,10 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
                                                                               "local clouds form a board, 3 -> local clouds form a box." )
         ( "do-not-perform-knn-search", "skip kNN search" )
         ( "do-not-perform-radius-search", "skip radius search" )
-        ( "shift-queries" , "Shift the queries away from the point cloud. By default, queries and points are generated in the same box "
-                            "on each processor. Enabling this option shrinks this box to a third of its size and moves it to the center "
-                            "of the global box.")
+        ( "shift-queries" , "Shift the the local box queries are created in from the point cloud. "
+                            "By default, points are reused for the queries. "
+                            "Enabling this option shrinks this box to a third of its size and moves it to the center of the global box. "
+                            "The result is a huge inbalance for the number of queries that need to be processed by each processor.")
         ;
   // clang-format on
   bpo::variables_map vm;

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -235,6 +235,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   int partition_dim;
   bool perform_knn_search = true;
   bool perform_radius_search = true;
+  bool shift_queries = false;
 
   bpo::options_description desc("Allowed options");
   // clang-format off
@@ -252,6 +253,9 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
                                                                               "local clouds form a board, 3 -> local clouds form a box." )
         ( "do-not-perform-knn-search", "skip kNN search" )
         ( "do-not-perform-radius-search", "skip radius search" )
+        ( "shift-queries" , "Shift the queries away from the point cloud. By default, queries and points are generated in the same box "
+                            "on each processor. Enabling this option shrinks this box to a third of its size and moves it to the center "
+                            "of the global box.")
         ;
   // clang-format on
   bpo::variables_map vm;
@@ -274,6 +278,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     perform_knn_search = false;
   if (vm.count("do-not-perform-radius-search"))
     perform_radius_search = false;
+  if (vm.count("shift-queries"))
+    shift_queries = true;
 
   if (comm_rank == 0)
   {
@@ -285,22 +291,26 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
               << "#queries/MPI process    : " << n_queries << '\n'
               << "size of shift           : " << shift << '\n'
               << "dimension               : " << partition_dim << '\n'
+              << "shift-queries           : " << shift_queries << '\n'
               << '\n';
   }
 
   Kokkos::View<ArborX::Point *, DeviceType> random_points("random_points", 0);
+  Kokkos::View<ArborX::Point *, DeviceType> random_queries("random_queries", 0);
   {
     // Random points are "reused" between building the tree and performing
     // queries. Note that this means that for the points in the middle of
     // the local domains there won't be any communication.
-    auto n = std::max(n_values, n_queries);
-    Kokkos::resize(random_points, n);
+    Kokkos::resize(random_points, n_values);
+    Kokkos::resize(random_queries, n_queries);
 
     auto random_points_host = Kokkos::create_mirror_view(random_points);
+    auto random_queries_host = Kokkos::create_mirror_view(random_queries);
 
     // Generate random points uniformly distributed within a box.
-    auto const a = std::cbrt(n_values);
-    std::uniform_real_distribution<double> distribution(-a, +a);
+    auto const a_values = std::cbrt(n_values);
+    auto const a_queries = std::cbrt(n_queries);
+    std::uniform_real_distribution<double> distribution(-1., 1.);
     std::default_random_engine generator;
     auto random = [&distribution, &generator]() {
       return distribution(generator);
@@ -309,6 +319,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     double offset_x = 0.;
     double offset_y = 0.;
     double offset_z = 0.;
+    int i_max = 0;
     // Change the geometry of the problem. In 1D, all the point clouds are
     // aligned on a line. In 2D, the point clouds create a board and in 3D,
     // they create a box.
@@ -316,30 +327,31 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     {
     case 1:
     {
-      offset_x = 2 * a * shift * comm_rank;
+      i_max = comm_size;
+      offset_x = 2 * shift * comm_rank;
 
       break;
     }
     case 2:
     {
-      int i_max = std::ceil(std::sqrt(comm_size));
+      i_max = std::ceil(std::sqrt(comm_size));
       int i = comm_rank % i_max;
       int j = comm_rank / i_max;
-      offset_x = 2 * a * shift * i;
-      offset_y = 2 * a * shift * j;
+      offset_x = 2 * shift * i;
+      offset_y = 2 * shift * j;
 
       break;
     }
     case 3:
     {
-      int i_max = std::ceil(std::cbrt(comm_size));
+      i_max = std::ceil(std::cbrt(comm_size));
       int j_max = i_max;
       int i = comm_rank % i_max;
       int j = (comm_rank / i_max) % j_max;
       int k = comm_rank / (i_max * j_max);
-      offset_x = 2 * a * shift * i;
-      offset_y = 2 * a * shift * j;
-      offset_z = 2 * a * shift * k;
+      offset_x = 2 * shift * i;
+      offset_y = 2 * shift * j;
+      offset_z = 2 * shift * k;
 
       break;
     }
@@ -349,11 +361,22 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     }
     }
 
-    for (int i = 0; i < n; ++i)
-      random_points_host(i) = {
-          {offset_x + random(), offset_y + random(), offset_z + random()}};
+    for (int i = 0; i < n_values; ++i)
+      random_points_host(i) = {{a_values * (offset_x + random()),
+                                a_values * (offset_y + random()),
+                                a_values * (offset_z + random())}};
+    int const max_offset = 2 * shift * i_max;
+    for (int i = 0; i < n_queries; ++i)
+      random_queries_host(i) = {
+          {a_queries * ((offset_x + random()) / 3 + max_offset / 3),
+           a_queries * ((offset_y + random()) / 3 + max_offset / 3),
+           a_queries * ((offset_z + random()) / 3 + max_offset / 3)}};
     Kokkos::deep_copy(random_points, random_points_host);
+    Kokkos::deep_copy(random_queries, random_queries_host);
   }
+
+  if (!shift_queries)
+    random_queries = random_points;
 
   Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes(
       Kokkos::ViewAllocateWithoutInitializing("bounding_boxes"), n_values);
@@ -388,7 +411,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     MPI_Barrier(comm);
     knn->start();
     distributed_tree.query(
-        NearestNeighborsSearches<DeviceType>{random_points, n_neighbors},
+        NearestNeighborsSearches<DeviceType>{random_queries, n_neighbors},
         indices, offset, ranks);
     knn->stop();
 
@@ -413,7 +436,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     auto radius = time_monitor.getNewTimer("radius");
     MPI_Barrier(comm);
     radius->start();
-    distributed_tree.query(RadiusSearches<DeviceType>{random_points, r},
+    distributed_tree.query(RadiusSearches<DeviceType>{random_queries, r},
                            indices, offset, ranks);
     radius->stop();
 

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -254,7 +254,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
         ( "do-not-perform-knn-search", "skip kNN search" )
         ( "do-not-perform-radius-search", "skip radius search" )
         ( "shift-queries" , "By default, points are reused for the queries. Enabling this option shrinks the local box queries are created "
-                            "in to a third of its size and moves it to the center of the global box. The result is a huge inbalance for the "
+                            "in to a third of its size and moves it to the center of the global box. The result is a huge imbalance for the "
                             "number of queries that need to be processed by each processor.")
         ;
   // clang-format on


### PR DESCRIPTION
This is the modification of the `distributed_tree_driver` benchmark used in https://github.com/arborx/ArborX/pull/199#issuecomment-562231451.