### PR TITLE
Minor fix for the API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The installation instructions can be found [here](https://github.com/arborx/Arbo
 
 Using ArborX
 ------------
-The interface is described [here](https://github.com/arborx/ArborX/blob/master/docs/bounding_volume_hierarchy.md).
+The interface is described [here](https://github.com/arborx/ArborX/blob/master/docs/bounding_volume_hierarchy.md#arborxbvh).
 
 Questions, Bug Reporting, and Issue Tracking
 --------------------------------------------

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -135,7 +135,7 @@ Output
 
 # `ArborX::Traits::Access<T,Tag>::size`
 ```C++
-size_type size(T const& data);
+static size_type size(T const& data);
 ```
 ## Parameters
 `data`
@@ -145,7 +145,7 @@ The number of primitives if the second template argument is `PrimitivesTag` or t
 
 # `ArborX::Traits::Access<T,Tag>::get`
 ```C++
-KOKKOS_FUNCTION context_dependent get(T const& data, size_type pos);
+KOKKOS_FUNCTION static context_dependent get(T const& data, size_type pos);
 ```
 If `std::is_same<Tag,PrimitimesTag>::value` is `true`, the return value type must either decay to `ArborX::Point` or to `ArborX::Box`.
 


### PR DESCRIPTION
* I realized I forgot the `static` keyword in the access traits documentation.
* Also I fixed the link to the API documentation in the README