### PR TITLE
Retain the original path to Kokkos

### DIFF
--- a/cmake/ArborXConfig.cmake.in
+++ b/cmake/ArborXConfig.cmake.in
@@ -4,10 +4,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
 include(CMakeFindDependencyMacro)
 
-if(NOT DEFINED Kokkos_DIR)
+find_package(Kokkos QUIET)
+if(NOT Kokkos_FOUND)
+  # If Kokkos was not found, try to use Kokkos used when building ArborX
   set(Kokkos_DIR @Kokkos_DIR@)
+  find_dependency(Kokkos)
 endif()
-find_dependency(Kokkos)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArborXSettings.cmake")
 if(ARBORX_ENABLE_MPI)

--- a/cmake/ArborXConfig.cmake.in
+++ b/cmake/ArborXConfig.cmake.in
@@ -3,6 +3,10 @@
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
 include(CMakeFindDependencyMacro)
+
+if(NOT DEFINED Kokkos_DIR)
+  set(Kokkos_DIR @Kokkos_DIR@)
+endif()
 find_dependency(Kokkos)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArborXSettings.cmake")


### PR DESCRIPTION
This PR is simply to facilitate the discussion of the best approach to provide transitive path to Kokkos when using ArborX.

The current approach was taken from [Cabana](https://github.com/ECP-copa/Cabana/blob/27a31ab987d978eff18b443de1f5dc658c02237e/core/src/CabanaConfig.cmakein#L2-L4).

Feel free to close if you think this is useless.