### PR TITLE
Attempt to filter out unrelated warnings in the builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,6 +98,7 @@ RUN BOOST_VERSION=1.67.0 && \
         hardcode-dll-paths=true dll-path=${BOOST_DIR}/lib \
         link=shared \
         variant=release \
+        cxxflags=-w \
         install \
         && \
     rm -rf ${SCRATCH_DIR}


### PR DESCRIPTION
Warnings seem to be coming from building the Docker image.
~~Try piping stderr to /dev/null so the warnings are not printed to the screen.~~
Piping stderr did not work.  Pass `-w` flag (suppress all warnings, including those which GNU CPP issues by default) when building Boost instead.

This is ready for review/merge.