### PR TITLE
Fix node parsing in the distributed benchmark

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -481,6 +481,7 @@ int main(int argc, char *argv[])
     bpo::store(parsed, vm);
     std::vector<std::string> pass_further =
         bpo::collect_unrecognized(parsed.options, bpo::include_positional);
+    bpo::notify(vm);
 
     if (comm_rank == 0 && std::find_if(pass_further.begin(), pass_further.end(),
                                        [](std::string const &x) {


### PR DESCRIPTION
notify() was never called, so the node type was never stored. This bug
did not allow changing the node type from the command line.