### PR TITLE
Cleanup Kokkos::{Impl:: -> }::SpaceAccesibility<Space, MemorySpace>

### DIFF
--- a/src/details/ArborX_DetailsKokkosExt.hpp
+++ b/src/details/ArborX_DetailsKokkosExt.hpp
@@ -38,10 +38,10 @@ struct is_accessible_from : std::false_type
 };
 
 template <typename MemorySpace, typename ExecutionSpace>
-struct is_accessible_from<
-    MemorySpace, ExecutionSpace,
-    typename std::enable_if<Kokkos::Impl::SpaceAccessibility<
-        ExecutionSpace, MemorySpace>::accessible>::type> : std::true_type
+struct is_accessible_from<MemorySpace, ExecutionSpace,
+                          typename std::enable_if<Kokkos::SpaceAccessibility<
+                              ExecutionSpace, MemorySpace>::accessible>::type>
+    : std::true_type
 {
 };
 

--- a/test/ArborX_BoostRangeAdapters.hpp
+++ b/test/ArborX_BoostRangeAdapters.hpp
@@ -23,15 +23,13 @@
 
 namespace boost
 {
-// TODO SpaceAccessibility has been promoted to Kokkos:: namespace in later
-// versions of Kokkos so eventually get rid of Impl::
 #define ARBORX_ASSERT_VIEW_COMPATIBLE(View)                                    \
   using Traits = typename View::traits;                                        \
   static_assert(Traits::rank == 1,                                             \
                 "Adaptor to Boost.Range only available for Views of rank 1");  \
   static_assert(                                                               \
-      Kokkos::Impl::SpaceAccessibility<                                        \
-          Kokkos::HostSpace, typename Traits::memory_space>::accessible,       \
+      Kokkos::SpaceAccessibility<Kokkos::HostSpace,                            \
+                                 typename Traits::memory_space>::accessible,   \
       "Adaptor to Boost.Range only available when View memory space is "       \
       "accessible from host");
 

--- a/test/tstDetailsDistributedSearchTreeImpl.cpp
+++ b/test/tstDetailsDistributedSearchTreeImpl.cpp
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(create_layout_right_mirror_view, DeviceType,
   using Kokkos::subview;
   using Kokkos::View;
 
-  if (!Kokkos::Impl::SpaceAccessibility<
+  if (!Kokkos::SpaceAccessibility<
           Kokkos::HostSpace, typename DeviceType::memory_space>::accessible)
     return;
 

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_prefix, DeviceType, ARBORX_DEVICE_TYPES)
 BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  if (!Kokkos::Impl::SpaceAccessibility<
+  if (!Kokkos::SpaceAccessibility<
           Kokkos::HostSpace, typename DeviceType::memory_space>::accessible)
     return;
 


### PR DESCRIPTION
`SpaceAccesibilty` has been promoted to the `Kokkos ::` namespace a while ago and we require version 3.0

It is only in `Impl::` for backward compatibility, we do not need to wait for Kokkos to deprecate it to act.