### PR TITLE
Let exclusivePrefixSum return the total sum

### DIFF
--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -117,8 +117,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
       KOKKOS_LAMBDA(int i) { offset(permute(i)) = queries(i)._k; });
 
-  exclusivePrefixSum(offset);
-  int const n_results = lastElement(offset);
+  int const n_results = exclusivePrefixSum(offset);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion("ArborX:BVH:traversal");
@@ -237,8 +236,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                              break;
                            }
                        });
-  exclusivePrefixSum(tmp_offset);
-  int const n_invalid_indices = lastElement(tmp_offset);
+  int const n_invalid_indices = exclusivePrefixSum(tmp_offset);
   if (n_invalid_indices > 0)
   {
     Kokkos::parallel_for(
@@ -386,13 +384,12 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   // [ 0 2 4 .... 2N-2 2N ]
   //                    ^
   //                    N
-  exclusivePrefixSum(offset);
-
+  //
   // Let us extract the last element in the view which is the total count of
   // objects which where found to meet the query predicates:
   //
   // [ 2N ]
-  int const n_results = lastElement(offset);
+  int const n_results = exclusivePrefixSum(offset);
 
   Kokkos::Profiling::popRegion();
 

--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -117,7 +117,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
       KOKKOS_LAMBDA(int i) { offset(permute(i)) = queries(i)._k; });
 
-  int const n_results = exclusivePrefixSum(offset);
+  int const n_results = exclusivePrefixSumWithTotal(offset);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion("ArborX:BVH:traversal");
@@ -236,7 +236,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
                              break;
                            }
                        });
-  int const n_invalid_indices = exclusivePrefixSum(tmp_offset);
+  int const n_invalid_indices = exclusivePrefixSumWithTotal(tmp_offset);
   if (n_invalid_indices > 0)
   {
     Kokkos::parallel_for(
@@ -389,7 +389,7 @@ void BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   // objects which where found to meet the query predicates:
   //
   // [ 2N ]
-  int const n_results = exclusivePrefixSum(offset);
+  int const n_results = exclusivePrefixSumWithTotal(offset);
 
   Kokkos::Profiling::popRegion();
 

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -271,7 +271,7 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
         }
       });
 
-  auto const total_count = exclusivePrefixSum(new_offset);
+  auto const total_count = exclusivePrefixSumWithTotal(new_offset);
 
   // Truncate results so that queries will only be forwarded to as many local
   // trees as necessary to find k neighbors.
@@ -644,7 +644,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
                                              Access::get(queries, q)._k);
                        });
 
-  int const n_truncated_results = exclusivePrefixSum(new_offset);
+  int const n_truncated_results = exclusivePrefixSumWithTotal(new_offset);
   Kokkos::View<int *, DeviceType> new_indices(indices.label(),
                                               n_truncated_results);
   Kokkos::View<int *, DeviceType> new_ranks(ranks.label(), n_truncated_results);

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -271,12 +271,11 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
         }
       });
 
-  exclusivePrefixSum(new_offset);
+  auto const total_count = exclusivePrefixSum(new_offset);
 
   // Truncate results so that queries will only be forwarded to as many local
   // trees as necessary to find k neighbors.
-  Kokkos::View<int *, DeviceType> new_indices(indices.label(),
-                                              lastElement(new_offset));
+  Kokkos::View<int *, DeviceType> new_indices(indices.label(), total_count);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("truncate_before_forwarding"),
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries), KOKKOS_LAMBDA(int i) {
@@ -645,9 +644,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
                                              Access::get(queries, q)._k);
                        });
 
-  exclusivePrefixSum(new_offset);
-
-  int const n_truncated_results = lastElement(new_offset);
+  int const n_truncated_results = exclusivePrefixSum(new_offset);
   Kokkos::View<int *, DeviceType> new_indices(indices.label(),
                                               n_truncated_results);
   Kokkos::View<int *, DeviceType> new_ranks(ranks.label(), n_truncated_results);

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -62,9 +62,49 @@ private:
  *  \pre \p src and \p dst must be of rank 1 and have the same size.
  */
 template <typename ST, typename... SP, typename DT, typename... DP>
+void exclusivePrefixSum(Kokkos::View<ST, SP...> const &src,
+                        Kokkos::View<DT, DP...> const &dst)
+{
+  static_assert(
+      std::is_same<
+          typename Kokkos::ViewTraits<DT, DP...>::value_type,
+          typename Kokkos::ViewTraits<DT, DP...>::non_const_value_type>::value,
+      "exclusivePrefixSum requires non-const destination type");
+
+  static_assert(
+      (unsigned(Kokkos::ViewTraits<DT, DP...>::rank) ==
+       unsigned(Kokkos::ViewTraits<ST, SP...>::rank)) &&
+          (unsigned(Kokkos::ViewTraits<DT, DP...>::rank) == unsigned(1)),
+      "exclusivePrefixSum requires Views of rank 1");
+
+  using ExecutionSpace =
+      typename Kokkos::ViewTraits<DT, DP...>::execution_space;
+  using ValueType = typename Kokkos::ViewTraits<DT, DP...>::value_type;
+  using DeviceType = typename Kokkos::ViewTraits<DT, DP...>::device_type;
+
+  auto const n = src.extent(0);
+  ARBORX_ASSERT(n == dst.extent(0));
+  Kokkos::parallel_scan(
+      "exclusive_scan", Kokkos::RangePolicy<ExecutionSpace>(0, n),
+      Details::ExclusiveScanFunctor<ValueType, DeviceType>(src, dst));
+}
+
+/** \brief In-place exclusive scan.
+ *
+ *  \param[in,out] v View with range of elements to sum
+ *
+ *  Calls \c exclusivePrefixSum(v, v)
+ */
+template <typename T, typename... P>
+inline void exclusivePrefixSum(Kokkos::View<T, P...> const &v)
+{
+  exclusivePrefixSum(v, v);
+}
+
+template <typename ST, typename... SP, typename DT, typename... DP>
 typename Kokkos::ViewTraits<DT, DP...>::value_type
-exclusivePrefixSum(Kokkos::View<ST, SP...> const &src,
-                   Kokkos::View<DT, DP...> const &dst)
+exclusivePrefixSumWithTotal(Kokkos::View<ST, SP...> const &src,
+                            Kokkos::View<DT, DP...> const &dst)
 {
   static_assert(
       std::is_same<
@@ -92,16 +132,10 @@ exclusivePrefixSum(Kokkos::View<ST, SP...> const &src,
   return result;
 }
 
-/** \brief In-place exclusive scan.
- *
- *  \param[in,out] v View with range of elements to sum
- *
- *  Calls \c exclusivePrefixSum(v, v)
- */
 template <typename T, typename... P>
-inline auto exclusivePrefixSum(Kokkos::View<T, P...> const &v)
+inline auto exclusivePrefixSumWithTotal(Kokkos::View<T, P...> const &v)
 {
-  return exclusivePrefixSum(v, v);
+  return exclusivePrefixSumWithTotal(v, v);
 }
 
 /** \brief Get a copy of the last element.

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -186,7 +186,7 @@ performQueries(RTree<Indexable> const &rtree, InputView const &queries)
   for (int i = 0; i < n_queries; ++i)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
-  auto const n_results = ArborX::exclusivePrefixSum(offset);
+  auto const n_results = ArborX::exclusivePrefixSumWithTotal(offset);
   OutputView indices("indices", n_results);
   for (int i = 0; i < n_queries; ++i)
     for (int j = offset(i); j < offset(i + 1); ++j)
@@ -208,7 +208,7 @@ performQueries(ParallelRTree<Indexable> const &rtree, InputView const &queries)
   for (int i = 0; i < n_queries; ++i)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
-  auto const n_results = ArborX::exclusivePrefixSum(offset);
+  auto const n_results = ArborX::exclusivePrefixSumWithTotal(offset);
   OutputView indices("indices", n_results);
   OutputView ranks("ranks", n_results);
   for (int i = 0; i < n_queries; ++i)

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -186,8 +186,7 @@ performQueries(RTree<Indexable> const &rtree, InputView const &queries)
   for (int i = 0; i < n_queries; ++i)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
-  ArborX::exclusivePrefixSum(offset);
-  auto const n_results = ArborX::lastElement(offset);
+  auto const n_results = ArborX::exclusivePrefixSum(offset);
   OutputView indices("indices", n_results);
   for (int i = 0; i < n_queries; ++i)
     for (int j = offset(i); j < offset(i + 1); ++j)
@@ -209,8 +208,7 @@ performQueries(ParallelRTree<Indexable> const &rtree, InputView const &queries)
   for (int i = 0; i < n_queries; ++i)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
-  ArborX::exclusivePrefixSum(offset);
-  auto const n_results = ArborX::lastElement(offset);
+  auto const n_results = ArborX::exclusivePrefixSum(offset);
   OutputView indices("indices", n_results);
   OutputView ranks("ranks", n_results);
   for (int i = 0; i < n_queries; ++i)


### PR DESCRIPTION
In many, places we need the total sum after calling `exlusivePrefixSum`. We can easily avoid a separate kernel launch.