### PR TITLE
Template BVH on memory space

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -230,7 +230,8 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
 
   if (size() == 1)
   {
-    Kokkos::View<size_t *, MemorySpace> permutation_indices("permute", 1);
+    Kokkos::View<size_t *, MemorySpace> permutation_indices(
+        Kokkos::view_alloc("permute", space), 1);
     Details::TreeConstruction::initializeLeafNodes(
         space, primitives, permutation_indices, getLeafNodes());
     return;

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -38,8 +38,9 @@ class BoundingVolumeHierarchy
 {
 public:
   using memory_space = MemorySpace;
-  using bounding_volume_type = Box;
+  static_assert(Kokkos::is_memory_space<MemorySpace>::value, "");
   using size_type = typename MemorySpace::size_type;
+  using bounding_volume_type = Box;
 
   BoundingVolumeHierarchy() = default; // build an empty tree
 

--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -26,7 +26,7 @@
 namespace ArborX
 {
 
-template <typename DeviceType>
+template <typename DeviceType, typename Enable>
 class BoundingVolumeHierarchy;
 
 namespace Details
@@ -163,14 +163,15 @@ struct BoundingVolumeHierarchyImpl
   // Views are passed by reference here because internally Kokkos::realloc()
   // is called.
   template <typename ExecutionSpace, typename Predicates>
-  static void queryDispatch(SpatialPredicateTag,
-                            BoundingVolumeHierarchy<DeviceType> const &bvh,
-                            ExecutionSpace const &space,
-                            Predicates const &predicates,
-                            Kokkos::View<int *, DeviceType> &indices,
-                            Kokkos::View<int *, DeviceType> &offset,
-                            Experimental::TraversalPolicy const &policy =
-                                Experimental::TraversalPolicy())
+  static void
+  queryDispatch(SpatialPredicateTag,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
+                ExecutionSpace const &space, Predicates const &predicates,
+                Kokkos::View<int *, DeviceType> &indices,
+                Kokkos::View<int *, DeviceType> &offset,
+                Experimental::TraversalPolicy const &policy =
+                    Experimental::TraversalPolicy())
   {
     queryDispatch(SpatialPredicateTag{}, bvh, space, predicates,
                   CallbackDefaultSpatialPredicate{}, indices, offset, policy);
@@ -181,7 +182,8 @@ struct BoundingVolumeHierarchyImpl
   static std::enable_if_t<
       std::is_same<typename Callback::tag, InlineCallbackTag>::value>
   queryDispatch(SpatialPredicateTag,
-                BoundingVolumeHierarchy<DeviceType> const &bvh,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
                 ExecutionSpace const &space, Predicates const &predicates,
                 Callback const &callback, OutputView &out,
                 Kokkos::View<int *, DeviceType> &offset,
@@ -193,7 +195,8 @@ struct BoundingVolumeHierarchyImpl
   static std::enable_if_t<
       std::is_same<typename Callback::tag, PostCallbackTag>::value>
   queryDispatch(SpatialPredicateTag,
-                BoundingVolumeHierarchy<DeviceType> const &bvh,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
                 ExecutionSpace const &space, Predicates const &predicates,
                 Callback const &callback, OutputView &out,
                 Kokkos::View<int *, DeviceType> &offset,
@@ -211,7 +214,8 @@ struct BoundingVolumeHierarchyImpl
   static std::enable_if_t<
       std::is_same<typename Callback::tag, InlineCallbackTag>::value>
   queryDispatch(NearestPredicateTag,
-                BoundingVolumeHierarchy<DeviceType> const &bvh,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
                 ExecutionSpace const &space, Predicates const &predicates,
                 Callback const &callback, OutputView &out,
                 Kokkos::View<int *, DeviceType> &offset,
@@ -223,7 +227,8 @@ struct BoundingVolumeHierarchyImpl
   static std::enable_if_t<
       std::is_same<typename Callback::tag, PostCallbackTag>::value>
   queryDispatch(NearestPredicateTag,
-                BoundingVolumeHierarchy<DeviceType> const &bvh,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
                 ExecutionSpace const &space, Predicates const &predicates,
                 Callback const &callback, OutputView &out,
                 Kokkos::View<int *, DeviceType> &offset,
@@ -239,29 +244,31 @@ struct BoundingVolumeHierarchyImpl
   }
 
   template <typename ExecutionSpace, typename Predicates>
-  static void queryDispatch(NearestPredicateTag,
-                            BoundingVolumeHierarchy<DeviceType> const &bvh,
-                            ExecutionSpace const &space,
-                            Predicates const &predicates,
-                            Kokkos::View<int *, DeviceType> &indices,
-                            Kokkos::View<int *, DeviceType> &offset,
-                            Experimental::TraversalPolicy const &policy =
-                                Experimental::TraversalPolicy())
+  static void
+  queryDispatch(NearestPredicateTag,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
+                ExecutionSpace const &space, Predicates const &predicates,
+                Kokkos::View<int *, DeviceType> &indices,
+                Kokkos::View<int *, DeviceType> &offset,
+                Experimental::TraversalPolicy const &policy =
+                    Experimental::TraversalPolicy())
   {
     queryDispatch(NearestPredicateTag{}, bvh, space, predicates,
                   CallbackDefaultNearestPredicate{}, indices, offset, policy);
   }
 
   template <typename ExecutionSpace, typename Predicates>
-  static void queryDispatch(NearestPredicateTag,
-                            BoundingVolumeHierarchy<DeviceType> const &bvh,
-                            ExecutionSpace const &space,
-                            Predicates const &predicates,
-                            Kokkos::View<int *, DeviceType> &indices,
-                            Kokkos::View<int *, DeviceType> &offset,
-                            Kokkos::View<float *, DeviceType> &distances,
-                            Experimental::TraversalPolicy const &policy =
-                                Experimental::TraversalPolicy())
+  static void
+  queryDispatch(NearestPredicateTag,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
+                ExecutionSpace const &space, Predicates const &predicates,
+                Kokkos::View<int *, DeviceType> &indices,
+                Kokkos::View<int *, DeviceType> &offset,
+                Kokkos::View<float *, DeviceType> &distances,
+                Experimental::TraversalPolicy const &policy =
+                    Experimental::TraversalPolicy())
   {
     Kokkos::View<Kokkos::pair<int, float> *, DeviceType> out(
         "pairs_index_distance", 0);
@@ -285,7 +292,8 @@ template <typename ExecutionSpace, typename Predicates, typename OutputView,
           typename Callback>
 std::enable_if_t<std::is_same<typename Callback::tag, InlineCallbackTag>::value>
 BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
-    NearestPredicateTag, BoundingVolumeHierarchy<DeviceType> const &bvh,
+    NearestPredicateTag,
+    BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const &bvh,
     ExecutionSpace const &space, Predicates const &predicates,
     Callback const &callback, OutputView &out,
     Kokkos::View<int *, DeviceType> &offset,
@@ -433,7 +441,8 @@ template <typename ExecutionSpace, typename Predicates, typename OutputView,
           typename Callback>
 std::enable_if_t<std::is_same<typename Callback::tag, InlineCallbackTag>::value>
 BoundingVolumeHierarchyImpl<DeviceType>::queryDispatch(
-    SpatialPredicateTag, BoundingVolumeHierarchy<DeviceType> const &bvh,
+    SpatialPredicateTag,
+    BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const &bvh,
     ExecutionSpace const &space, Predicates const &predicates,
     Callback const &callback, OutputView &out,
     Kokkos::View<int *, DeviceType> &offset,

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -21,7 +21,7 @@
 namespace ArborX
 {
 
-template <typename DeviceType>
+template <typename DeviceType, typename Enable>
 class BoundingVolumeHierarchy;
 
 namespace Details
@@ -34,8 +34,9 @@ public:
 
   template <typename Predicate, typename... Args>
   KOKKOS_INLINE_FUNCTION static int
-  query(BoundingVolumeHierarchy<DeviceType> const &bvh, Predicate const &pred,
-        Args &&... args)
+  query(BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
+            &bvh,
+        Predicate const &pred, Args &&... args)
   {
     using Tag = typename Predicate::Tag;
     return queryDispatch(Tag{}, bvh, pred, std::forward<Args>(args)...);
@@ -46,7 +47,8 @@ public:
   // documentation).
   template <typename Predicate, typename Insert>
   KOKKOS_FUNCTION static int
-  spatialQuery(BoundingVolumeHierarchy<DeviceType> const &bvh,
+  spatialQuery(BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                       void> const &bvh,
                Predicate const &predicate, Insert const &insert)
   {
     if (bvh.empty())
@@ -96,7 +98,8 @@ public:
   // query k nearest neighbours
   template <typename Distance, typename Insert, typename Buffer>
   KOKKOS_FUNCTION static int
-  nearestQuery(BoundingVolumeHierarchy<DeviceType> const &bvh,
+  nearestQuery(BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                       void> const &bvh,
                Distance const &distance, std::size_t k, Insert const &insert,
                Buffer const &buffer)
   {
@@ -220,7 +223,8 @@ public:
     // version with a stack.
     template <typename Distance, typename Insert>
     KOKKOS_FUNCTION static int
-    nearestQuery(BoundingVolumeHierarchy<DeviceType> const &bvh,
+    nearestQuery(BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                         void> const &bvh,
                  Distance const &distance, std::size_t k, Insert const &insert)
     {
       if (bvh.empty() || k < 1)
@@ -283,7 +287,8 @@ public:
   template <typename Predicate, typename Insert>
   KOKKOS_INLINE_FUNCTION static int
   queryDispatch(SpatialPredicateTag,
-                BoundingVolumeHierarchy<DeviceType> const &bvh,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
                 Predicate const &pred, Insert const &insert)
   {
     return spatialQuery(bvh, pred, insert);
@@ -291,7 +296,9 @@ public:
 
   template <typename Predicate, typename Insert, typename Buffer>
   KOKKOS_INLINE_FUNCTION static int queryDispatch(
-      NearestPredicateTag, BoundingVolumeHierarchy<DeviceType> const &bvh,
+      NearestPredicateTag,
+      BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
+          &bvh,
       Predicate const &pred, Insert const &insert, Buffer const &buffer)
   {
     auto const geometry = getGeometry(pred);
@@ -309,7 +316,8 @@ public:
   template <typename Predicate, typename Insert>
   KOKKOS_INLINE_FUNCTION static int
   queryDispatch(NearestPredicateTag,
-                BoundingVolumeHierarchy<DeviceType> const &bvh,
+                BoundingVolumeHierarchy<typename DeviceType::memory_space,
+                                        void> const &bvh,
                 Predicate const &pred, Insert const &insert)
   {
     auto const geometry = getGeometry(pred);

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -20,7 +20,7 @@
 namespace ArborX
 {
 
-template <typename DeviceType>
+template <typename DeviceType, typename Enable>
 class BoundingVolumeHierarchy;
 
 namespace Details
@@ -46,8 +46,10 @@ struct TreeVisualization
   struct TreeAccess
   {
     KOKKOS_INLINE_FUNCTION
-    static Node const *getLeaf(BoundingVolumeHierarchy<DeviceType> const &bvh,
-                               size_t index)
+    static Node const *getLeaf(
+        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
+            &bvh,
+        size_t index)
     {
       auto leaf_nodes = bvh.getLeafNodes();
       Node const *first = leaf_nodes.data();
@@ -59,22 +61,28 @@ struct TreeVisualization
     }
 
     KOKKOS_INLINE_FUNCTION
-    static int getIndex(Node const *node,
-                        BoundingVolumeHierarchy<DeviceType> const &bvh)
+    static int getIndex(
+        Node const *node,
+        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
+            &bvh)
     {
       return node->isLeaf() ? node->getLeafPermutationIndex()
                             : node - bvh.getRoot();
     }
 
     KOKKOS_INLINE_FUNCTION
-    static Node const *getRoot(BoundingVolumeHierarchy<DeviceType> const &bvh)
+    static Node const *getRoot(
+        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
+            &bvh)
     {
       return bvh.getRoot();
     }
 
     KOKKOS_INLINE_FUNCTION
-    static Node const *
-    getNodePtr(BoundingVolumeHierarchy<DeviceType> const &bvh, int index)
+    static Node const *getNodePtr(
+        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
+            &bvh,
+        int index)
     {
       return bvh.getNodePtr(index);
     }


### PR DESCRIPTION
Constructor and query() take execution space as first argument.

Old syntax is still valid for now.