### PR TITLE
[WIP] Avoid Alltoall in createFromSends

### DIFF
--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -347,26 +347,49 @@ public:
 private:
   size_t preparePointToPointCommunication()
   {
-    int comm_size;
-    MPI_Comm_size(_comm, &comm_size);
-
-    std::vector<int> src_counts_dense(comm_size);
+    // Send the number of messages to the respective processors...
     int const dest_size = _destinations.size();
+    std::vector<MPI_Request> send_requests(dest_size);
     for (int i = 0; i < dest_size; ++i)
     {
-      src_counts_dense[_destinations[i]] = _dest_counts[i];
+      int const ierr =
+          MPI_Isend(&(_dest_counts[i]), 1, MPI_INT, _destinations[i], 32766,
+                    _comm, &(send_requests[i]));
+      ARBORX_ASSERT(ierr == MPI_SUCCESS);
     }
-    MPI_Alltoall(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, src_counts_dense.data(), 1,
-                 MPI_INT, _comm);
 
+    std::vector<int> sent_to_process(comm_size);
+    for (int i = 0; i < dest_size; ++i)
+    {
+      sent_to_process[_destinations[i]] = 1;
+    }
+
+    unsigned int n_recv_from;
+    int ierr = MPI_Reduce_scatter_block(sent_to_process.data(), &n_recv_from, 1,
+                                        MPI_INT, MPI_SUM, _comm);
+    ARBORX_ASSERT(ierr == MPI_SUCCESS);
+
+    // ...and receive them.
     _src_offsets.push_back(0);
-    for (int i = 0; i < comm_size; ++i)
-      if (src_counts_dense[i] > 0)
+    for (unsigned int i = 0; i < n_recv_from; ++i)
+    {
+      MPI_Status status;
+      MPI_Probe(MPI_ANY_SOURCE, 32766, _comm, &status);
+      int n_elements;
+      int const source_rank = status.MPI_SOURCE;
+      int const ierr = MPI_Recv(&n_elements, 1, MPI_UNSIGNED, source_rank,
+                                32766, _comm, MPI_STATUS_IGNORE);
+      ARBORX_ASSERT(ierr == MPI_SUCCESS);
+      if (n_elements > 0)
       {
-        _sources.push_back(i);
-        _src_counts.push_back(src_counts_dense[i]);
-        _src_offsets.push_back(_src_offsets.back() + _src_counts.back());
+        _sources.push_back(source_rank);
+        _src_counts.push_back(n_elements);
+        _src_offsets.push_back(n_elements + _src_offsets.back());
       }
+    }
+
+    ierr = MPI_Waitall(dest_size, send_requests.data(), MPI_STATUSES_IGNORE);
+    ARBORX_ASSERT(ierr == MPI_SUCCESS);
 
     return _src_offsets.back();
   }


### PR DESCRIPTION
For a large number of processes, it should be better to avoid `MPI_Alltoall` and compute the number of messages to receive instead and then just perform necessary point-to-point communication.

I still need to measure if there is an impact on larger runs.