### PR TITLE
Always permute on the device

### DIFF
--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -262,25 +262,15 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
                            exports.extent(7);
 
 #ifndef ARBORX_USE_CUDA_AWARE_MPI
-  (void)space;
-  auto exports_host = create_layout_right_mirror_view(exports);
-  Kokkos::deep_copy(space, exports_host, exports);
-
   auto imports_host = create_layout_right_mirror_view(imports);
 
   using NonConstValueType = typename View::non_const_value_type;
-  using ConstValueType = typename View::const_value_type;
-
-  Kokkos::View<ConstValueType *, Kokkos::HostSpace,
-               Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-      export_buffer(exports_host.data(), exports_host.size());
 
   Kokkos::View<NonConstValueType *, Kokkos::HostSpace,
                Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       import_buffer(imports_host.data(), imports_host.size());
 
-  distributor.doPostsAndWaits(Kokkos::DefaultHostExecutionSpace{},
-                              export_buffer, num_packets, import_buffer);
+  distributor.doPostsAndWaits(space, exports, num_packets, import_buffer);
   Kokkos::deep_copy(space, imports, imports_host);
 #else
   distributor.doPostsAndWaits(space, exports, num_packets, imports);

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -13,6 +13,7 @@
 
 #include <ArborX_Config.hpp>
 
+#include <ArborX_DetailsSortUtils.hpp>
 #include <ArborX_DetailsUtils.hpp> // max
 #include <ArborX_Exception.hpp>
 #include <ArborX_Macros.hpp>
@@ -236,8 +237,8 @@ public:
   }
 
   template <typename ExecutionSpace, typename ExportView, typename ImportView>
-  void doPostsAndWaits(ExecutionSpace const& space, ExportView const &exports, size_t num_packets,
-                       ImportView const &imports) const
+  void doPostsAndWaits(ExecutionSpace const &space, ExportView const &exports,
+                       size_t num_packets, ImportView const &imports) const
   {
     ARBORX_ASSERT(num_packets * _src_offsets.back() == imports.size());
     ARBORX_ASSERT(num_packets * _dest_offsets.back() == exports.size());
@@ -267,7 +268,10 @@ public:
       // Use KOKKOS_CLASS_LAMBDA when we require C++17.
       auto const permute_copy = _permute;
 
-      Kokkos::parallel_for(ARBORX_MARK_REGION("copy_destinations_permuted"),
+      ArborX::Details::applyPermutation(space, permute_copy, exports,
+                                        dest_buffer, true);
+
+      /*Kokkos::parallel_for(ARBORX_MARK_REGION("copy_destinations_permuted"),
                            Kokkos::RangePolicy<ExecutionSpace>(
                                space, 0, _dest_offsets.back() * num_packets),
                            KOKKOS_LAMBDA(int const k) {
@@ -275,7 +279,7 @@ public:
                              int const j = k % num_packets;
                              dest_buffer(num_packets * permute_copy[i] + j) =
                                  exports[num_packets * i + j];
-                           });
+                           });*/
     }
     auto dest_buffer_mirror = Kokkos::create_mirror_view_and_copy(
         typename ImportView::memory_space(), dest_buffer);

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -277,7 +277,7 @@ public:
                                  exports[num_packets * i + j];
                            });
     }
-    auto copied_dest_buffer = Kokkos::create_mirror_view_and_copy(
+    auto dest_buffer_mirror = Kokkos::create_mirror_view_and_copy(
         typename ImportView::memory_space(), dest_buffer);
 
     int comm_rank;
@@ -312,7 +312,7 @@ public:
           _dest_counts[i] * num_packets * sizeof(ValueType);
       auto const send_buffer_ptr =
           permutation_necessary
-              ? copied_dest_buffer.data() + _dest_offsets[i] * num_packets
+              ? dest_buffer_mirror.data() + _dest_offsets[i] * num_packets
               : exports.data() + _dest_offsets[i] * num_packets;
       if (_destinations[i] == comm_rank)
       {

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -270,7 +270,7 @@ public:
       auto const permute_size = _permute.size();
 
       for (unsigned int i = 0; i < num_packets; ++i)
-        ArborX::Details::applyReversePermutation(
+        ArborX::Details::applyInversePermutation(
             space, permute_copy,
             Kokkos::subview(exports,
                             std::pair<unsigned int, unsigned int>(

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -209,8 +209,7 @@ void applyPermutation(ExecutionSpace const &space,
   static_assert(std::is_integral<typename PermutationView::value_type>::value,
                 "");
   auto scratch_view = clone(space, view);
-  applyPermutation(space, permutation, view, scratch_view);
-  Kokkos::deep_copy(space, view, scratch_view);
+  applyPermutation(space, permutation, scratch_view, view);
 }
 
 } // namespace Details

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -160,21 +160,57 @@ struct CopyOp<DstViewType, SrcViewType, 3>
 };
 } // namespace PermuteHelper
 
-template <typename ExecutionSpace, typename PermutationView, typename View>
+template <typename ExecutionSpace, typename PermutationView, typename InputView,
+          typename OutputView>
 void applyPermutation(ExecutionSpace const &space,
-                      PermutationView const &permutation, View &view)
+                      PermutationView const &permutation,
+                      InputView const &input_view, OutputView &output_view,
+                      const bool reverse = false)
 {
   static_assert(std::is_integral<typename PermutationView::value_type>::value,
                 "");
-  ARBORX_ASSERT(permutation.extent(0) == view.extent(0));
+  int const permutation_size = permutation.extent(0);
+  int const num_packets = input_view.extent(0) / permutation_size;
+  ARBORX_ASSERT(num_packets * permutation_size == input_view.extent(0));
+  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
+
+  if (reverse)
+  {
+    Kokkos::parallel_for(
+        ARBORX_MARK_REGION("permute"),
+        Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
+        KOKKOS_LAMBDA(int k) {
+          int const i = k / permutation_size;
+          int const j = k % permutation_size;
+          PermuteHelper::CopyOp<OutputView, InputView>::copy(
+              output_view, permutation_size * i + permutation(j), input_view,
+              permutation_size * i + j);
+        });
+  }
+  else
+  {
+    Kokkos::parallel_for(
+        ARBORX_MARK_REGION("permute"),
+        Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
+        KOKKOS_LAMBDA(int k) {
+          int const i = k / permutation_size;
+          int const j = k % permutation_size;
+          PermuteHelper::CopyOp<OutputView, InputView>::copy(
+              output_view, permutation_size * i + j, input_view,
+              permutation_size * i + permutation(j));
+        });
+  }
+}
+
+template <typename ExecutionSpace, typename PermutationView, typename View>
+void applyPermutation(ExecutionSpace const &space,
+                      PermutationView const &permutation, View &view,
+                      const bool reverse = false)
+{
+  static_assert(std::is_integral<typename PermutationView::value_type>::value,
+                "");
   auto scratch_view = clone(space, view);
-  Kokkos::parallel_for(
-      ARBORX_MARK_REGION("permute"),
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, view.extent(0)),
-      KOKKOS_LAMBDA(int i) {
-        PermuteHelper::CopyOp<View, View>::copy(scratch_view, i, view,
-                                                permutation(i));
-      });
+  applyPermutation(space, permutation, view, scratch_view, reverse);
   Kokkos::deep_copy(space, view, scratch_view);
 }
 

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -162,7 +162,7 @@ struct CopyOp<DstViewType, SrcViewType, 3>
 
 template <typename ExecutionSpace, typename PermutationView, typename InputView,
           typename OutputView>
-void applyReversePermutation(ExecutionSpace const &space,
+void applyInversePermutation(ExecutionSpace const &space,
                              PermutationView const &permutation,
                              InputView const &input_view,
                              OutputView const &output_view)
@@ -173,7 +173,7 @@ void applyReversePermutation(ExecutionSpace const &space,
   ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
 
   Kokkos::parallel_for(
-      ARBORX_MARK_REGION("permute"),
+      ARBORX_MARK_REGION("inverse_permute"),
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
       KOKKOS_LAMBDA(int i) {
         PermuteHelper::CopyOp<OutputView, InputView>::copy(


### PR DESCRIPTION
Running more profiling, it turned out that we benefit from `CUDA`-aware MPI when we have a lot of data (which was the case for the test case I used so far). Otherwise, non-`CUDA`-MPI seems to be better since the fewer copies in our code are not worth the longer runtime for the MPI calls.

While doing this, I discovered that a major difference in `doPostsAndWaits` is due to the permutation being executed on the device for `CUDA`-aware MPI. This pull request makes sure that we always perform the permutation on the device and only copy the data back to the host afterward.

Radius:

|  # MPI processes | old   |  new   |
|------------|-------|--------|
|   1        | 2.34e0 | 1.80e0 |
|   6        | 2.77e0 | 2.27e0 |
|  12        | 2.78e0 | 2.23e0 |
|  24        | 2.89e0 | 2.32e0 |
|  48        | 2.91e0 | 2.36e0 |
|  96        | 2.93e0 | 2.34e0 |
| 192        | 2.96e0 | 2.37e0 |
| 384        | 2.97e0 | 2.44e0 |
| 768        | 3.02e0 | 2.42e0 |


knn:

|  # MPI processes | old   |  new   |
|------------|-------|--------|
|   1        | 5.70e0 | 4.69e0 |
|   6        | 6.92e0 | 5.88e0 |
|  12        | 6.95e0 | 6.08e0 |
|  24        | 7.38e0 | 6.29e0 |
|  48        | 7.60e0 | 6.46e0 |
|  96        | 7.43e0 | 6.60e0 |
| 192        | 7.72e0 | 6.78e0 |
| 384        | 7.74e0 | 6.87e0 |
| 768        | 7.89e0 | 6.88e0 |

