### PR TITLE
Use execution_space in Kokkos::parallel_ and Kokkos::deep_copy

### DIFF
--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -54,7 +54,8 @@ public:
                               Predicates const &predicates)
   {
     Kokkos::View<Box, DeviceType> bounds("bounds");
-    Kokkos::deep_copy(bounds, scene_bounding_box);
+    // doesn't compile
+    Kokkos::deep_copy(/*space,*/ bounds, scene_bounding_box);
     return sortQueriesAlongZOrderCurve(space, bounds, predicates);
   }
 

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -54,7 +54,7 @@ public:
                               Predicates const &predicates)
   {
     Kokkos::View<Box, DeviceType> bounds("bounds");
-    // doesn't compile
+    // FIXME doesn't compile
     Kokkos::deep_copy(/*space,*/ bounds, scene_bounding_box);
     return sortQueriesAlongZOrderCurve(space, bounds, predicates);
   }

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -258,7 +258,8 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 #ifndef ARBORX_USE_CUDA_AWARE_MPI
   (void)space;
   auto exports_host = create_layout_right_mirror_view(exports);
-  Kokkos::deep_copy(exports_host, exports);
+  // doesn't work yet
+  Kokkos::deep_copy(/*space,*/ exports_host, exports);
 
   auto imports_host = create_layout_right_mirror_view(imports);
 
@@ -275,8 +276,8 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 
   distributor.doPostsAndWaits(Kokkos::DefaultHostExecutionSpace{},
                               export_buffer, num_packets, import_buffer);
-
-  Kokkos::deep_copy(imports, imports_host);
+  // doesn't work yet
+  Kokkos::deep_copy(/*space,*/ imports, imports_host);
 #else
   distributor.doPostsAndWaits(space, exports, num_packets, imports);
 #endif
@@ -594,7 +595,7 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
 
   Kokkos::View<int *, DeviceType> export_ranks(
       Kokkos::ViewAllocateWithoutInitializing("export_ranks"), n_exports);
-  Kokkos::deep_copy(export_ranks, comm_rank);
+  Kokkos::deep_copy(space, export_ranks, comm_rank);
 
   Kokkos::View<int *, DeviceType> import_ranks(
       Kokkos::ViewAllocateWithoutInitializing("import_ranks"), n_imports);
@@ -646,7 +647,7 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
 
   Kokkos::View<int *, DeviceType> export_ranks(
       Kokkos::ViewAllocateWithoutInitializing(ranks.label()), n_exports);
-  Kokkos::deep_copy(export_ranks, comm_rank);
+  Kokkos::deep_copy(space, export_ranks, comm_rank);
   Kokkos::View<int *, DeviceType> export_ids(
       Kokkos::ViewAllocateWithoutInitializing(ids.label()), n_exports);
   Kokkos::parallel_for(

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -258,7 +258,7 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 #ifndef ARBORX_USE_CUDA_AWARE_MPI
   (void)space;
   auto exports_host = create_layout_right_mirror_view(exports);
-  // doesn't work yet
+  // FIXME doesn't work yet
   Kokkos::deep_copy(/*space,*/ exports_host, exports);
 
   auto imports_host = create_layout_right_mirror_view(imports);
@@ -276,7 +276,7 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 
   distributor.doPostsAndWaits(Kokkos::DefaultHostExecutionSpace{},
                               export_buffer, num_packets, import_buffer);
-  // doesn't work yet
+  // FIXME doesn't work yet
   Kokkos::deep_copy(/*space,*/ imports, imports_host);
 #else
   distributor.doPostsAndWaits(space, exports, num_packets, imports);

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -256,6 +256,7 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
                            exports.extent(7);
 
 #ifndef ARBORX_USE_CUDA_AWARE_MPI
+  (void)space;
   auto exports_host = create_layout_right_mirror_view(exports);
   Kokkos::deep_copy(exports_host, exports);
 
@@ -272,7 +273,8 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
                Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       import_buffer(imports_host.data(), imports_host.size());
 
-  distributor.doPostsAndWaits(space, export_buffer, num_packets, import_buffer);
+  distributor.doPostsAndWaits(Kokkos::DefaultHostExecutionSpace{},
+                              export_buffer, num_packets, import_buffer);
 
   Kokkos::deep_copy(imports, imports_host);
 #else

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -308,7 +308,7 @@ public:
 
     // make sure the data in dest_buffer has been copied before sending it.
     if (permutation_necessary)
-      ExecutionSpace().fence();
+      space.fence();
 
     for (int i = 0; i < outdegrees; ++i)
     {

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -153,7 +153,7 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
 
   Kokkos::View<int *, DeviceType> device_ranks_duplicate(
       Kokkos::ViewAllocateWithoutInitializing(ranks.label()), ranks.size());
-  Kokkos::deep_copy(device_ranks_duplicate, ranks);
+  Kokkos::deep_copy(space, device_ranks_duplicate, ranks);
   auto device_permutation_indices =
       Kokkos::create_mirror_view(DeviceType(), permutation_indices);
   int offset = 0;
@@ -187,7 +187,8 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
   counts.reserve(offsets.size() - 1);
   for (unsigned int i = 1; i < offsets.size(); ++i)
     counts.push_back(offsets[i] - offsets[i - 1]);
-  Kokkos::deep_copy(permutation_indices, device_permutation_indices);
+  // doesn't work yet
+  Kokkos::deep_copy(/*space,*/ permutation_indices, device_permutation_indices);
   ARBORX_ASSERT(offsets.back() == static_cast<int>(ranks.size()));
 }
 
@@ -332,7 +333,7 @@ public:
         Kokkos::View<const ValueType *, typename View::traits::device_type,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>
             send_view(send_buffer_ptr, message_size / sizeof(ValueType));
-        Kokkos::deep_copy(receive_view, send_view);
+        Kokkos::deep_copy(space, receive_view, send_view);
       }
       else
       {

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -131,7 +131,6 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
                                          std::vector<int> &counts,
                                          std::vector<int> &offsets)
 {
-  static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
   ARBORX_ASSERT(unique_ranks.empty());
   ARBORX_ASSERT(offsets.empty());
   ARBORX_ASSERT(counts.empty());
@@ -159,8 +158,7 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
   int offset = 0;
   while (true)
   {
-    int const largest_rank =
-        ArborX::max(ExecutionSpace{}, device_ranks_duplicate);
+    int const largest_rank = ArborX::max(space, device_ranks_duplicate);
     if (largest_rank == -1)
       break;
     unique_ranks.push_back(largest_rank);
@@ -187,7 +185,7 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
   counts.reserve(offsets.size() - 1);
   for (unsigned int i = 1; i < offsets.size(); ++i)
     counts.push_back(offsets[i] - offsets[i - 1]);
-  // doesn't work yet
+  // FIXME doesn't work yet
   Kokkos::deep_copy(/*space,*/ permutation_indices, device_permutation_indices);
   ARBORX_ASSERT(offsets.back() == static_cast<int>(ranks.size()));
 }

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -17,7 +17,7 @@
 #include <ArborX_Exception.hpp>
 #include <ArborX_Macros.hpp>
 
-#include <Kokkos_Core.hpp> // FIXME
+#include <Kokkos_Core.hpp>
 
 #include <algorithm> // max_element
 #include <numeric>   // iota

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -141,7 +141,8 @@ lastElement(Kokkos::View<T, P...> const &v)
   ARBORX_ASSERT(n > 0);
   auto v_subview = Kokkos::subview(v, n - 1);
   auto v_host = Kokkos::create_mirror_view(v_subview);
-  Kokkos::deep_copy(v_host, v_subview);
+  Kokkos::deep_copy(typename Kokkos::View<T, P...>::execution_space{}, v_host,
+                    v_subview);
   return v_host();
 }
 

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -141,8 +141,7 @@ lastElement(Kokkos::View<T, P...> const &v)
   ARBORX_ASSERT(n > 0);
   auto v_subview = Kokkos::subview(v, n - 1);
   auto v_host = Kokkos::create_mirror_view(v_subview);
-  Kokkos::deep_copy(typename Kokkos::View<T, P...>::execution_space{}, v_host,
-                    v_subview);
+  Kokkos::deep_copy(v_host, v_subview);
   return v_host();
 }
 

--- a/test/tstDetailsDistributedSearchTreeImpl.cpp
+++ b/test/tstDetailsDistributedSearchTreeImpl.cpp
@@ -288,7 +288,9 @@ void checkBufferLayout(std::vector<int> const &ranks,
   std::vector<int> unique;
   std::vector<int> counts;
   std::vector<int> offsets;
+  Kokkos::DefaultHostExecutionSpace space;
   ArborX::Details::sortAndDetermineBufferLayout(
+      space,
       Kokkos::View<int const *, Kokkos::HostSpace,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ranks.data(),
                                                             ranks.size()),


### PR DESCRIPTION
In particular, this should deal with `Distributor`.
The cases that don't work yet are marked (most likely due to the bug reported by @dalg24 in `Kokkos`).