### PR TITLE
Optional sorting of predicates

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -40,16 +40,8 @@ public:
   template <typename Query>
   void query(Kokkos::View<Query *, DeviceType> queries,
              Kokkos::View<int *, DeviceType> &indices,
-             Kokkos::View<int *, DeviceType> &offset, bool)
-  {
-    std::tie(offset, indices) =
-        BoostRTreeHelpers::performQueries(_tree, queries);
-  }
-
-  template <typename Query>
-  void query(Kokkos::View<Query *, DeviceType> queries,
-             Kokkos::View<int *, DeviceType> &indices,
-             Kokkos::View<int *, DeviceType> &offset, bool, int)
+             Kokkos::View<int *, DeviceType> &offset,
+             ArborX::TraversalPolicy const &)
   {
     std::tie(offset, indices) =
         BoostRTreeHelpers::performQueries(_tree, queries);
@@ -166,7 +158,9 @@ void BM_knn_search(benchmark::State &state)
     Kokkos::View<int *, DeviceType> offset("offset", 0);
     Kokkos::View<int *, DeviceType> indices("indices", 0);
     auto const start = std::chrono::high_resolution_clock::now();
-    index.query(queries, indices, offset, do_predicate_sort_int);
+    index.query(
+        queries, indices, offset,
+        ArborX::TraversalPolicy().setPredicateSorting(do_predicate_sort_int));
     auto const end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
@@ -197,7 +191,10 @@ void BM_radius_search(benchmark::State &state)
     Kokkos::View<int *, DeviceType> offset("offset", 0);
     Kokkos::View<int *, DeviceType> indices("indices", 0);
     auto const start = std::chrono::high_resolution_clock::now();
-    index.query(queries, indices, offset, do_predicate_sort_int, buffer_size);
+    index.query(queries, indices, offset,
+                ArborX::TraversalPolicy()
+                    .setPredicateSorting(do_predicate_sort_int)
+                    .setBufferSize(buffer_size));
     auto const end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -293,33 +293,33 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(buffer_optimization, DeviceType,
   auto const max_results_per_query = ArborX::max(counts);
   BOOST_TEST(max_results_per_query == 4);
 
-  bool const do_predicate_sort = true;
-
   // optimal size
-  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset, do_predicate_sort,
-                                 -max_results_per_query));
+  BOOST_CHECK_NO_THROW(bvh.query(
+      queries, indices, offset,
+      ArborX::TraversalPolicy().setBufferSize(-max_results_per_query)));
   checkResultsAreFine();
 
   // buffer size insufficient
   BOOST_TEST(max_results_per_query > 1);
-  BOOST_CHECK_NO_THROW(
-      bvh.query(queries, indices, offset, do_predicate_sort, +1));
+  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
+                                 ArborX::TraversalPolicy().setBufferSize(+1)));
   checkResultsAreFine();
-  BOOST_CHECK_THROW(bvh.query(queries, indices, offset, do_predicate_sort, -1),
+  BOOST_CHECK_THROW(bvh.query(queries, indices, offset,
+                              ArborX::TraversalPolicy().setBufferSize(-1)),
                     ArborX::SearchException);
 
   // adequate buffer size
   BOOST_TEST(max_results_per_query < 5);
-  BOOST_CHECK_NO_THROW(
-      bvh.query(queries, indices, offset, do_predicate_sort, +5));
+  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
+                                 ArborX::TraversalPolicy().setBufferSize(+5)));
   checkResultsAreFine();
-  BOOST_CHECK_NO_THROW(
-      bvh.query(queries, indices, offset, do_predicate_sort, -5));
+  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
+                                 ArborX::TraversalPolicy().setBufferSize(-5)));
   checkResultsAreFine();
 
   // passing null size skips the buffer optimization and never throws
-  BOOST_CHECK_NO_THROW(
-      bvh.query(queries, indices, offset, do_predicate_sort, 0));
+  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
+                                 ArborX::TraversalPolicy().setBufferSize(0)));
   checkResultsAreFine();
 }
 
@@ -355,13 +355,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unsorted_predicates, DeviceType,
         {{{0., 0., 0.}}, {{1., 1., 1.}}},
     });
 
-    bool const do_predicate_sort = true;
     BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset, do_predicate_sort));
+        bvh.query(queries, indices, offset,
+                  ArborX::TraversalPolicy().setPredicateSorting(true)));
     checkResultsAreFine();
 
     BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset, !do_predicate_sort));
+        bvh.query(queries, indices, offset,
+                  ArborX::TraversalPolicy().setPredicateSorting(false)));
     checkResultsAreFine();
   }
 
@@ -372,13 +373,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unsorted_predicates, DeviceType,
         {{{0.5, 0.5, 0.5}}, 2},
     });
 
-    bool const do_predicate_sort = true;
     BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset, do_predicate_sort));
+        bvh.query(queries, indices, offset,
+                  ArborX::TraversalPolicy().setPredicateSorting(true)));
     checkResultsAreFine();
 
     BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset, !do_predicate_sort));
+        bvh.query(queries, indices, offset,
+                  ArborX::TraversalPolicy().setPredicateSorting(false)));
     checkResultsAreFine();
   }
 }
@@ -1157,10 +1159,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
 
   validateResults(rtree_results, bvh_results);
 
-  auto const alternate_tree_traversal_algorithm =
-      ArborX::Details::NearestQueryAlgorithm::PriorityQueueBased_Deprecated;
   bvh.query(nearest_queries, indices_nearest, offset_nearest,
-            true /*do_predicate_sort*/, alternate_tree_traversal_algorithm);
+            ArborX::TraversalPolicy().setTraversalAlgorithm(
+                ArborX::Details::NearestQueryAlgorithm::
+                    PriorityQueueBased_Deprecated));
   Kokkos::deep_copy(offset_nearest_host, offset_nearest);
   Kokkos::deep_copy(indices_nearest_host, indices_nearest);
   bvh_results = std::make_tuple(offset_nearest_host, indices_nearest_host);

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -1094,7 +1094,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
   auto const alternate_tree_traversal_algorithm =
       ArborX::Details::NearestQueryAlgorithm::PriorityQueueBased_Deprecated;
   bvh.query(nearest_queries, indices_nearest, offset_nearest,
-            alternate_tree_traversal_algorithm);
+            true /*do_predicate_sort*/, alternate_tree_traversal_algorithm);
   Kokkos::deep_copy(offset_nearest_host, offset_nearest);
   Kokkos::deep_copy(indices_nearest_host, indices_nearest);
   bvh_results = std::make_tuple(offset_nearest_host, indices_nearest_host);

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -294,32 +294,38 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(buffer_optimization, DeviceType,
   BOOST_TEST(max_results_per_query == 4);
 
   // optimal size
-  BOOST_CHECK_NO_THROW(bvh.query(
-      queries, indices, offset,
-      ArborX::TraversalPolicy().setBufferSize(-max_results_per_query)));
+  BOOST_CHECK_NO_THROW(
+      bvh.query(queries, indices, offset,
+                ArborX::Experimental::TraversalPolicy().setBufferSize(
+                    -max_results_per_query)));
   checkResultsAreFine();
 
   // buffer size insufficient
   BOOST_TEST(max_results_per_query > 1);
-  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
-                                 ArborX::TraversalPolicy().setBufferSize(+1)));
+  BOOST_CHECK_NO_THROW(
+      bvh.query(queries, indices, offset,
+                ArborX::Experimental::TraversalPolicy().setBufferSize(+1)));
   checkResultsAreFine();
-  BOOST_CHECK_THROW(bvh.query(queries, indices, offset,
-                              ArborX::TraversalPolicy().setBufferSize(-1)),
-                    ArborX::SearchException);
+  BOOST_CHECK_THROW(
+      bvh.query(queries, indices, offset,
+                ArborX::Experimental::TraversalPolicy().setBufferSize(-1)),
+      ArborX::SearchException);
 
   // adequate buffer size
   BOOST_TEST(max_results_per_query < 5);
-  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
-                                 ArborX::TraversalPolicy().setBufferSize(+5)));
+  BOOST_CHECK_NO_THROW(
+      bvh.query(queries, indices, offset,
+                ArborX::Experimental::TraversalPolicy().setBufferSize(+5)));
   checkResultsAreFine();
-  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
-                                 ArborX::TraversalPolicy().setBufferSize(-5)));
+  BOOST_CHECK_NO_THROW(
+      bvh.query(queries, indices, offset,
+                ArborX::Experimental::TraversalPolicy().setBufferSize(-5)));
   checkResultsAreFine();
 
   // passing null size skips the buffer optimization and never throws
-  BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset,
-                                 ArborX::TraversalPolicy().setBufferSize(0)));
+  BOOST_CHECK_NO_THROW(
+      bvh.query(queries, indices, offset,
+                ArborX::Experimental::TraversalPolicy().setBufferSize(0)));
   checkResultsAreFine();
 }
 
@@ -355,14 +361,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unsorted_predicates, DeviceType,
         {{{0., 0., 0.}}, {{1., 1., 1.}}},
     });
 
-    BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset,
-                  ArborX::TraversalPolicy().setPredicateSorting(true)));
+    BOOST_CHECK_NO_THROW(bvh.query(
+        queries, indices, offset,
+        ArborX::Experimental::TraversalPolicy().setPredicateSorting(true)));
     checkResultsAreFine();
 
-    BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset,
-                  ArborX::TraversalPolicy().setPredicateSorting(false)));
+    BOOST_CHECK_NO_THROW(bvh.query(
+        queries, indices, offset,
+        ArborX::Experimental::TraversalPolicy().setPredicateSorting(false)));
     checkResultsAreFine();
   }
 
@@ -373,14 +379,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unsorted_predicates, DeviceType,
         {{{0.5, 0.5, 0.5}}, 2},
     });
 
-    BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset,
-                  ArborX::TraversalPolicy().setPredicateSorting(true)));
+    BOOST_CHECK_NO_THROW(bvh.query(
+        queries, indices, offset,
+        ArborX::Experimental::TraversalPolicy().setPredicateSorting(true)));
     checkResultsAreFine();
 
-    BOOST_CHECK_NO_THROW(
-        bvh.query(queries, indices, offset,
-                  ArborX::TraversalPolicy().setPredicateSorting(false)));
+    BOOST_CHECK_NO_THROW(bvh.query(
+        queries, indices, offset,
+        ArborX::Experimental::TraversalPolicy().setPredicateSorting(false)));
     checkResultsAreFine();
   }
 }
@@ -1160,7 +1166,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
   validateResults(rtree_results, bvh_results);
 
   bvh.query(nearest_queries, indices_nearest, offset_nearest,
-            ArborX::TraversalPolicy().setTraversalAlgorithm(
+            ArborX::Experimental::TraversalPolicy().setTraversalAlgorithm(
                 ArborX::Details::NearestQueryAlgorithm::
                     PriorityQueueBased_Deprecated));
   Kokkos::deep_copy(offset_nearest_host, offset_nearest);


### PR DESCRIPTION
Fix #206.

I added a new boolean parameter. I opted to have it before `buffer_size` as it is common from both kNN and spatial searches, while the  parameters after it are specific (`buffer_size` to spatial, `which` to kNN). This choice made the patch slightly larger than it could have been.

I also decided to keep the default to sorted as of now. I'm not married to it, but this allows us to still be able to compare benchmark results with older runs.