### PR TITLE
Update STL-like algorithms to take execution space as first argument

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -109,6 +109,9 @@ DistributedSearchTree<DeviceType>::DistributedSearchTree(
     MPI_Comm comm, Primitives const &primitives)
     : _bottom_tree(primitives)
 {
+  using ExecutionSpace = typename DeviceType::device_type;
+  ExecutionSpace space{};
+
   // Create new context for the library to isolate library's communication from
   // user's
   MPI_Comm_dup(comm, &_comm);
@@ -142,7 +145,7 @@ DistributedSearchTree<DeviceType>::DistributedSearchTree(
                 sizeof(size_type), MPI_BYTE, _comm);
   Kokkos::deep_copy(_bottom_tree_sizes, bottom_tree_sizes_host);
 
-  _top_tree_size = accumulate(_bottom_tree_sizes, 0);
+  _top_tree_size = accumulate(space, _bottom_tree_sizes, 0);
 }
 
 } // namespace ArborX

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -109,7 +109,7 @@ DistributedSearchTree<DeviceType>::DistributedSearchTree(
     MPI_Comm comm, Primitives const &primitives)
     : _bottom_tree(primitives)
 {
-  using ExecutionSpace = typename DeviceType::device_type;
+  using ExecutionSpace = typename DeviceType::execution_space;
   ExecutionSpace space{};
 
   // Create new context for the library to isolate library's communication from

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -16,7 +16,7 @@
 #include <ArborX_DetailsAlgorithms.hpp> // returnCentroid, translateAndScale
 #include <ArborX_DetailsMortonCode.hpp> // morton3D
 #include <ArborX_DetailsSortUtils.hpp>  // sortObjects
-#include <ArborX_DetailsUtils.hpp>      // iota, exclusivePrefixSum, lastElement
+#include <ArborX_DetailsUtils.hpp>      // exclusivePrefixSum, lastElement
 #include <ArborX_Macros.hpp>
 #include <ArborX_Traits.hpp>
 

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -125,7 +125,7 @@ public:
           tmp_offset(permute(i)) = offset(i + 1) - offset(i);
         });
 
-    exclusivePrefixSum(tmp_offset);
+    exclusivePrefixSum(ExecutionSpace{}, tmp_offset);
 
     return tmp_offset;
   }

--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -531,7 +531,8 @@ BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   // positive value can be assigned otherwise.
   auto const max_results_per_query =
       (buffer_size > 0)
-          ? max(Kokkos::subview(offset,
+          ? max(ExecutionSpace{},
+                Kokkos::subview(offset,
                                 Kokkos::pair<size_t, size_t>(0, n_queries)))
           : std::numeric_limits<typename std::remove_reference<decltype(
                 offset)>::type::value_type>::max();

--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -324,7 +324,7 @@ BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
       Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
       KOKKOS_LAMBDA(int i) { offset(permute(i)) = getK(queries(i)); });
 
-  exclusivePrefixSum(offset);
+  exclusivePrefixSum(ExecutionSpace{}, offset);
   int const n_results = lastElement(offset);
 
   Kokkos::Profiling::popRegion();
@@ -394,7 +394,7 @@ BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   // Find out if they are any invalid entries in the indices (i.e. at least
   // one query asked for more neighbors than there are leaves in the tree) and
   // eliminate them if necessary.
-  exclusivePrefixSum(tmp_offset);
+  exclusivePrefixSum(ExecutionSpace{}, tmp_offset);
   int const n_tmp_results = lastElement(tmp_offset);
   if (n_tmp_results != n_results)
   {
@@ -540,7 +540,7 @@ BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   // [ 0 2 4 .... 2N-2 2N ]
   //                    ^
   //                    N
-  exclusivePrefixSum(offset);
+  exclusivePrefixSum(ExecutionSpace{}, offset);
 
   // Let us extract the last element in the view which is the total count of
   // objects which where found to meet the query predicates:

--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -307,7 +307,7 @@ BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   {
     permute = Kokkos::View<size_t *, DeviceType>(
         Kokkos::ViewAllocateWithoutInitializing("permute"), n_queries);
-    iota(permute);
+    iota(ExecutionSpace{}, permute);
   }
 
   // FIXME  readability!  queries is a sorted copy of the predicates
@@ -455,7 +455,7 @@ BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
   {
     permute = Kokkos::View<size_t *, DeviceType>(
         Kokkos::ViewAllocateWithoutInitializing("permute"), n_queries);
-    iota(permute);
+    iota(ExecutionSpace{}, permute);
   }
 
   // FIXME  readability!  queries is a sorted copy of the predicates

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -310,7 +310,7 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
         }
       });
 
-  exclusivePrefixSum(new_offset);
+  exclusivePrefixSum(ExecutionSpace{}, new_offset);
 
   // Truncate results so that queries will only be forwarded to as many local
   // trees as necessary to find k neighbors.
@@ -540,7 +540,7 @@ void DistributedSearchTreeImpl<DeviceType>::countResults(
                          Kokkos::atomic_increment(&offset(query_ids(i)));
                        });
 
-  exclusivePrefixSum(offset);
+  exclusivePrefixSum(ExecutionSpace{}, offset);
 }
 
 template <typename DeviceType>
@@ -685,7 +685,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
                                              getK(Access::get(queries, q)));
                        });
 
-  exclusivePrefixSum(new_offset);
+  exclusivePrefixSum(ExecutionSpace{}, new_offset);
 
   int const n_truncated_results = lastElement(new_offset);
   Kokkos::View<int *, DeviceType> new_indices(indices.label(),

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -26,8 +26,6 @@
 #include <Kokkos_Sort.hpp>
 #include <Kokkos_View.hpp>
 
-#include <numeric> // accumulate
-
 #include <mpi.h>
 
 namespace ArborX

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -159,7 +159,8 @@ static void sortAndDetermineBufferLayout(InputView ranks,
   int offset = 0;
   while (true)
   {
-    int const largest_rank = ArborX::max(device_ranks_duplicate);
+    int const largest_rank =
+        ArborX::max(ExecutionSpace{}, device_ranks_duplicate);
     if (largest_rank == -1)
       break;
     unique_ranks.push_back(largest_rank);

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -163,15 +163,15 @@ void applyPermutation(PermutationView const &permutation, View &view)
 {
   static_assert(std::is_integral<typename PermutationView::value_type>::value,
                 "");
+  using ExecutionSpace = typename View::execution_space;
   ARBORX_ASSERT(permutation.extent(0) == view.extent(0));
-  auto scratch_view = clone(view);
-  Kokkos::parallel_for(
-      ARBORX_MARK_REGION("permute"),
-      Kokkos::RangePolicy<typename View::execution_space>(0, view.extent(0)),
-      KOKKOS_LAMBDA(int i) {
-        PermuteHelper::CopyOp<View, View>::copy(scratch_view, i, view,
-                                                permutation(i));
-      });
+  auto scratch_view = clone(ExecutionSpace{}, view);
+  Kokkos::parallel_for(ARBORX_MARK_REGION("permute"),
+                       Kokkos::RangePolicy<ExecutionSpace>(0, view.extent(0)),
+                       KOKKOS_LAMBDA(int i) {
+                         PermuteHelper::CopyOp<View, View>::copy(
+                             scratch_view, i, view, permutation(i));
+                       });
   Kokkos::deep_copy(view, scratch_view);
 }
 

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -104,7 +104,7 @@ Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> sortObjects(
 
   Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> permute(
       Kokkos::ViewAllocateWithoutInitializing("permutation"), n);
-  ArborX::iota(ExecutionSpace{}, permute);
+  ArborX::iota(Kokkos::Cuda{}, permute);
 
   auto permute_ptr = thrust::device_ptr<size_t>(permute.data());
   auto begin_ptr = thrust::device_ptr<ValueType>(view.data());

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -76,7 +76,7 @@ sortObjects(ViewType &view)
   {
     Kokkos::View<size_t *, typename ViewType::device_type> permute(
         Kokkos::ViewAllocateWithoutInitializing("permute"), n);
-    iota(permute);
+    iota(ExecutionSpace{}, permute);
     return permute;
   }
 
@@ -104,7 +104,7 @@ Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> sortObjects(
 
   Kokkos::View<size_t *, Kokkos::Device<Kokkos::Cuda, MemorySpace>> permute(
       Kokkos::ViewAllocateWithoutInitializing("permutation"), n);
-  ArborX::iota(permute);
+  ArborX::iota(ExecutionSpace{}, permute);
 
   auto permute_ptr = thrust::device_ptr<size_t>(permute.data());
   auto begin_ptr = thrust::device_ptr<ValueType>(view.data());

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -24,16 +24,6 @@ namespace ArborX
 
 namespace Details
 {
-
-template <class T>
-struct remove_cvref
-{
-  typedef std::remove_cv_t<std::remove_reference_t<T>> type;
-};
-
-template <class T>
-using remove_cvref_t = typename remove_cvref<T>::type;
-
 // NOTE: This functor is used in exclusivePrefixSum( src, dst ).  We were
 // getting a compile error on CUDA when using a KOKKOS_LAMBDA.
 template <typename T, typename DeviceType>
@@ -96,7 +86,7 @@ void exclusivePrefixSum(ExecutionSpace &&space,
 
   auto const n = src.extent(0);
   ARBORX_ASSERT(n == dst.extent(0));
-  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_scan(
       ARBORX_MARK_REGION("exclusive_scan"), policy,
@@ -181,7 +171,7 @@ void iota(ExecutionSpace &&space, Kokkos::View<T, P...> const &v,
                                   T, P...>::non_const_value_type>::value,
       "iota requires a View with non-const value type");
   auto const n = v.extent(0);
-  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_for(ARBORX_MARK_REGION("iota"), policy,
                        KOKKOS_LAMBDA(int i) { v(i) = value + (ValueType)i; });
@@ -214,7 +204,7 @@ minMax(ExecutionSpace &&space, ViewType const &v)
   ARBORX_ASSERT(n > 0);
   Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
   Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(ARBORX_MARK_REGION("min_max"), policy,
                           Kokkos::Impl::min_max_functor<ViewType>(v), reducer);
@@ -244,7 +234,7 @@ typename ViewType::non_const_value_type min(ExecutionSpace &&space,
   ARBORX_ASSERT(n > 0);
   typename ViewType::non_const_value_type result;
   Kokkos::Min<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(ARBORX_MARK_REGION("min"), policy,
                           KOKKOS_LAMBDA(int i, int &update) {
@@ -277,7 +267,7 @@ typename ViewType::non_const_value_type max(ExecutionSpace &&space,
   ARBORX_ASSERT(n > 0);
   typename ViewType::non_const_value_type result;
   Kokkos::Max<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(ARBORX_MARK_REGION("max"), policy,
                           KOKKOS_LAMBDA(int i, int &update) {
@@ -319,7 +309,7 @@ accumulate(ExecutionSpace &&space, ViewType const &v,
   // the reduction, introduce here a temporary variable and add it to init
   // before returning.
   typename ViewType::non_const_value_type tmp = 0;
-  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(
       ARBORX_MARK_REGION("accumulate"), policy,
@@ -372,7 +362,7 @@ void adjacentDifference(ExecutionSpace &&space, SrcViewType const &src,
   auto const n = src.extent(0);
   ARBORX_ASSERT(n == dst.extent(0));
   ARBORX_ASSERT(src != dst);
-  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_for(ARBORX_MARK_REGION("adjacent_difference"), policy,
                        KOKKOS_LAMBDA(int i) {

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -24,6 +24,16 @@ namespace ArborX
 
 namespace Details
 {
+
+template <class T>
+struct remove_cvref
+{
+  typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+};
+
+template <class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
 // NOTE: This functor is used in exclusivePrefixSum( src, dst ).  We were
 // getting a compile error on CUDA when using a KOKKOS_LAMBDA.
 template <typename T, typename DeviceType>

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -85,8 +85,8 @@ void exclusivePrefixSum(ExecutionSpace &&space,
 
   auto const n = src.extent(0);
   ARBORX_ASSERT(n == dst.extent(0));
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
-      std::forward<ExecutionSpace>(space), 0, n};
+  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+      std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_scan(
       "exclusive_scan", policy,
       Details::ExclusiveScanFunctor<ValueType, DeviceType>(src, dst));
@@ -170,8 +170,8 @@ void iota(ExecutionSpace &&space, Kokkos::View<T, P...> const &v,
                                   T, P...>::non_const_value_type>::value,
       "iota requires a View with non-const value type");
   auto const n = v.extent(0);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
-      std::forward<ExecutionSpace>(space), 0, n};
+  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+      std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_for("iota", policy,
                        KOKKOS_LAMBDA(int i) { v(i) = value + (ValueType)i; });
 }
@@ -203,8 +203,8 @@ minMax(ExecutionSpace &&space, ViewType const &v)
   ARBORX_ASSERT(n > 0);
   Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
   Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
-      std::forward<ExecutionSpace>(space), 0, n};
+  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+      std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce("minMax", policy,
                           Kokkos::Impl::min_max_functor<ViewType>(v), reducer);
   return std::make_pair(result.min_val, result.max_val);
@@ -233,8 +233,8 @@ typename ViewType::non_const_value_type min(ExecutionSpace &&space,
   ARBORX_ASSERT(n > 0);
   typename ViewType::non_const_value_type result;
   Kokkos::Min<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
-      std::forward<ExecutionSpace>(space), 0, n};
+  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+      std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce("min", policy,
                           KOKKOS_LAMBDA(int i, int &update) {
                             if (v(i) < update)
@@ -266,8 +266,8 @@ typename ViewType::non_const_value_type max(ExecutionSpace &&space,
   ARBORX_ASSERT(n > 0);
   typename ViewType::non_const_value_type result;
   Kokkos::Max<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
-      std::forward<ExecutionSpace>(space), 0, n};
+  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+      std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce("max", policy,
                           KOKKOS_LAMBDA(int i, int &update) {
                             if (v(i) > update)
@@ -308,8 +308,8 @@ accumulate(ExecutionSpace &&space, ViewType const &v,
   // the reduction, introduce here a temporary variable and add it to init
   // before returning.
   typename ViewType::non_const_value_type tmp = 0;
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
-      std::forward<ExecutionSpace>(space), 0, n};
+  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+      std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(
       "accumulate", policy,
       KOKKOS_LAMBDA(int i, typename ViewType::non_const_value_type &update) {
@@ -361,8 +361,8 @@ void adjacentDifference(ExecutionSpace &&space, SrcViewType const &src,
   auto const n = src.extent(0);
   ARBORX_ASSERT(n == dst.extent(0));
   ARBORX_ASSERT(src != dst);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
-      std::forward<ExecutionSpace>(space), 0, n};
+  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+      std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_for("adjacentDifference", policy, KOKKOS_LAMBDA(int i) {
     if (i > 0)
       dst(i) = src(i) - src(i - 1);

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -96,7 +96,7 @@ void exclusivePrefixSum(ExecutionSpace &&space,
 
   auto const n = src.extent(0);
   ARBORX_ASSERT(n == dst.extent(0));
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_scan(
       ARBORX_MARK_REGION("exclusive_scan"), policy,
@@ -181,7 +181,7 @@ void iota(ExecutionSpace &&space, Kokkos::View<T, P...> const &v,
                                   T, P...>::non_const_value_type>::value,
       "iota requires a View with non-const value type");
   auto const n = v.extent(0);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_for(ARBORX_MARK_REGION("iota"), policy,
                        KOKKOS_LAMBDA(int i) { v(i) = value + (ValueType)i; });
@@ -214,7 +214,7 @@ minMax(ExecutionSpace &&space, ViewType const &v)
   ARBORX_ASSERT(n > 0);
   Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
   Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(ARBORX_MARK_REGION("min_max"), policy,
                           Kokkos::Impl::min_max_functor<ViewType>(v), reducer);
@@ -244,7 +244,7 @@ typename ViewType::non_const_value_type min(ExecutionSpace &&space,
   ARBORX_ASSERT(n > 0);
   typename ViewType::non_const_value_type result;
   Kokkos::Min<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(ARBORX_MARK_REGION("min"), policy,
                           KOKKOS_LAMBDA(int i, int &update) {
@@ -277,7 +277,7 @@ typename ViewType::non_const_value_type max(ExecutionSpace &&space,
   ARBORX_ASSERT(n > 0);
   typename ViewType::non_const_value_type result;
   Kokkos::Max<typename ViewType::non_const_value_type> reducer(result);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(ARBORX_MARK_REGION("max"), policy,
                           KOKKOS_LAMBDA(int i, int &update) {
@@ -319,7 +319,7 @@ accumulate(ExecutionSpace &&space, ViewType const &v,
   // the reduction, introduce here a temporary variable and add it to init
   // before returning.
   typename ViewType::non_const_value_type tmp = 0;
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(
       ARBORX_MARK_REGION("accumulate"), policy,
@@ -372,7 +372,7 @@ void adjacentDifference(ExecutionSpace &&space, SrcViewType const &src,
   auto const n = src.extent(0);
   ARBORX_ASSERT(n == dst.extent(0));
   ARBORX_ASSERT(src != dst);
-  Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
+  Kokkos::RangePolicy<Details::remove_cvref_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_for(ARBORX_MARK_REGION("adjacent_difference"), policy,
                        KOKKOS_LAMBDA(int i) {

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -224,7 +224,7 @@ typename ViewType::non_const_value_type min(ExecutionSpace &&space,
   Kokkos::Min<typename ViewType::non_const_value_type> reducer(result);
   Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
       std::forward<ExecutionSpace>(space), 0, n};
-  Kokkos::parallel_reduce(policy,
+  Kokkos::parallel_reduce("min", policy,
                           KOKKOS_LAMBDA(int i, int &update) {
                             if (v(i) < update)
                               update = v(i);
@@ -257,7 +257,7 @@ typename ViewType::non_const_value_type max(ExecutionSpace &&space,
   Kokkos::Max<typename ViewType::non_const_value_type> reducer(result);
   Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy{
       std::forward<ExecutionSpace>(space), 0, n};
-  Kokkos::parallel_reduce(policy,
+  Kokkos::parallel_reduce("max", policy,
                           KOKKOS_LAMBDA(int i, int &update) {
                             if (v(i) > update)
                               update = v(i);

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -206,7 +206,7 @@ minMax(ExecutionSpace &&space, ViewType const &v)
   Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
   Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
-  Kokkos::parallel_reduce(ARBORX_MARK_REGION("minMax"), policy,
+  Kokkos::parallel_reduce(ARBORX_MARK_REGION("min_max"), policy,
                           Kokkos::Impl::min_max_functor<ViewType>(v), reducer);
   return std::make_pair(result.min_val, result.max_val);
 }
@@ -364,7 +364,7 @@ void adjacentDifference(ExecutionSpace &&space, SrcViewType const &src,
   ARBORX_ASSERT(src != dst);
   Kokkos::RangePolicy<std::remove_reference_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
-  Kokkos::parallel_for(ARBORX_MARK_REGION("adjacentDifference"), policy,
+  Kokkos::parallel_for(ARBORX_MARK_REGION("adjacent_difference"), policy,
                        KOKKOS_LAMBDA(int i) {
                          if (i > 0)
                            dst(i) = src(i) - src(i - 1);

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -416,13 +416,20 @@ typename View::non_const_type cloneWithoutInitializingNorCopying(View &v)
       Kokkos::ViewAllocateWithoutInitializing(v.label()), v.layout());
 }
 
-template <typename View>
-typename View::non_const_type clone(View &v)
+template <typename ExecutionSpace, typename View>
+typename View::non_const_type clone(ExecutionSpace &&space, View &v)
 {
   typename View::non_const_type w(
       Kokkos::ViewAllocateWithoutInitializing(v.label()), v.layout());
-  Kokkos::deep_copy(w, v);
+  Kokkos::deep_copy(std::forward<ExecutionSpace>(space), w, v);
   return w;
+}
+
+template <typename View>
+[[deprecated]] inline typename View::non_const_type clone(View &v)
+{
+  using ExecutionSpace = typename View::execution_space;
+  return clone(ExecutionSpace{}, v);
 }
 
 } // namespace ArborX

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -186,7 +186,8 @@ performQueries(RTree<Indexable> const &rtree, InputView const &queries)
   for (int i = 0; i < n_queries; ++i)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
-  ArborX::exclusivePrefixSum(offset);
+  using ExecutionSpace = typename InputView::execution_space;
+  ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);
   auto const n_results = ArborX::lastElement(offset);
   OutputView indices("indices", n_results);
   for (int i = 0; i < n_queries; ++i)
@@ -209,7 +210,8 @@ performQueries(ParallelRTree<Indexable> const &rtree, InputView const &queries)
   for (int i = 0; i < n_queries; ++i)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
-  ArborX::exclusivePrefixSum(offset);
+  using ExecutionSpace = typename InputView::execution_space;
+  ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);
   auto const n_results = ArborX::lastElement(offset);
   OutputView indices("indices", n_results);
   OutputView ranks("ranks", n_results);

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -15,7 +15,6 @@
 #include <ArborX_DetailsMortonCode.hpp> // expandBits, morton3D
 #include <ArborX_DetailsSortUtils.hpp>  // sortObjects
 #include <ArborX_DetailsTreeConstruction.hpp>
-#include <ArborX_DetailsUtils.hpp> // iota
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/tstDetailsUtils.cpp
+++ b/test/tstDetailsUtils.cpp
@@ -28,10 +28,12 @@ namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(iota, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace space{};
   int const n = 10;
   double const val = 3.;
   Kokkos::View<double *, DeviceType> v("v", n);
-  ArborX::iota(v, val);
+  ArborX::iota(space, v, val);
   std::vector<double> v_ref(n);
   std::iota(v_ref.begin(), v_ref.end(), val);
   auto v_host = Kokkos::create_mirror_view(v);
@@ -39,7 +41,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(iota, DeviceType, ARBORX_DEVICE_TYPES)
   BOOST_TEST(v_ref == v_host, tt::per_element());
 
   Kokkos::View<int[3], DeviceType> w("w");
-  ArborX::iota(w);
+  ArborX::iota(space, w);
   std::vector<int> w_ref = {0, 1, 2};
   auto w_host = Kokkos::create_mirror_view(w);
   Kokkos::deep_copy(w_host, w);
@@ -48,6 +50,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(iota, DeviceType, ARBORX_DEVICE_TYPES)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(prefix_sum, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace space{};
   int const n = 10;
   Kokkos::View<int *, DeviceType> x("x", n);
   std::vector<int> x_ref(n, 1);
@@ -57,7 +61,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(prefix_sum, DeviceType, ARBORX_DEVICE_TYPES)
     x_host(i) = x_ref[i];
   Kokkos::deep_copy(x, x_host);
   Kokkos::View<int *, DeviceType> y("y", n);
-  ArborX::exclusivePrefixSum(x, y);
+  ArborX::exclusivePrefixSum(space, x, y);
   std::vector<int> y_ref(n);
   std::iota(y_ref.begin(), y_ref.end(), 0);
   auto y_host = Kokkos::create_mirror_view(y);
@@ -66,31 +70,33 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(prefix_sum, DeviceType, ARBORX_DEVICE_TYPES)
   BOOST_TEST(y_host == y_ref, tt::per_element());
   BOOST_TEST(x_host == x_ref, tt::per_element());
   // in-place
-  ArborX::exclusivePrefixSum(x, x);
+  ArborX::exclusivePrefixSum(space, x, x);
   Kokkos::deep_copy(x_host, x);
   BOOST_TEST(x_host == y_ref, tt::per_element());
   int const m = 11;
   BOOST_TEST(n != m);
   Kokkos::View<int *, DeviceType> z("z", m);
-  BOOST_CHECK_THROW(ArborX::exclusivePrefixSum(x, z), ArborX::SearchException);
+  BOOST_CHECK_THROW(ArborX::exclusivePrefixSum(space, x, z),
+                    ArborX::SearchException);
   Kokkos::View<double[3], DeviceType> v("v");
   auto v_host = Kokkos::create_mirror_view(v);
   v_host(0) = 1.;
   v_host(1) = 1.;
   v_host(2) = 0.;
   Kokkos::deep_copy(v, v_host);
-  ArborX::exclusivePrefixSum(v);
+  ArborX::exclusivePrefixSum(space, v);
   Kokkos::deep_copy(v_host, v);
   std::vector<double> v_ref = {0., 1., 2.};
   BOOST_TEST(v_host == v_ref, tt::per_element());
   Kokkos::View<double *, DeviceType> w("w", 4);
-  BOOST_CHECK_THROW(ArborX::exclusivePrefixSum(v, w), ArborX::SearchException);
+  BOOST_CHECK_THROW(ArborX::exclusivePrefixSum(space, v, w),
+                    ArborX::SearchException);
   v_host(0) = 1.;
   v_host(1) = 0.;
   v_host(2) = 0.;
   Kokkos::deep_copy(v, v_host);
   Kokkos::resize(w, 3);
-  ArborX::exclusivePrefixSum(v, w);
+  ArborX::exclusivePrefixSum(space, v, w);
   auto w_host = Kokkos::create_mirror_view(w);
   Kokkos::deep_copy(w_host, w);
   std::vector<double> w_ref = {0., 1., 1.};
@@ -114,6 +120,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(last_element, DeviceType, ARBORX_DEVICE_TYPES)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(minmax, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace space{};
+
   Kokkos::View<double[4], DeviceType> v("v");
   auto v_host = Kokkos::create_mirror_view(v);
   v_host(0) = 3.14;
@@ -122,14 +131,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(minmax, DeviceType, ARBORX_DEVICE_TYPES)
   v_host(3) = 1.62;
   Kokkos::deep_copy(v, v_host);
 
-  auto const result_float = ArborX::minMax(v);
+  auto const result_float = ArborX::minMax(space, v);
   BOOST_TEST(std::get<0>(result_float) == 1.41);
   BOOST_TEST(std::get<1>(result_float) == 3.14);
   Kokkos::View<int *, DeviceType> w("w", 0);
-  BOOST_CHECK_THROW(ArborX::minMax(w), ArborX::SearchException);
+  BOOST_CHECK_THROW(ArborX::minMax(space, w), ArborX::SearchException);
   Kokkos::resize(w, 1);
   Kokkos::deep_copy(w, 255);
-  auto const result_int = ArborX::minMax(w);
+  auto const result_int = ArborX::minMax(space, w);
   BOOST_TEST(std::get<0>(result_int) == 255);
   BOOST_TEST(std::get<1>(result_int) == 255);
 
@@ -158,18 +167,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(minmax, DeviceType, ARBORX_DEVICE_TYPES)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(accumulate, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace space{};
+
   Kokkos::View<int[6], DeviceType> v("v");
   Kokkos::deep_copy(v, 5);
-  BOOST_TEST(ArborX::accumulate(v, 3) == 33);
+  BOOST_TEST(ArborX::accumulate(space, v, 3) == 33);
 
   Kokkos::View<int *, DeviceType> w("w", 5);
-  ArborX::iota(w, 2);
-  BOOST_TEST(ArborX::accumulate(w, 4) == 24);
+  ArborX::iota(space, w, 2);
+  BOOST_TEST(ArborX::accumulate(space, w, 4) == 24);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(adjacent_difference, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace space{};
+
   Kokkos::View<int[5], DeviceType> v("v");
   auto v_host = Kokkos::create_mirror_view(v);
   v_host(0) = 2;
@@ -179,9 +194,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(adjacent_difference, DeviceType,
   v_host(4) = 10;
   Kokkos::deep_copy(v, v_host);
   // In-place operation is not allowed
-  BOOST_CHECK_THROW(ArborX::adjacentDifference(v, v), ArborX::SearchException);
+  BOOST_CHECK_THROW(ArborX::adjacentDifference(space, v, v),
+                    ArborX::SearchException);
   auto w = Kokkos::create_mirror(DeviceType(), v);
-  BOOST_CHECK_NO_THROW(ArborX::adjacentDifference(v, w));
+  BOOST_CHECK_NO_THROW(ArborX::adjacentDifference(space, v, w));
   auto w_host = Kokkos::create_mirror_view(w);
   Kokkos::deep_copy(w_host, w);
   std::vector<int> w_ref(5, 2);
@@ -189,9 +205,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(adjacent_difference, DeviceType,
 
   Kokkos::View<float *, DeviceType> x("x", 10);
   Kokkos::deep_copy(x, 3.14);
-  BOOST_CHECK_THROW(ArborX::adjacentDifference(x, x), ArborX::SearchException);
+  BOOST_CHECK_THROW(ArborX::adjacentDifference(space, x, x),
+                    ArborX::SearchException);
   Kokkos::View<float[10], DeviceType> y("y");
-  BOOST_CHECK_NO_THROW(ArborX::adjacentDifference(x, y));
+  BOOST_CHECK_NO_THROW(ArborX::adjacentDifference(space, x, y));
   std::vector<float> y_ref(10);
   y_ref[0] = 3.14;
   auto y_host = Kokkos::create_mirror_view(y);
@@ -199,18 +216,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(adjacent_difference, DeviceType,
   BOOST_TEST(y_host == y_ref, tt::per_element());
 
   Kokkos::resize(x, 5);
-  BOOST_CHECK_THROW(ArborX::adjacentDifference(y, x), ArborX::SearchException);
+  BOOST_CHECK_THROW(ArborX::adjacentDifference(space, y, x),
+                    ArborX::SearchException);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(min_and_max, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace space{};
+
   Kokkos::View<int[4], DeviceType> v("v");
-  ArborX::iota(v);
-  BOOST_TEST(ArborX::min(v) == 0);
-  BOOST_TEST(ArborX::max(v) == 3);
+  ArborX::iota(space, v);
+  BOOST_TEST(ArborX::min(space, v) == 0);
+  BOOST_TEST(ArborX::max(space, v) == 3);
 
   Kokkos::View<int *, DeviceType> w("w", 7);
-  ArborX::iota(w, 2);
-  BOOST_TEST(ArborX::min(w) == 2);
-  BOOST_TEST(ArborX::max(w) == 8);
+  ArborX::iota(space, w, 2);
+  BOOST_TEST(ArborX::min(space, w) == 2);
+  BOOST_TEST(ArborX::max(space, w) == 8);
 }

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -286,11 +286,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(buffer_optimization, DeviceType,
   BOOST_CHECK_NO_THROW(bvh.query(queries, indices, offset));
   checkResultsAreFine();
 
+  using ExecutionSpace = typename DeviceType::execution_space;
   // compute number of results per query
   auto counts = ArborX::cloneWithoutInitializingNorCopying(offset);
-  ArborX::adjacentDifference(offset, counts);
+  ArborX::adjacentDifference(ExecutionSpace{}, offset, counts);
   // extract optimal buffer size
-  auto const max_results_per_query = ArborX::max(counts);
+  auto const max_results_per_query = ArborX::max(ExecutionSpace{}, counts);
   BOOST_TEST(max_results_per_query == 4);
 
   // optimal size


### PR DESCRIPTION
Deprecated older form to emit warnings rather than break code downstream