### PR TITLE
Use KOKKOS_DEFAULTED_FUNCTION

### DIFF
--- a/src/details/ArborX_Box.hpp
+++ b/src/details/ArborX_Box.hpp
@@ -25,7 +25,7 @@ namespace ArborX
  */
 struct Box
 {
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   constexpr Box() = default;
 
   KOKKOS_INLINE_FUNCTION

--- a/src/details/ArborX_DetailsContainers.hpp
+++ b/src/details/ArborX_DetailsContainers.hpp
@@ -35,7 +35,7 @@ class StaticVector
     using const_reference = value_type const &;
     using pointer = value_type *;
     using const_pointer = value_type const *;
-    KOKKOS_FUNCTION StaticVector() = default;
+    KOKKOS_DEFAULTED_FUNCTION StaticVector() = default;
     KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
     KOKKOS_INLINE_FUNCTION size_type size() const { return _size; }
     KOKKOS_INLINE_FUNCTION constexpr size_type maxSize() const { return N; }

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -24,7 +24,7 @@ namespace Details
 {
 struct Node
 {
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   constexpr Node() = default;
 
   KOKKOS_INLINE_FUNCTION constexpr bool isLeaf() const noexcept

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -61,7 +61,7 @@ public:
                 "the type of the elements stored by the underlying "
                 "container Container::value_type");
 
-  KOKKOS_FUNCTION PriorityQueue() = default;
+  KOKKOS_DEFAULTED_FUNCTION PriorityQueue() = default;
 
   KOKKOS_FUNCTION PriorityQueue(Container const &c)
       : _c(c)

--- a/src/details/ArborX_DetailsStack.hpp
+++ b/src/details/ArborX_DetailsStack.hpp
@@ -37,7 +37,7 @@ public:
                 "the type of the elements stored by the underlying "
                 "container Container::value_type");
 
-  KOKKOS_FUNCTION Stack() = default;
+  KOKKOS_DEFAULTED_FUNCTION Stack() = default;
 
   // Capacity
   KOKKOS_INLINE_FUNCTION bool empty() const { return _c.empty(); }

--- a/src/details/ArborX_Point.hpp
+++ b/src/details/ArborX_Point.hpp
@@ -27,7 +27,7 @@ private:
   } _data = {};
 
 public:
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   constexpr Point() noexcept = default;
 
   KOKKOS_INLINE_FUNCTION

--- a/src/details/ArborX_Predicates.hpp
+++ b/src/details/ArborX_Predicates.hpp
@@ -50,7 +50,7 @@ struct Intersects
 {
   using Tag = Details::SpatialPredicateTag;
 
-  KOKKOS_INLINE_FUNCTION Intersects() = default;
+  KOKKOS_DEFAULTED_FUNCTION Intersects() = default;
 
   KOKKOS_INLINE_FUNCTION Intersects(Geometry const &geometry)
       : _geometry(geometry)
@@ -102,7 +102,7 @@ getGeometry(Intersects<Geometry> const &pred)
 template <typename Predicate, typename Data>
 struct PredicateWithAttachment : Predicate
 {
-  KOKKOS_INLINE_FUNCTION PredicateWithAttachment() = default;
+  KOKKOS_DEFAULTED_FUNCTION PredicateWithAttachment() = default;
   KOKKOS_INLINE_FUNCTION PredicateWithAttachment(Predicate const &pred,
                                                  Data const &data)
       : Predicate{pred}

--- a/src/details/ArborX_Sphere.hpp
+++ b/src/details/ArborX_Sphere.hpp
@@ -20,7 +20,7 @@ namespace ArborX
 
 struct Sphere
 {
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   Sphere() = default;
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
This avoids warnings similar to
```
src/details/ArborX_Predicates.hpp(34): warning: __device__ annotation is ignored on a function("Nearest") that is explicitly defaulted on its first declaration
```

There are still some coming from `Boost` which are not covered here:
```
boost-new/include/boost/fusion/container/vector/vector.hpp(195): warning: __host__ annotation is ignored on a function("vector_data") that is explicitly defaulted on its first declaration
boost-new/include/boost/fusion/container/vector/vector.hpp(195): warning: __device__ annotation is ignored on a function("vector_data") that is explicitly defaulted on its first declaration
boost-new/include/boost/fusion/container/vector/vector.hpp(273): warning: __host__ annotation is ignored on a function("vector") that is explicitly defaulted on its first declaration
boost-new/include/boost/fusion/container/vector/vector.hpp(273): warning: __device__ annotation is ignored on a function("vector") that is explicitly defaulted on its first declaration

```