### PR TITLE
Kokkos 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(ArborX CXX)
 
-find_package(Kokkos 3.0 REQUIRED QUIET)
+find_package(Kokkos 3.1 REQUIRED QUIET)
 if(Kokkos_ENABLE_CUDA)
   kokkos_check(OPTIONS CUDA_LAMBDA)
 endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,7 +127,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 ENV LD_LIBRARY_PATH=/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}
 
 # Install Kokkos
-ARG KOKKOS_VERSION=3.0.00
+ARG KOKKOS_VERSION=3.1.00
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \

--- a/docker/Dockerfile.pgi
+++ b/docker/Dockerfile.pgi
@@ -89,7 +89,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     rm -rf ${SCRATCH_DIR}
 
 # Install Kokkos
-ARG KOKKOS_VERSION=3.0.00
+ARG KOKKOS_VERSION=3.1.00
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_PROFILING=OFF -DKokkos_ENABLE_LIBDL=OFF"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \

--- a/docs/build.md
+++ b/docs/build.md
@@ -2,7 +2,7 @@
 
 Dependency | Version | Required           | Runtime
 ---        | ---     | ---                | ---
-Kokkos     | 3.0.00  | :heavy_check_mark: | :heavy_check_mark:
+Kokkos     | 3.1.00  | :heavy_check_mark: | :heavy_check_mark:
 MPI        | 2       |                    | :heavy_check_mark:
 CMake      | 3.12    | :heavy_check_mark: |
 

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -136,8 +136,7 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
   MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
                 static_cast<void *>(boxes_host.data()), sizeof(Box), MPI_BYTE,
                 _comm);
-  // FIXME bug in Kokkos that should be fixed in 3.1
-  Kokkos::deep_copy(/*space,*/ boxes, boxes_host);
+  Kokkos::deep_copy(space, boxes, boxes_host);
 
   _top_tree = BVH<MemorySpace>{space, boxes};
 
@@ -149,8 +148,7 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
   MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
                 static_cast<void *>(bottom_tree_sizes_host.data()),
                 sizeof(size_type), MPI_BYTE, _comm);
-  // FIXME
-  Kokkos::deep_copy(/*space,*/ _bottom_tree_sizes, bottom_tree_sizes_host);
+  Kokkos::deep_copy(space, _bottom_tree_sizes, bottom_tree_sizes_host);
 
   _top_tree_size = accumulate(space, _bottom_tree_sizes, 0);
 }

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -155,7 +155,7 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
 
 template <typename DeviceType>
 class DistributedSearchTree<
-    DeviceType, std::enable_if_t<Details::is_device_type<DeviceType>::value>>
+    DeviceType, std::enable_if_t<Kokkos::is_device<DeviceType>::value>>
     : public DistributedSearchTree<typename DeviceType::memory_space>
 {
 public:

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -155,7 +155,7 @@ using is_device_type = typename is_device_type_impl<std::remove_cv_t<T>>::type;
 
 template <typename DeviceType>
 class BoundingVolumeHierarchy<
-    DeviceType, std::enable_if_t<Details::is_device_type<DeviceType>::value>>
+    DeviceType, std::enable_if_t<Kokkos::is_device<DeviceType>::value>>
     : public BoundingVolumeHierarchy<typename DeviceType::memory_space>
 {
 public:

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -138,21 +138,6 @@ private:
   Kokkos::View<Node *, MemorySpace> _internal_and_leaf_nodes;
 };
 
-namespace Details
-{
-template <typename T>
-struct is_device_type_impl : std::false_type
-{
-};
-template <typename ExecutionSpace, typename MemorySpace>
-struct is_device_type_impl<Kokkos::Device<ExecutionSpace, MemorySpace>>
-    : std::true_type
-{
-};
-template <typename T>
-using is_device_type = typename is_device_type_impl<std::remove_cv_t<T>>::type;
-} // namespace Details
-
 template <typename DeviceType>
 class BoundingVolumeHierarchy<
     DeviceType, std::enable_if_t<Kokkos::is_device<DeviceType>::value>>

--- a/src/details/ArborX_Box.hpp
+++ b/src/details/ArborX_Box.hpp
@@ -25,7 +25,7 @@ namespace ArborX
  */
 struct Box
 {
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   constexpr Box() = default;
 
   KOKKOS_INLINE_FUNCTION

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -54,8 +54,7 @@ public:
                               Predicates const &predicates)
   {
     Kokkos::View<Box, DeviceType> bounds("bounds");
-    // FIXME doesn't compile
-    Kokkos::deep_copy(/*space,*/ bounds, scene_bounding_box);
+    Kokkos::deep_copy(space, bounds, scene_bounding_box);
     return sortQueriesAlongZOrderCurve(space, bounds, predicates);
   }
 

--- a/src/details/ArborX_DetailsContainers.hpp
+++ b/src/details/ArborX_DetailsContainers.hpp
@@ -35,7 +35,7 @@ class StaticVector
     using const_reference = value_type const &;
     using pointer = value_type *;
     using const_pointer = value_type const *;
-    KOKKOS_FUNCTION StaticVector() = default;
+    KOKKOS_DEFAULTED_FUNCTION StaticVector() = default;
     KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
     KOKKOS_INLINE_FUNCTION size_type size() const { return _size; }
     KOKKOS_INLINE_FUNCTION constexpr size_type maxSize() const { return N; }

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -264,8 +264,7 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 #ifndef ARBORX_USE_CUDA_AWARE_MPI
   (void)space;
   auto exports_host = create_layout_right_mirror_view(exports);
-  // FIXME doesn't work yet
-  Kokkos::deep_copy(/*space,*/ exports_host, exports);
+  Kokkos::deep_copy(space, exports_host, exports);
 
   auto imports_host = create_layout_right_mirror_view(imports);
 
@@ -282,8 +281,7 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
 
   distributor.doPostsAndWaits(Kokkos::DefaultHostExecutionSpace{},
                               export_buffer, num_packets, import_buffer);
-  // FIXME doesn't work yet
-  Kokkos::deep_copy(/*space,*/ imports, imports_host);
+  Kokkos::deep_copy(space, imports, imports_host);
 #else
   distributor.doPostsAndWaits(space, exports, num_packets, imports);
 #endif

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -185,8 +185,7 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
   counts.reserve(offsets.size() - 1);
   for (unsigned int i = 1; i < offsets.size(); ++i)
     counts.push_back(offsets[i] - offsets[i - 1]);
-  // FIXME doesn't work yet
-  Kokkos::deep_copy(/*space,*/ permutation_indices, device_permutation_indices);
+  Kokkos::deep_copy(space, permutation_indices, device_permutation_indices);
   ARBORX_ASSERT(offsets.back() == static_cast<int>(ranks.size()));
 }
 

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -24,7 +24,7 @@ namespace Details
 {
 struct Node
 {
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   constexpr Node() = default;
 
   KOKKOS_INLINE_FUNCTION constexpr bool isLeaf() const noexcept

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -61,7 +61,7 @@ public:
                 "the type of the elements stored by the underlying "
                 "container Container::value_type");
 
-  KOKKOS_FUNCTION PriorityQueue() = default;
+  KOKKOS_DEFAULTED_FUNCTION PriorityQueue() = default;
 
   KOKKOS_FUNCTION PriorityQueue(Container const &c)
       : _c(c)

--- a/src/details/ArborX_DetailsStack.hpp
+++ b/src/details/ArborX_DetailsStack.hpp
@@ -37,7 +37,7 @@ public:
                 "the type of the elements stored by the underlying "
                 "container Container::value_type");
 
-  KOKKOS_FUNCTION Stack() = default;
+  KOKKOS_DEFAULTED_FUNCTION Stack() = default;
 
   // Capacity
   KOKKOS_INLINE_FUNCTION bool empty() const { return _c.empty(); }

--- a/src/details/ArborX_Point.hpp
+++ b/src/details/ArborX_Point.hpp
@@ -32,7 +32,7 @@ private:
   };
 
 public:
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   constexpr Point() noexcept = default;
 
   KOKKOS_INLINE_FUNCTION

--- a/src/details/ArborX_Predicates.hpp
+++ b/src/details/ArborX_Predicates.hpp
@@ -31,7 +31,7 @@ struct Nearest
 {
   using Tag = Details::NearestPredicateTag;
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   Nearest() = default;
 
   KOKKOS_INLINE_FUNCTION
@@ -50,7 +50,7 @@ struct Intersects
 {
   using Tag = Details::SpatialPredicateTag;
 
-  KOKKOS_INLINE_FUNCTION Intersects() = default;
+  KOKKOS_DEFAULTED_FUNCTION Intersects() = default;
 
   KOKKOS_INLINE_FUNCTION Intersects(Geometry const &geometry)
       : _geometry(geometry)
@@ -102,7 +102,7 @@ getGeometry(Intersects<Geometry> const &pred)
 template <typename Predicate, typename Data>
 struct PredicateWithAttachment : Predicate
 {
-  KOKKOS_INLINE_FUNCTION PredicateWithAttachment() = default;
+  KOKKOS_DEFAULTED_FUNCTION PredicateWithAttachment() = default;
   KOKKOS_INLINE_FUNCTION PredicateWithAttachment(Predicate const &pred,
                                                  Data const &data)
       : Predicate{pred}

--- a/src/details/ArborX_Sphere.hpp
+++ b/src/details/ArborX_Sphere.hpp
@@ -20,7 +20,7 @@ namespace ArborX
 
 struct Sphere
 {
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   Sphere() = default;
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
The main motivation for updating to 3.1 it to allow HIP backend. We could have done magic to still work with 3.0, but we decided not to bear cost of supporting that.