### PR TITLE
Spellchecking comments

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -66,7 +66,7 @@ constructPoints(int n_values, PointCloudType point_cloud_type)
 {
   Kokkos::View<ArborX::Point *, DeviceType> random_points(
       Kokkos::ViewAllocateWithoutInitializing("random_points"), n_values);
-  // Generate random points uniformely distributed within a box.  The edge
+  // Generate random points uniformly distributed within a box.  The edge
   // length of the box chosen such that object density (here objects will be
   // boxes 2x2x2 centered around a random point) will remain constant as
   // problem size is changed.

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(intersects)
 {
   using ArborX::Details::intersects;
 
-  // uninitalized box does not intersect with other boxes
+  // uninitialized box does not intersect with other boxes
   STATIC_ASSERT(!intersects(Box{}, {{{1.0, 2.0, 3.0}}, {{4.0, 5.0, 6.0}}}));
   // uninitialized box does not even intersect with itself
   STATIC_ASSERT(!intersects(Box{}, Box{}));
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(intersects)
   STATIC_ASSERT(intersects(box, {{{1.0, 0.0, 0.0}}, {{2.0, 1.0, 1.0}}}));
   STATIC_ASSERT(intersects(box, {{{-0.5, -0.5, -0.5}}, {{0.5, 0.0, 0.5}}}));
 
-  // unit shpere
+  // unit sphere
   constexpr Sphere sphere{{{0., 0., 0.}}, 1.};
   BOOST_TEST(intersects(sphere, {{{0., 0., 0.}}, {{1., 1., 1.}}}));
   BOOST_TEST(!intersects(sphere, {{{1., 2., 3.}}, {{4., 5., 6.}}}));

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(indirect_sort, DeviceType, ARBORX_DEVICE_TYPES)
                        fill_k_functor);
 
   std::vector<size_t> ref = {3, 2, 1, 0};
-  // sort morton codes and object ids
+  // sort Morton codes and object ids
   auto ids = details::sortObjects(k);
 
   auto k_host = Kokkos::create_mirror_view(k);

--- a/test/tstDetailsTreeTraversal.cpp
+++ b/test/tstDetailsTreeTraversal.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(pop_push)
 {
   // note that calling pop_push(x) does not necessarily yield the same heap
   // than calling consecutively pop() and push(x)
-  // below is a max heap example to illustate this interesting property
+  // below is a max heap example to illustrate this interesting property
   details::PriorityQueue<int> queue;
 
   std::vector<int> ref = {100, 19, 36, 17, 3, 25, 1, 2, 7};

--- a/test/tstHeapOperations.cpp
+++ b/test/tstHeapOperations.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(max_heap)
   // std::push_heap() and std::pop_heap().  It turns out that calling
   // std::make_heap() on { 3, 1, 4, 1, 5, 9 } is not equivalent to inserting
   // one element at a time (I also tried to insert them in reverse order out
-  // of curiousity) and yields 9 5 4 1 1 3 :/
+  // of curiosity) and yields 9 5 4 1 1 3 :/
   // cpluplus.com does make a note that the order of the elements will depend
   // on implementation.
   // Nevertheless, I thought it helps understanding how the algorithm works so

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -483,7 +483,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
               (k - 1) * Lz / (nz - 1)}},
             {{(i + 1) * Lx / (nx - 1), (j + 1) * Ly / (ny - 1),
               (k + 1) * Lz / (nz - 1)}}};
-        // fill in reference solution to check againt the collision
+        // fill in reference solution to check against the collision
         // list computed during the tree traversal
         if ((i > 0) && (j > 0) && (k > 0))
           ref[index].emplace(ind(i - 1, j - 1, k - 1));
@@ -661,7 +661,7 @@ std::vector<std::array<double, 3>> make_random_cloud(double Lx, double Ly,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
 {
-  // contruct a cloud of points (nodes of a structured grid)
+  // construct a cloud of points (nodes of a structured grid)
   double Lx = 10.0;
   double Ly = 10.0;
   double Lz = 10.0;


### PR DESCRIPTION
The command used:
```
find . -name '*hpp' -or -name '*cpp' -exec aspell --mode ccpp --check {} \;
```