### PR TITLE
Take execution space as argument in tree construction

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -232,7 +232,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   // calculate bounding volume for each internal node by walking the
   // hierarchy toward the root
   Details::TreeConstruction<DeviceType>::calculateInternalNodesBoundingVolumes(
-      getLeafNodes(), getInternalNodes(), parents);
+      space, getLeafNodes(), getInternalNodes(), parents);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::popRegion();

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -183,8 +183,8 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   Kokkos::Profiling::pushRegion("ArborX:BVH:calculate_scene_bounding_box");
 
   // determine the bounding box of the scene
-  Details::DeprecatedTreeConstruction<
-      DeviceType>::calculateBoundingBoxOfTheScene(space, primitives, _bounds);
+  Details::TreeConstruction::calculateBoundingBoxOfTheScene(space, primitives,
+                                                            _bounds);
 
   Kokkos::Profiling::popRegion();
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -192,7 +192,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   {
     Kokkos::View<size_t *, DeviceType> permutation_indices("permute", 1);
     Details::TreeConstruction<DeviceType>::initializeLeafNodes(
-        primitives, permutation_indices, getLeafNodes());
+        space, primitives, permutation_indices, getLeafNodes());
     return;
   }
 
@@ -215,7 +215,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
 
   // initialize leaves using the computed ordering
   Details::TreeConstruction<DeviceType>::initializeLeafNodes(
-      primitives, permutation_indices, getLeafNodes());
+      space, primitives, permutation_indices, getLeafNodes());
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion("ArborX:BVH:generate_hierarchy");

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -201,8 +201,8 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   // calculate Morton codes of all objects
   Kokkos::View<unsigned int *, DeviceType> morton_indices(
       Kokkos::ViewAllocateWithoutInitializing("morton"), size());
-  Details::DeprecatedTreeConstruction<DeviceType>::assignMortonCodes(
-      space, primitives, morton_indices, _bounds);
+  Details::TreeConstruction::assignMortonCodes(space, primitives,
+                                               morton_indices, _bounds);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion("ArborX:BVH:sort_morton_codes");

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -191,7 +191,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   if (size() == 1)
   {
     Kokkos::View<size_t *, DeviceType> permutation_indices("permute", 1);
-    Details::DeprecatedTreeConstruction<DeviceType>::initializeLeafNodes(
+    Details::TreeConstruction::initializeLeafNodes(
         space, primitives, permutation_indices, getLeafNodes());
     return;
   }
@@ -214,7 +214,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   Kokkos::Profiling::pushRegion("ArborX:BVH:init_leaves");
 
   // initialize leaves using the computed ordering
-  Details::DeprecatedTreeConstruction<DeviceType>::initializeLeafNodes(
+  Details::TreeConstruction::initializeLeafNodes(
       space, primitives, permutation_indices, getLeafNodes());
 
   Kokkos::Profiling::popRegion();

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -223,7 +223,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   // generate bounding volume hierarchy
   Kokkos::View<int *, DeviceType> parents(
       Kokkos::ViewAllocateWithoutInitializing("parents"), 2 * size() - 1);
-  Details::DeprecatedTreeConstruction<DeviceType>::generateHierarchy(
+  Details::TreeConstruction::generateHierarchy(
       space, morton_indices, getLeafNodes(), getInternalNodes(), parents);
 
   Kokkos::Profiling::popRegion();

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -202,7 +202,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   Kokkos::View<unsigned int *, DeviceType> morton_indices(
       Kokkos::ViewAllocateWithoutInitializing("morton"), size());
   Details::TreeConstruction<DeviceType>::assignMortonCodes(
-      primitives, morton_indices, _bounds);
+      space, primitives, morton_indices, _bounds);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion("ArborX:BVH:sort_morton_codes");

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -145,6 +145,8 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
           Kokkos::ViewAllocateWithoutInitializing("internal_and_leaf_nodes"),
           _size > 0 ? 2 * _size - 1 : 0)
 {
+  typename DeviceType::execution_space space{};
+
   Kokkos::Profiling::pushRegion("ArborX:BVH:construction");
 
   using Access = Traits::Access<Primitives, Traits::PrimitivesTag>;
@@ -182,7 +184,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
 
   // determine the bounding box of the scene
   Details::TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
-      primitives, _bounds);
+      space, primitives, _bounds);
 
   Kokkos::Profiling::popRegion();
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -231,10 +231,8 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
 
   // calculate bounding volume for each internal node by walking the
   // hierarchy toward the root
-  Details::DeprecatedTreeConstruction<
-      DeviceType>::calculateInternalNodesBoundingVolumes(space, getLeafNodes(),
-                                                         getInternalNodes(),
-                                                         parents);
+  Details::TreeConstruction::calculateInternalNodesBoundingVolumes(
+      space, getLeafNodes(), getInternalNodes(), parents);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::popRegion();

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -183,15 +183,15 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   Kokkos::Profiling::pushRegion("ArborX:BVH:calculate_scene_bounding_box");
 
   // determine the bounding box of the scene
-  Details::TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
-      space, primitives, _bounds);
+  Details::DeprecatedTreeConstruction<
+      DeviceType>::calculateBoundingBoxOfTheScene(space, primitives, _bounds);
 
   Kokkos::Profiling::popRegion();
 
   if (size() == 1)
   {
     Kokkos::View<size_t *, DeviceType> permutation_indices("permute", 1);
-    Details::TreeConstruction<DeviceType>::initializeLeafNodes(
+    Details::DeprecatedTreeConstruction<DeviceType>::initializeLeafNodes(
         space, primitives, permutation_indices, getLeafNodes());
     return;
   }
@@ -201,7 +201,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   // calculate Morton codes of all objects
   Kokkos::View<unsigned int *, DeviceType> morton_indices(
       Kokkos::ViewAllocateWithoutInitializing("morton"), size());
-  Details::TreeConstruction<DeviceType>::assignMortonCodes(
+  Details::DeprecatedTreeConstruction<DeviceType>::assignMortonCodes(
       space, primitives, morton_indices, _bounds);
 
   Kokkos::Profiling::popRegion();
@@ -214,7 +214,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   Kokkos::Profiling::pushRegion("ArborX:BVH:init_leaves");
 
   // initialize leaves using the computed ordering
-  Details::TreeConstruction<DeviceType>::initializeLeafNodes(
+  Details::DeprecatedTreeConstruction<DeviceType>::initializeLeafNodes(
       space, primitives, permutation_indices, getLeafNodes());
 
   Kokkos::Profiling::popRegion();
@@ -223,7 +223,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   // generate bounding volume hierarchy
   Kokkos::View<int *, DeviceType> parents(
       Kokkos::ViewAllocateWithoutInitializing("parents"), 2 * size() - 1);
-  Details::TreeConstruction<DeviceType>::generateHierarchy(
+  Details::DeprecatedTreeConstruction<DeviceType>::generateHierarchy(
       space, morton_indices, getLeafNodes(), getInternalNodes(), parents);
 
   Kokkos::Profiling::popRegion();
@@ -231,8 +231,10 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
 
   // calculate bounding volume for each internal node by walking the
   // hierarchy toward the root
-  Details::TreeConstruction<DeviceType>::calculateInternalNodesBoundingVolumes(
-      space, getLeafNodes(), getInternalNodes(), parents);
+  Details::DeprecatedTreeConstruction<
+      DeviceType>::calculateInternalNodesBoundingVolumes(space, getLeafNodes(),
+                                                         getInternalNodes(),
+                                                         parents);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::popRegion();

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -224,7 +224,7 @@ BoundingVolumeHierarchy<DeviceType>::BoundingVolumeHierarchy(
   Kokkos::View<int *, DeviceType> parents(
       Kokkos::ViewAllocateWithoutInitializing("parents"), 2 * size() - 1);
   Details::TreeConstruction<DeviceType>::generateHierarchy(
-      morton_indices, getLeafNodes(), getInternalNodes(), parents);
+      space, morton_indices, getLeafNodes(), getInternalNodes(), parents);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion("ArborX:BVH:calculate_bounding_volumes");

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -117,9 +117,10 @@ public:
   }
 
   template <typename... MortonCodesViewProperties>
-  KOKKOS_FUNCTION static int commonPrefix(
-      Kokkos::View<unsigned int *, MortonCodesViewProperties...> morton_codes,
-      int i, int j)
+  KOKKOS_FUNCTION static int
+  commonPrefix(Kokkos::View<unsigned int const *, MortonCodesViewProperties...>
+                   morton_codes,
+               int i, int j)
   {
     using KokkosExt::clz;
 
@@ -139,8 +140,19 @@ public:
   }
 
   template <typename... MortonCodesViewProperties>
+  KOKKOS_FUNCTION static int commonPrefix(
+      Kokkos::View<unsigned int *, MortonCodesViewProperties...> morton_codes,
+      int i, int j)
+  {
+    return commonPrefix(
+        Kokkos::View<unsigned int const *, MortonCodesViewProperties...>{
+            morton_codes},
+        i, j);
+  }
+
+  template <typename... MortonCodesViewProperties>
   KOKKOS_FUNCTION static int
-  findSplit(Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+  findSplit(Kokkos::View<unsigned int const *, MortonCodesViewProperties...>
                 sorted_morton_codes,
             int first, int last)
   {
@@ -172,10 +184,22 @@ public:
   }
 
   template <typename... MortonCodesViewProperties>
-  KOKKOS_FUNCTION static Kokkos::pair<int, int>
-  determineRange(Kokkos::View<unsigned int *, MortonCodesViewProperties...>
-                     sorted_morton_codes,
-                 int i)
+  KOKKOS_FUNCTION static int
+  findSplit(Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+                sorted_morton_codes,
+            int first, int last)
+  {
+    return findSplit(
+        Kokkos::View<unsigned int const *, MortonCodesViewProperties...>{
+            sorted_morton_codes},
+        first, last);
+  }
+
+  template <typename... MortonCodesViewProperties>
+  KOKKOS_FUNCTION static Kokkos::pair<int, int> determineRange(
+      Kokkos::View<unsigned int const *, MortonCodesViewProperties...>
+          sorted_morton_codes,
+      int i)
   {
     using KokkosExt::max;
     using KokkosExt::min;
@@ -208,6 +232,18 @@ public:
     int j = i + split * direction;
 
     return {min(i, j), max(i, j)};
+  }
+
+  template <typename... MortonCodesViewProperties>
+  KOKKOS_FUNCTION static Kokkos::pair<int, int>
+  determineRange(Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+                     sorted_morton_codes,
+                 int i)
+  {
+    return determineRange(
+        Kokkos::View<unsigned int const *, MortonCodesViewProperties...>{
+            sorted_morton_codes},
+        i);
   }
 };
 
@@ -372,7 +408,7 @@ class GenerateHierarchyFunctor
 {
 public:
   GenerateHierarchyFunctor(
-      Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
+      Kokkos::View<unsigned int const *, DeviceType> sorted_morton_codes,
       Kokkos::View<Node *, DeviceType> leaf_nodes,
       Kokkos::View<Node *, DeviceType> internal_nodes,
       Kokkos::View<int *, DeviceType> parents)
@@ -431,7 +467,7 @@ public:
   }
 
 private:
-  Kokkos::View<unsigned int *, DeviceType> _sorted_morton_codes;
+  Kokkos::View<unsigned int const *, DeviceType> _sorted_morton_codes;
   Kokkos::View<Node *, DeviceType> _leaf_nodes;
   Kokkos::View<Node *, DeviceType> _internal_nodes;
   Kokkos::View<int *, DeviceType> _parents;

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -330,53 +330,6 @@ initializeLeafNodes(ExecutionSpace const &space, Primitives const &primitives,
           permutation_indices},
       leaf_nodes);
 }
-} // namespace TreeConstruction
-
-/**
- * This structure contains all the functions used to build the BVH. All the
- * functions are static.
- */
-template <typename DeviceType>
-struct DeprecatedTreeConstruction
-{
-public:
-  template <typename ExecutionSpace, typename... MortonCodesViewProperties,
-            typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static Node *generateHierarchy(
-      ExecutionSpace const &space,
-      Kokkos::View<unsigned int *, MortonCodesViewProperties...>
-          sorted_morton_codes,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int *, ParentsViewProperties...> parents);
-
-  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static void calculateInternalNodesBoundingVolumes(
-      ExecutionSpace const &space,
-      Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int const *, ParentsViewProperties...> parents);
-
-  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static void calculateInternalNodesBoundingVolumes(
-      ExecutionSpace const &space,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int *, ParentsViewProperties...> parents)
-  {
-    calculateInternalNodesBoundingVolumes(
-        space,
-        Kokkos::View<Node const *, LeafNodesViewProperties...>{leaf_nodes},
-        internal_nodes,
-        Kokkos::View<int const *, ParentsViewProperties...>{parents});
-  }
-};
 
 template <typename MemorySpace>
 class GenerateHierarchyFunctor
@@ -470,12 +423,11 @@ private:
   int _leaf_nodes_shift;
 };
 
-template <typename DeviceType>
 template <typename ExecutionSpace, typename... MortonCodesViewProperties,
           typename... LeafNodesViewProperties,
           typename... InternalNodesViewProperties,
           typename... ParentsViewProperties>
-Node *DeprecatedTreeConstruction<DeviceType>::generateHierarchy(
+Node *generateHierarchy(
     ExecutionSpace const &space,
     Kokkos::View<unsigned int *, MortonCodesViewProperties...>
         sorted_morton_codes,
@@ -493,6 +445,41 @@ Node *DeprecatedTreeConstruction<DeviceType>::generateHierarchy(
   // returns a pointer to the root node of the tree
   return internal_nodes.data();
 }
+} // namespace TreeConstruction
+
+/**
+ * This structure contains all the functions used to build the BVH. All the
+ * functions are static.
+ */
+template <typename DeviceType>
+struct DeprecatedTreeConstruction
+{
+public:
+  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
+            typename... InternalNodesViewProperties,
+            typename... ParentsViewProperties>
+  static void calculateInternalNodesBoundingVolumes(
+      ExecutionSpace const &space,
+      Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
+      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+      Kokkos::View<int const *, ParentsViewProperties...> parents);
+
+  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
+            typename... InternalNodesViewProperties,
+            typename... ParentsViewProperties>
+  static void calculateInternalNodesBoundingVolumes(
+      ExecutionSpace const &space,
+      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
+      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+      Kokkos::View<int *, ParentsViewProperties...> parents)
+  {
+    calculateInternalNodesBoundingVolumes(
+        space,
+        Kokkos::View<Node const *, LeafNodesViewProperties...>{leaf_nodes},
+        internal_nodes,
+        Kokkos::View<int const *, ParentsViewProperties...>{parents});
+  }
+};
 
 template <typename DeviceType>
 class CalculateInternalNodesBoundingVolumesFunctor

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -418,7 +418,7 @@ public:
   }
 
   // from "Thinking Parallel, Part III: Tree Construction on the GPU" by Karras
-  KOKKOS_INLINE_FUNCTION void operator()(int const i) const
+  KOKKOS_FUNCTION void operator()(int i) const
   {
     using TreeConstruction::determineRange;
     using TreeConstruction::findSplit;

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -36,7 +36,7 @@ namespace Details
  * functions are static.
  */
 template <typename DeviceType>
-struct TreeConstruction
+struct DeprecatedTreeConstruction
 {
 public:
   template <typename ExecutionSpace, typename Primitives>
@@ -279,7 +279,8 @@ private:
 
 template <typename DeviceType>
 template <typename ExecutionSpace, typename Primitives>
-inline void TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
+inline void
+DeprecatedTreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
     ExecutionSpace const &space, Primitives const &primitives,
     Box &scene_bounding_box)
 {
@@ -330,7 +331,7 @@ inline void assignMortonCodesDispatch(PointTag, ExecutionSpace const &space,
 template <typename DeviceType>
 template <typename ExecutionSpace, typename Primitives,
           typename... MortonCodesViewProperties>
-inline void TreeConstruction<DeviceType>::assignMortonCodes(
+inline void DeprecatedTreeConstruction<DeviceType>::assignMortonCodes(
     ExecutionSpace const &space, Primitives const &primitives,
     Kokkos::View<unsigned int *, MortonCodesViewProperties...> morton_codes,
     Box const &scene_bounding_box)
@@ -386,7 +387,7 @@ template <typename DeviceType>
 template <typename ExecutionSpace, typename Primitives,
           typename... PermutationIndicesViewProperties,
           typename... LeafNodesViewProperties>
-inline void TreeConstruction<DeviceType>::initializeLeafNodes(
+inline void DeprecatedTreeConstruction<DeviceType>::initializeLeafNodes(
     ExecutionSpace const &space, Primitives const &primitives,
     Kokkos::View<size_t const *, PermutationIndicesViewProperties...>
         permutation_indices,
@@ -429,15 +430,15 @@ public:
     // Find out which range of objects the node corresponds to.
     // (This is where the magic happens!)
 
-    auto range =
-        TreeConstruction<DeviceType>::determineRange(_sorted_morton_codes, i);
+    auto range = DeprecatedTreeConstruction<DeviceType>::determineRange(
+        _sorted_morton_codes, i);
     int first = range.first;
     int last = range.second;
 
     // Determine where to split the range.
 
-    int split = TreeConstruction<DeviceType>::findSplit(_sorted_morton_codes,
-                                                        first, last);
+    int split = DeprecatedTreeConstruction<DeviceType>::findSplit(
+        _sorted_morton_codes, first, last);
 
     // Select first child and record parent-child relationship.
 
@@ -479,7 +480,7 @@ template <typename ExecutionSpace, typename... MortonCodesViewProperties,
           typename... LeafNodesViewProperties,
           typename... InternalNodesViewProperties,
           typename... ParentsViewProperties>
-Node *TreeConstruction<DeviceType>::generateHierarchy(
+Node *DeprecatedTreeConstruction<DeviceType>::generateHierarchy(
     ExecutionSpace const &space,
     Kokkos::View<unsigned int *, MortonCodesViewProperties...>
         sorted_morton_codes,
@@ -559,11 +560,12 @@ template <typename DeviceType>
 template <typename ExecutionSpace, typename... LeafNodesViewProperties,
           typename... InternalNodesViewProperties,
           typename... ParentsViewProperties>
-void TreeConstruction<DeviceType>::calculateInternalNodesBoundingVolumes(
-    ExecutionSpace const &space,
-    Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
-    Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-    Kokkos::View<int const *, ParentsViewProperties...> parents)
+void DeprecatedTreeConstruction<DeviceType>::
+    calculateInternalNodesBoundingVolumes(
+        ExecutionSpace const &space,
+        Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
+        Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+        Kokkos::View<int const *, ParentsViewProperties...> parents)
 {
   auto const first = internal_nodes.extent(0);
   auto const last = first + leaf_nodes.extent(0);

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -39,7 +39,7 @@ template <typename DeviceType>
 struct TreeConstruction
 {
 public:
-  using ExecutionSpace = typename DeviceType::execution_space;
+  using DeprecatedExecutionSpace = typename DeviceType::execution_space;
 
   template <typename Primitives>
   static void calculateBoundingBoxOfTheScene(Primitives const &primitives,
@@ -393,7 +393,7 @@ Node *TreeConstruction<DeviceType>::generateHierarchy(
   auto const n = sorted_morton_codes.extent(0);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("generate_hierarchy"),
-      Kokkos::RangePolicy<ExecutionSpace>(0, n - 1),
+      Kokkos::RangePolicy<DeprecatedExecutionSpace>(0, n - 1),
       GenerateHierarchyFunctor<DeviceType>(sorted_morton_codes, leaf_nodes,
                                            internal_nodes, parents));
   // returns a pointer to the root node of the tree
@@ -468,10 +468,11 @@ void TreeConstruction<DeviceType>::calculateInternalNodesBoundingVolumes(
   auto const last = first + leaf_nodes.extent(0);
   Kokkos::View<Node *, DeviceType, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       internal_and_leaf_nodes(internal_nodes.data(), last);
-  Kokkos::parallel_for(ARBORX_MARK_REGION("calculate_bounding_boxes"),
-                       Kokkos::RangePolicy<ExecutionSpace>(first, last),
-                       CalculateInternalNodesBoundingVolumesFunctor<DeviceType>(
-                           internal_and_leaf_nodes, parents, first));
+  Kokkos::parallel_for(
+      ARBORX_MARK_REGION("calculate_bounding_boxes"),
+      Kokkos::RangePolicy<DeprecatedExecutionSpace>(first, last),
+      CalculateInternalNodesBoundingVolumesFunctor<DeviceType>(
+          internal_and_leaf_nodes, parents, first));
 }
 
 } // namespace Details

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -429,7 +429,7 @@ template <typename ExecutionSpace, typename... MortonCodesViewProperties,
           typename... ParentsViewProperties>
 Node *generateHierarchy(
     ExecutionSpace const &space,
-    Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+    Kokkos::View<unsigned int const *, MortonCodesViewProperties...>
         sorted_morton_codes,
     Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
     Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
@@ -444,6 +444,25 @@ Node *generateHierarchy(
                                             internal_nodes, parents));
   // returns a pointer to the root node of the tree
   return internal_nodes.data();
+}
+
+template <typename ExecutionSpace, typename... MortonCodesViewProperties,
+          typename... LeafNodesViewProperties,
+          typename... InternalNodesViewProperties,
+          typename... ParentsViewProperties>
+inline Node *generateHierarchy(
+    ExecutionSpace const &space,
+    Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+        sorted_morton_codes,
+    Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
+    Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+    Kokkos::View<int *, ParentsViewProperties...> parents)
+{
+  return generateHierarchy(
+      space,
+      Kokkos::View<unsigned int const *, MortonCodesViewProperties...>{
+          sorted_morton_codes},
+      leaf_nodes, internal_nodes, parents);
 }
 } // namespace TreeConstruction
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -353,23 +353,6 @@ public:
   {
   }
 
-  template <typename... MortonCodesViewProperties,
-            typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  GenerateHierarchyFunctor(
-      Kokkos::View<unsigned int *, MortonCodesViewProperties...>
-          sorted_morton_codes,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int *, ParentsViewProperties...> parents)
-      : GenerateHierarchyFunctor(
-            Kokkos::View<unsigned int const *, MortonCodesViewProperties...>{
-                sorted_morton_codes},
-            leaf_nodes, internal_nodes, parents)
-  {
-  }
-
   // from "Thinking Parallel, Part III: Tree Construction on the GPU" by Karras
   KOKKOS_FUNCTION void operator()(int i) const
   {

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -69,7 +69,9 @@ public:
       Kokkos::View<Node *, DeviceType> internal_nodes,
       Kokkos::View<int *, DeviceType> parents);
 
+  template <typename ExecutionSpace>
   static void calculateInternalNodesBoundingVolumes(
+      ExecutionSpace const &space,
       Kokkos::View<Node const *, DeviceType> leaf_nodes,
       Kokkos::View<Node *, DeviceType> internal_nodes,
       Kokkos::View<int const *, DeviceType> parents);
@@ -467,7 +469,9 @@ private:
 };
 
 template <typename DeviceType>
+template <typename ExecutionSpace>
 void TreeConstruction<DeviceType>::calculateInternalNodesBoundingVolumes(
+    ExecutionSpace const &space,
     Kokkos::View<Node const *, DeviceType> leaf_nodes,
     Kokkos::View<Node *, DeviceType> internal_nodes,
     Kokkos::View<int const *, DeviceType> parents)
@@ -476,11 +480,10 @@ void TreeConstruction<DeviceType>::calculateInternalNodesBoundingVolumes(
   auto const last = first + leaf_nodes.extent(0);
   Kokkos::View<Node *, DeviceType, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       internal_and_leaf_nodes(internal_nodes.data(), last);
-  Kokkos::parallel_for(
-      ARBORX_MARK_REGION("calculate_bounding_boxes"),
-      Kokkos::RangePolicy<DeprecatedExecutionSpace>(first, last),
-      CalculateInternalNodesBoundingVolumesFunctor<DeviceType>(
-          internal_and_leaf_nodes, parents, first));
+  Kokkos::parallel_for(ARBORX_MARK_REGION("calculate_bounding_boxes"),
+                       Kokkos::RangePolicy<ExecutionSpace>(space, first, last),
+                       CalculateInternalNodesBoundingVolumesFunctor<DeviceType>(
+                           internal_and_leaf_nodes, parents, first));
 }
 
 } // namespace Details

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -257,78 +257,6 @@ inline void assignMortonCodes(
   assignMortonCodesDispatch(Tag{}, space, primitives, morton_codes,
                             scene_bounding_box);
 }
-} // namespace TreeConstruction
-
-/**
- * This structure contains all the functions used to build the BVH. All the
- * functions are static.
- */
-template <typename DeviceType>
-struct DeprecatedTreeConstruction
-{
-public:
-  template <typename ExecutionSpace, typename Primitives,
-            typename... PermutationIndicesViewProperties,
-            typename... LeafNodesViewProperties>
-  static void initializeLeafNodes(
-      ExecutionSpace const &space, Primitives const &primitives,
-      Kokkos::View<size_t const *, PermutationIndicesViewProperties...>
-          permutation_indices,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes);
-
-  template <typename ExecutionSpace, typename Primitives,
-            typename... PermutationIndicesViewProperties,
-            typename... LeafNodesViewProperties>
-  static void initializeLeafNodes(
-      ExecutionSpace const &space, Primitives const &primitives,
-      Kokkos::View<size_t *, PermutationIndicesViewProperties...>
-          permutation_indices,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes)
-  {
-    initializeLeafNodes(
-        space, primitives,
-        Kokkos::View<size_t const *, PermutationIndicesViewProperties...>{
-            permutation_indices},
-        leaf_nodes);
-  }
-
-  template <typename ExecutionSpace, typename... MortonCodesViewProperties,
-            typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static Node *generateHierarchy(
-      ExecutionSpace const &space,
-      Kokkos::View<unsigned int *, MortonCodesViewProperties...>
-          sorted_morton_codes,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int *, ParentsViewProperties...> parents);
-
-  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static void calculateInternalNodesBoundingVolumes(
-      ExecutionSpace const &space,
-      Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int const *, ParentsViewProperties...> parents);
-
-  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static void calculateInternalNodesBoundingVolumes(
-      ExecutionSpace const &space,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int *, ParentsViewProperties...> parents)
-  {
-    calculateInternalNodesBoundingVolumes(
-        space,
-        Kokkos::View<Node const *, LeafNodesViewProperties...>{leaf_nodes},
-        internal_nodes,
-        Kokkos::View<int const *, ParentsViewProperties...>{parents});
-  }
-};
 
 template <typename ExecutionSpace, typename Primitives, typename Indices,
           typename Nodes>
@@ -367,11 +295,10 @@ inline void initializeLeafNodesDispatch(PointTag, ExecutionSpace const &space,
       });
 }
 
-template <typename DeviceType>
 template <typename ExecutionSpace, typename Primitives,
           typename... PermutationIndicesViewProperties,
           typename... LeafNodesViewProperties>
-inline void DeprecatedTreeConstruction<DeviceType>::initializeLeafNodes(
+inline void initializeLeafNodes(
     ExecutionSpace const &space, Primitives const &primitives,
     Kokkos::View<size_t const *, PermutationIndicesViewProperties...>
         permutation_indices,
@@ -387,6 +314,69 @@ inline void DeprecatedTreeConstruction<DeviceType>::initializeLeafNodes(
   initializeLeafNodesDispatch(Tag{}, space, primitives, permutation_indices,
                               leaf_nodes);
 }
+
+template <typename ExecutionSpace, typename Primitives,
+          typename... PermutationIndicesViewProperties,
+          typename... LeafNodesViewProperties>
+inline void
+initializeLeafNodes(ExecutionSpace const &space, Primitives const &primitives,
+                    Kokkos::View<size_t *, PermutationIndicesViewProperties...>
+                        permutation_indices,
+                    Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes)
+{
+  initializeLeafNodes(
+      space, primitives,
+      Kokkos::View<size_t const *, PermutationIndicesViewProperties...>{
+          permutation_indices},
+      leaf_nodes);
+}
+} // namespace TreeConstruction
+
+/**
+ * This structure contains all the functions used to build the BVH. All the
+ * functions are static.
+ */
+template <typename DeviceType>
+struct DeprecatedTreeConstruction
+{
+public:
+  template <typename ExecutionSpace, typename... MortonCodesViewProperties,
+            typename... LeafNodesViewProperties,
+            typename... InternalNodesViewProperties,
+            typename... ParentsViewProperties>
+  static Node *generateHierarchy(
+      ExecutionSpace const &space,
+      Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+          sorted_morton_codes,
+      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
+      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+      Kokkos::View<int *, ParentsViewProperties...> parents);
+
+  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
+            typename... InternalNodesViewProperties,
+            typename... ParentsViewProperties>
+  static void calculateInternalNodesBoundingVolumes(
+      ExecutionSpace const &space,
+      Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
+      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+      Kokkos::View<int const *, ParentsViewProperties...> parents);
+
+  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
+            typename... InternalNodesViewProperties,
+            typename... ParentsViewProperties>
+  static void calculateInternalNodesBoundingVolumes(
+      ExecutionSpace const &space,
+      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
+      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+      Kokkos::View<int *, ParentsViewProperties...> parents)
+  {
+    calculateInternalNodesBoundingVolumes(
+        space,
+        Kokkos::View<Node const *, LeafNodesViewProperties...>{leaf_nodes},
+        internal_nodes,
+        Kokkos::View<int const *, ParentsViewProperties...>{parents});
+  }
+};
 
 template <typename DeviceType>
 class GenerateHierarchyFunctor

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -22,14 +22,7 @@
 #include <ArborX_Macros.hpp>
 #include <ArborX_Traits.hpp>
 
-// FIXME provides definition of Kokkos::Iterate for Kokkos_CopyViews.hpp
-#include <KokkosExp_MDRangePolicy.hpp>
-#include <Kokkos_Atomic.hpp>
-#include <Kokkos_CopyViews.hpp> // deep_copy
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Pair.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <cassert>
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -447,41 +447,6 @@ inline Node *generateHierarchy(
           sorted_morton_codes},
       leaf_nodes, internal_nodes, parents);
 }
-} // namespace TreeConstruction
-
-/**
- * This structure contains all the functions used to build the BVH. All the
- * functions are static.
- */
-template <typename DeviceType>
-struct DeprecatedTreeConstruction
-{
-public:
-  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static void calculateInternalNodesBoundingVolumes(
-      ExecutionSpace const &space,
-      Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int const *, ParentsViewProperties...> parents);
-
-  template <typename ExecutionSpace, typename... LeafNodesViewProperties,
-            typename... InternalNodesViewProperties,
-            typename... ParentsViewProperties>
-  static void calculateInternalNodesBoundingVolumes(
-      ExecutionSpace const &space,
-      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
-      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-      Kokkos::View<int *, ParentsViewProperties...> parents)
-  {
-    calculateInternalNodesBoundingVolumes(
-        space,
-        Kokkos::View<Node const *, LeafNodesViewProperties...>{leaf_nodes},
-        internal_nodes,
-        Kokkos::View<int const *, ParentsViewProperties...>{parents});
-  }
-};
 
 template <typename MemorySpace>
 class CalculateInternalNodesBoundingVolumesFunctor
@@ -545,16 +510,14 @@ private:
   Kokkos::View<Node *, MemorySpace> _internal_and_leaf_nodes;
 };
 
-template <typename DeviceType>
 template <typename ExecutionSpace, typename... LeafNodesViewProperties,
           typename... InternalNodesViewProperties,
           typename... ParentsViewProperties>
-void DeprecatedTreeConstruction<DeviceType>::
-    calculateInternalNodesBoundingVolumes(
-        ExecutionSpace const &space,
-        Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
-        Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
-        Kokkos::View<int const *, ParentsViewProperties...> parents)
+void calculateInternalNodesBoundingVolumes(
+    ExecutionSpace const &space,
+    Kokkos::View<Node const *, LeafNodesViewProperties...> leaf_nodes,
+    Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+    Kokkos::View<int const *, ParentsViewProperties...> parents)
 {
   auto const first = internal_nodes.extent(0);
   auto const last = first + leaf_nodes.extent(0);
@@ -568,6 +531,31 @@ void DeprecatedTreeConstruction<DeviceType>::
       CalculateInternalNodesBoundingVolumesFunctor<MemorySpace>(
           space, internal_and_leaf_nodes, parents, first));
 }
+
+template <typename ExecutionSpace, typename... LeafNodesViewProperties,
+          typename... InternalNodesViewProperties,
+          typename... ParentsViewProperties>
+inline void calculateInternalNodesBoundingVolumes(
+    ExecutionSpace const &space,
+    Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
+    Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+    Kokkos::View<int *, ParentsViewProperties...> parents)
+{
+  calculateInternalNodesBoundingVolumes(
+      space, Kokkos::View<Node const *, LeafNodesViewProperties...>{leaf_nodes},
+      internal_nodes,
+      Kokkos::View<int const *, ParentsViewProperties...>{parents});
+}
+} // namespace TreeConstruction
+
+/**
+ * This structure contains all the functions used to build the BVH. All the
+ * functions are static.
+ */
+template <typename DeviceType>
+struct DeprecatedTreeConstruction
+{
+};
 
 } // namespace Details
 } // namespace ArborX

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -547,16 +547,6 @@ inline void calculateInternalNodesBoundingVolumes(
       Kokkos::View<int const *, ParentsViewProperties...>{parents});
 }
 } // namespace TreeConstruction
-
-/**
- * This structure contains all the functions used to build the BVH. All the
- * functions are static.
- */
-template <typename DeviceType>
-struct DeprecatedTreeConstruction
-{
-};
-
 } // namespace Details
 } // namespace ArborX
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -61,7 +61,9 @@ public:
       Kokkos::View<size_t const *, DeviceType> permutation_indices,
       Kokkos::View<Node *, DeviceType> leaf_nodes);
 
+  template <typename ExecutionSpace>
   static Node *generateHierarchy(
+      ExecutionSpace const &space,
       Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
       Kokkos::View<Node *, DeviceType> leaf_nodes,
       Kokkos::View<Node *, DeviceType> internal_nodes,
@@ -388,7 +390,9 @@ private:
 };
 
 template <typename DeviceType>
+template <typename ExecutionSpace>
 Node *TreeConstruction<DeviceType>::generateHierarchy(
+    ExecutionSpace const &space,
     Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
     Kokkos::View<Node *, DeviceType> leaf_nodes,
     Kokkos::View<Node *, DeviceType> internal_nodes,
@@ -397,7 +401,7 @@ Node *TreeConstruction<DeviceType>::generateHierarchy(
   auto const n = sorted_morton_codes.extent(0);
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("generate_hierarchy"),
-      Kokkos::RangePolicy<DeprecatedExecutionSpace>(0, n - 1),
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n - 1),
       GenerateHierarchyFunctor<DeviceType>(sorted_morton_codes, leaf_nodes,
                                            internal_nodes, parents));
   // returns a pointer to the root node of the tree

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -75,9 +75,10 @@ public:
       Kokkos::View<Node *, DeviceType> internal_nodes,
       Kokkos::View<int const *, DeviceType> parents);
 
-  KOKKOS_FUNCTION
-  static int commonPrefix(Kokkos::View<unsigned int *, DeviceType> morton_codes,
-                          int i, int j)
+  template <typename... MortonCodesViewProperties>
+  KOKKOS_FUNCTION static int commonPrefix(
+      Kokkos::View<unsigned int *, MortonCodesViewProperties...> morton_codes,
+      int i, int j)
   {
     using KokkosExt::clz;
 
@@ -96,9 +97,10 @@ public:
     return clz(morton_codes[i] ^ morton_codes[j]);
   }
 
-  KOKKOS_FUNCTION
-  static int
-  findSplit(Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
+  template <typename... MortonCodesViewProperties>
+  KOKKOS_FUNCTION static int
+  findSplit(Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+                sorted_morton_codes,
             int first, int last)
   {
     // Calculate the number of highest bits that are the same
@@ -128,9 +130,10 @@ public:
     return split;
   }
 
-  KOKKOS_FUNCTION
-  static Kokkos::pair<int, int>
-  determineRange(Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
+  template <typename... MortonCodesViewProperties>
+  KOKKOS_FUNCTION static Kokkos::pair<int, int>
+  determineRange(Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+                     sorted_morton_codes,
                  int i)
   {
     using KokkosExt::max;

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -501,7 +501,7 @@ public:
     Kokkos::deep_copy(_flags, 0);
   }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   void operator()(int i) const
   {
     // Walk toward the root and do process it even though technically its

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -487,8 +487,10 @@ template <typename MemorySpace>
 class CalculateInternalNodesBoundingVolumesFunctor
 {
 public:
-  template <typename... NodesViewProperties, typename... ParentsViewProperties>
+  template <typename ExecutionSpace, typename... NodesViewProperties,
+            typename... ParentsViewProperties>
   CalculateInternalNodesBoundingVolumesFunctor(
+      ExecutionSpace const &space,
       Kokkos::View<Node *, NodesViewProperties...> internal_and_leaf_nodes,
       Kokkos::View<int const *, ParentsViewProperties...> parents,
       size_t n_internal_nodes)
@@ -498,7 +500,7 @@ public:
       , _internal_and_leaf_nodes(internal_and_leaf_nodes)
   {
     // Initialize flags to zero
-    Kokkos::deep_copy(_flags, 0);
+    Kokkos::deep_copy(space, _flags, 0);
   }
 
   KOKKOS_FUNCTION
@@ -564,7 +566,7 @@ void DeprecatedTreeConstruction<DeviceType>::
       ARBORX_MARK_REGION("calculate_bounding_boxes"),
       Kokkos::RangePolicy<ExecutionSpace>(space, first, last),
       CalculateInternalNodesBoundingVolumesFunctor<MemorySpace>(
-          internal_and_leaf_nodes, parents, first));
+          space, internal_and_leaf_nodes, parents, first));
 }
 
 } // namespace Details

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -79,13 +79,17 @@ public:
         leaf_nodes);
   }
 
-  template <typename ExecutionSpace>
+  template <typename ExecutionSpace, typename... MortonCodesViewProperties,
+            typename... LeafNodesViewProperties,
+            typename... InternalNodesViewProperties,
+            typename... ParentsViewProperties>
   static Node *generateHierarchy(
       ExecutionSpace const &space,
-      Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
-      Kokkos::View<Node *, DeviceType> leaf_nodes,
-      Kokkos::View<Node *, DeviceType> internal_nodes,
-      Kokkos::View<int *, DeviceType> parents);
+      Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+          sorted_morton_codes,
+      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
+      Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+      Kokkos::View<int *, ParentsViewProperties...> parents);
 
   template <typename ExecutionSpace>
   static void calculateInternalNodesBoundingVolumes(
@@ -417,13 +421,17 @@ private:
 };
 
 template <typename DeviceType>
-template <typename ExecutionSpace>
+template <typename ExecutionSpace, typename... MortonCodesViewProperties,
+          typename... LeafNodesViewProperties,
+          typename... InternalNodesViewProperties,
+          typename... ParentsViewProperties>
 Node *TreeConstruction<DeviceType>::generateHierarchy(
     ExecutionSpace const &space,
-    Kokkos::View<unsigned int *, DeviceType> sorted_morton_codes,
-    Kokkos::View<Node *, DeviceType> leaf_nodes,
-    Kokkos::View<Node *, DeviceType> internal_nodes,
-    Kokkos::View<int *, DeviceType> parents)
+    Kokkos::View<unsigned int *, MortonCodesViewProperties...>
+        sorted_morton_codes,
+    Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
+    Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes,
+    Kokkos::View<int *, ParentsViewProperties...> parents)
 {
   auto const n = sorted_morton_codes.extent(0);
   Kokkos::parallel_for(

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -41,8 +41,9 @@ struct TreeConstruction
 public:
   using DeprecatedExecutionSpace = typename DeviceType::execution_space;
 
-  template <typename Primitives>
-  static void calculateBoundingBoxOfTheScene(Primitives const &primitives,
+  template <typename ExecutionSpace, typename Primitives>
+  static void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
+                                             Primitives const &primitives,
                                              Box &scene_bounding_box);
 
   // to assign the Morton code for a given object, we use the centroid point
@@ -194,15 +195,16 @@ private:
 };
 
 template <typename DeviceType>
-template <typename Primitives>
+template <typename ExecutionSpace, typename Primitives>
 inline void TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
-    Primitives const &primitives, Box &scene_bounding_box)
+    ExecutionSpace const &space, Primitives const &primitives,
+    Box &scene_bounding_box)
 {
   using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
   auto const n = Access::size(primitives);
   Kokkos::parallel_reduce(
       ARBORX_MARK_REGION("calculate_bounding_box_of_the_scene"),
-      Kokkos::RangePolicy<ExecutionSpace>(0, n),
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),
       CalculateBoundingBoxOfTheSceneFunctor<Primitives>(primitives),
       scene_bounding_box);
 }

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -54,11 +54,30 @@ public:
       Kokkos::View<unsigned int *, MortonCodesViewProperties...> morton_codes,
       Box const &scene_bounding_box);
 
-  template <typename ExecutionSpace, typename Primitives>
+  template <typename ExecutionSpace, typename Primitives,
+            typename... PermutationIndicesViewProperties,
+            typename... LeafNodesViewProperties>
   static void initializeLeafNodes(
       ExecutionSpace const &space, Primitives const &primitives,
-      Kokkos::View<size_t const *, DeviceType> permutation_indices,
-      Kokkos::View<Node *, DeviceType> leaf_nodes);
+      Kokkos::View<size_t const *, PermutationIndicesViewProperties...>
+          permutation_indices,
+      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes);
+
+  template <typename ExecutionSpace, typename Primitives,
+            typename... PermutationIndicesViewProperties,
+            typename... LeafNodesViewProperties>
+  static void initializeLeafNodes(
+      ExecutionSpace const &space, Primitives const &primitives,
+      Kokkos::View<size_t *, PermutationIndicesViewProperties...>
+          permutation_indices,
+      Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes)
+  {
+    initializeLeafNodes(
+        space, primitives,
+        Kokkos::View<size_t const *, PermutationIndicesViewProperties...>{
+            permutation_indices},
+        leaf_nodes);
+  }
 
   template <typename ExecutionSpace>
   static Node *generateHierarchy(
@@ -306,11 +325,14 @@ inline void initializeLeafNodesDispatch(PointTag, ExecutionSpace const &space,
 }
 
 template <typename DeviceType>
-template <typename ExecutionSpace, typename Primitives>
+template <typename ExecutionSpace, typename Primitives,
+          typename... PermutationIndicesViewProperties,
+          typename... LeafNodesViewProperties>
 inline void TreeConstruction<DeviceType>::initializeLeafNodes(
     ExecutionSpace const &space, Primitives const &primitives,
-    Kokkos::View<size_t const *, DeviceType> permutation_indices,
-    Kokkos::View<Node *, DeviceType> leaf_nodes)
+    Kokkos::View<size_t const *, PermutationIndicesViewProperties...>
+        permutation_indices,
+    Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes)
 {
   using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -39,8 +39,6 @@ template <typename DeviceType>
 struct TreeConstruction
 {
 public:
-  using DeprecatedExecutionSpace = typename DeviceType::execution_space;
-
   template <typename ExecutionSpace, typename Primitives>
   static void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
                                              Primitives const &primitives,

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -47,11 +47,12 @@ public:
   // to assign the Morton code for a given object, we use the centroid point
   // of its bounding box, and express it relative to the bounding box of the
   // scene.
-  template <typename ExecutionSpace, typename Primitives>
-  static void
-  assignMortonCodes(ExecutionSpace const &space, Primitives const &primitives,
-                    Kokkos::View<unsigned int *, DeviceType> morton_codes,
-                    Box const &scene_bounding_box);
+  template <typename ExecutionSpace, typename Primitives,
+            typename... MortonCodesViewProperties>
+  static void assignMortonCodes(
+      ExecutionSpace const &space, Primitives const &primitives,
+      Kokkos::View<unsigned int *, MortonCodesViewProperties...> morton_codes,
+      Box const &scene_bounding_box);
 
   template <typename ExecutionSpace, typename Primitives>
   static void initializeLeafNodes(
@@ -247,10 +248,11 @@ inline void assignMortonCodesDispatch(PointTag, ExecutionSpace const &space,
 }
 
 template <typename DeviceType>
-template <typename ExecutionSpace, typename Primitives>
+template <typename ExecutionSpace, typename Primitives,
+          typename... MortonCodesViewProperties>
 inline void TreeConstruction<DeviceType>::assignMortonCodes(
     ExecutionSpace const &space, Primitives const &primitives,
-    Kokkos::View<unsigned int *, DeviceType> morton_codes,
+    Kokkos::View<unsigned int *, MortonCodesViewProperties...> morton_codes,
     Box const &scene_bounding_box)
 {
   using Access = typename Traits::Access<Primitives, Traits::PrimitivesTag>;

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -29,8 +29,6 @@
 
 #define BOOST_TEST_MODULE DetailsTreeConstruction
 
-namespace details = ArborX::Details;
-
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
@@ -46,11 +44,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
       {{0, 0, 0}}, {{0, 0, 0}}, {{0, 0, 0}},         {{0, 0, 0}},
       {{1, 2, 3}}, {{1, 2, 3}}, {{1023, 1023, 1023}}};
   auto fun = [](std::array<unsigned int, 3> const &anchor) {
+    using ArborX::Details::expandBits;
     unsigned int i = std::get<0>(anchor);
     unsigned int j = std::get<1>(anchor);
     unsigned int k = std::get<2>(anchor);
-    return 4 * details::expandBits(i) + 2 * details::expandBits(j) +
-           details::expandBits(k);
+    return 4 * expandBits(i) + 2 * expandBits(j) + expandBits(k);
   };
   std::vector<unsigned int> ref(n, std::numeric_limits<unsigned int>::max());
   for (int i = 0; i < n; ++i)
@@ -60,7 +58,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::View<ArborX::Box *, DeviceType> boxes("boxes", n);
   auto boxes_host = Kokkos::create_mirror_view(boxes);
   for (int i = 0; i < n; ++i)
-    details::expand(boxes_host(i), points[i]);
+    ArborX::Details::expand(boxes_host(i), points[i]);
   Kokkos::deep_copy(boxes, boxes_host);
 
   typename DeviceType::execution_space space{};
@@ -68,8 +66,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
   ArborX::Details::TreeConstruction::calculateBoundingBoxOfTheScene(
       space, boxes, scene_host);
 
-  BOOST_TEST(
-      details::equals(scene_host, {{{0., 0., 0.}}, {{1024., 1024., 1024.}}}));
+  BOOST_TEST(ArborX::Details::equals(
+      scene_host, {{{0., 0., 0.}}, {{1024., 1024., 1024.}}}));
 
   Kokkos::View<unsigned int *, DeviceType> morton_codes("morton_codes", n);
   ArborX::Details::TreeConstruction::assignMortonCodes(
@@ -113,7 +111,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(indirect_sort, DeviceType, ARBORX_DEVICE_TYPES)
 
   std::vector<size_t> ref = {3, 2, 1, 0};
   // sort Morton codes and object ids
-  auto ids = details::sortObjects(k);
+  auto ids = ArborX::Details::sortObjects(k);
 
   auto k_host = Kokkos::create_mirror_view(k);
   Kokkos::deep_copy(k_host, k);

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -194,9 +194,8 @@ public:
     int index_1[] = {0, 0, 1, 1, 1, 2, 2, 0, 12, 12};
     int index_2[] = {0, 1, 0, 1, 2, 1, 2, -1, 12, 13};
 
-    _results[i] =
-        ArborX::Details::DeprecatedTreeConstruction<DeviceType>::commonPrefix(
-            _fi, index_1[i], index_2[i]);
+    _results[i] = ArborX::Details::TreeConstruction::commonPrefix(
+        _fi, index_1[i], index_2[i]);
   }
 
 private:

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -315,8 +315,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   Kokkos::View<int *, DeviceType> parents("parents", 2 * n + 1);
   Kokkos::deep_copy(parents, -1);
 
+  typename DeviceType::execution_space space{};
   details::TreeConstruction<DeviceType>::generateHierarchy(
-      sorted_morton_codes, leaf_nodes, internal_nodes, parents);
+      space, sorted_morton_codes, leaf_nodes, internal_nodes, parents);
 
   BOOST_TEST(parents(0) == -1);
 

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -63,9 +63,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
     details::expand(boxes_host(i), points[i]);
   Kokkos::deep_copy(boxes, boxes_host);
 
+  typename DeviceType::execution_space space{};
   ArborX::Box scene_host;
   details::TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
-      boxes, scene_host);
+      space, boxes, scene_host);
 
   BOOST_TEST(
       details::equals(scene_host, {{{0., 0., 0.}}, {{1024., 1024., 1024.}}}));

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -65,14 +65,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
 
   typename DeviceType::execution_space space{};
   ArborX::Box scene_host;
-  details::TreeConstruction<DeviceType>::calculateBoundingBoxOfTheScene(
-      space, boxes, scene_host);
+  details::DeprecatedTreeConstruction<
+      DeviceType>::calculateBoundingBoxOfTheScene(space, boxes, scene_host);
 
   BOOST_TEST(
       details::equals(scene_host, {{{0., 0., 0.}}, {{1024., 1024., 1024.}}}));
 
   Kokkos::View<unsigned int *, DeviceType> morton_codes("morton_codes", n);
-  details::TreeConstruction<DeviceType>::assignMortonCodes(
+  details::DeprecatedTreeConstruction<DeviceType>::assignMortonCodes(
       space, boxes, morton_codes, scene_host);
   auto morton_codes_host = Kokkos::create_mirror_view(morton_codes);
   Kokkos::deep_copy(morton_codes_host, morton_codes);
@@ -194,8 +194,9 @@ public:
     int index_1[] = {0, 0, 1, 1, 1, 2, 2, 0, 12, 12};
     int index_2[] = {0, 1, 0, 1, 2, 1, 2, -1, 12, 13};
 
-    _results[i] = ArborX::Details::TreeConstruction<DeviceType>::commonPrefix(
-        _fi, index_1[i], index_2[i]);
+    _results[i] =
+        ArborX::Details::DeprecatedTreeConstruction<DeviceType>::commonPrefix(
+            _fi, index_1[i], index_2[i]);
   }
 
 private:
@@ -316,7 +317,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   Kokkos::deep_copy(parents, -1);
 
   typename DeviceType::execution_space space{};
-  details::TreeConstruction<DeviceType>::generateHierarchy(
+  details::DeprecatedTreeConstruction<DeviceType>::generateHierarchy(
       space, sorted_morton_codes, leaf_nodes, internal_nodes, parents);
 
   BOOST_TEST(parents(0) == -1);

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   Kokkos::deep_copy(parents, -1);
 
   typename DeviceType::execution_space space{};
-  details::DeprecatedTreeConstruction<DeviceType>::generateHierarchy(
+  ArborX::Details::TreeConstruction::generateHierarchy(
       space, sorted_morton_codes, leaf_nodes, internal_nodes, parents);
 
   BOOST_TEST(parents(0) == -1);

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
       details::equals(scene_host, {{{0., 0., 0.}}, {{1024., 1024., 1024.}}}));
 
   Kokkos::View<unsigned int *, DeviceType> morton_codes("morton_codes", n);
-  details::TreeConstruction<DeviceType>::assignMortonCodes(boxes, morton_codes,
-                                                           scene_host);
+  details::TreeConstruction<DeviceType>::assignMortonCodes(
+      space, boxes, morton_codes, scene_host);
   auto morton_codes_host = Kokkos::create_mirror_view(morton_codes);
   Kokkos::deep_copy(morton_codes_host, morton_codes);
   BOOST_TEST(morton_codes_host == ref, tt::per_element());

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -65,8 +65,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
 
   typename DeviceType::execution_space space{};
   ArborX::Box scene_host;
-  details::DeprecatedTreeConstruction<
-      DeviceType>::calculateBoundingBoxOfTheScene(space, boxes, scene_host);
+  ArborX::Details::TreeConstruction::calculateBoundingBoxOfTheScene(
+      space, boxes, scene_host);
 
   BOOST_TEST(
       details::equals(scene_host, {{{0., 0., 0.}}, {{1024., 1024., 1024.}}}));

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(morton_codes, DeviceType, ARBORX_DEVICE_TYPES)
       details::equals(scene_host, {{{0., 0., 0.}}, {{1024., 1024., 1024.}}}));
 
   Kokkos::View<unsigned int *, DeviceType> morton_codes("morton_codes", n);
-  details::DeprecatedTreeConstruction<DeviceType>::assignMortonCodes(
+  ArborX::Details::TreeConstruction::assignMortonCodes(
       space, boxes, morton_codes, scene_host);
   auto morton_codes_host = Kokkos::create_mirror_view(morton_codes);
   Kokkos::deep_copy(morton_codes_host, morton_codes);


### PR DESCRIPTION
~~Not entirely done with dropping the `DeviceType` template parameter from the `Details::TreeConstruction` struct and turning it in a namespace.
There are some subtleties with views that I still need to work out.~~
Done