### PR TITLE
Stop pretending we can cherry-pick Kokkos headers

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -17,7 +17,7 @@
 #include <ArborX_DetailsUtils.hpp> // accumulate
 #include <ArborX_LinearBVH.hpp>
 
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <mpi.h>
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -22,8 +22,7 @@
 #include <ArborX_DetailsTreeConstruction.hpp>
 #include <ArborX_Traits.hpp>
 
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 namespace ArborX
 {

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -21,8 +21,6 @@
 #include <ArborX_Traits.hpp>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_View.hpp>
 
 #include <tuple>
 

--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -20,8 +20,7 @@
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Traits.hpp>
 
-#include <Kokkos_Pair.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 namespace ArborX
 {

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -20,11 +20,7 @@
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_Predicates.hpp>
 
-#include <Kokkos_Atomic.hpp>
-#include <Kokkos_HostSpace.hpp>
-#include <Kokkos_Pair.hpp>
-#include <Kokkos_Sort.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <mpi.h>
 

--- a/src/details/ArborX_DetailsKokkosExt.hpp
+++ b/src/details/ArborX_DetailsKokkosExt.hpp
@@ -11,8 +11,7 @@
 #ifndef ARBORX_DETAILS_KOKKOS_EXT_HPP
 #define ARBORX_DETAILS_KOKKOS_EXT_HPP
 
-#include <Kokkos_Concepts.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <cfloat>  // DBL_MAX, DBL_EPSILON
 #include <cmath>   // isfinite, HUGE_VAL

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -16,8 +16,8 @@
 #include <ArborX_Exception.hpp>
 #include <ArborX_Macros.hpp>
 
+#include <Kokkos_Core.hpp>
 #include <Kokkos_Sort.hpp> // min_max_functor
-#include <Kokkos_View.hpp>
 
 // clang-format off
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -13,7 +13,7 @@
 
 #include <ArborX_DetailsTreeTraversal.hpp>
 
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <tuple> // ignore
 

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -15,9 +15,8 @@
 #include <ArborX_Exception.hpp>
 #include <ArborX_Macros.hpp>
 
-#include <Kokkos_Parallel.hpp>
+#include <Kokkos_Core.hpp>
 #include <Kokkos_Sort.hpp> // min_max_functor
-#include <Kokkos_View.hpp>
 
 namespace ArborX
 {

--- a/src/details/ArborX_Traits.hpp
+++ b/src/details/ArborX_Traits.hpp
@@ -16,7 +16,7 @@
 #include <ArborX_DetailsTags.hpp>
 #include <ArborX_Point.hpp>
 
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 namespace ArborX
 {

--- a/test/ArborX_BoostRangeAdapters.hpp
+++ b/test/ArborX_BoostRangeAdapters.hpp
@@ -14,8 +14,7 @@
 
 #include <ArborX_Exception.hpp>
 
-#include <Kokkos_Concepts.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <boost/range.hpp>
 

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -26,8 +26,6 @@
 #endif
 #include <ArborX_LinearBVH.hpp>
 
-#include <Kokkos_View.hpp>
-
 #include <boost/test/unit_test.hpp>
 
 #include <iostream>


### PR DESCRIPTION
The only headers other than `<Kokkos_Core.hpp>` that may be included specifically are `Kokkos_Macros.hpp` or things like `Kokkos_Pair.hpp` or `Kokkos_Array.hpp`