### PR TITLE
Use Clang workaround for Thrust regarless of the version

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -22,10 +22,14 @@
 // clang-format off
 #if defined(KOKKOS_ENABLE_CUDA)
 #  if defined(KOKKOS_COMPILER_CLANG)
-// A range of versions of Clang cannot compile Thrust, failing with errors
-// like this:
+// Some versions of Clang fail to compile Thrust, failing with errors like
+// this:
 //    <snip>/thrust/system/cuda/detail/core/agent_launcher.h:557:11:
 //    error: use of undeclared identifier 'va_printf'
+// The exact combination of versions for Clang and Thrust (or CUDA) for this
+// failure was not investigated, however even very recent version combination
+// (Clang 10.0.0 and Cuda 10.0) demonstrated failure.
+//
 // Defining _CubLog here allows us to avoid that code path, however disabling
 // some debugging diagnostics
 //

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -21,8 +21,8 @@
 
 // clang-format off
 #if defined(KOKKOS_ENABLE_CUDA)
-#  if defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900
-// Clang of version less than 9.0 cannot compile Thrust, failing with errors
+#  if defined(KOKKOS_COMPILER_CLANG)
+// A range of versions of Clang cannot compile Thrust, failing with errors
 // like this:
 //    <snip>/thrust/system/cuda/detail/core/agent_launcher.h:557:11:
 //    error: use of undeclared identifier 'va_printf'
@@ -42,10 +42,10 @@
 #      define _CubLog ARBORX_CubLog_save
 #      undef ARBORX_CubLog_save
 #    endif
-#  else // #if (KOKKOS_COMPILER_CLANG < 900)
+#  else // #if defined(KOKKOS_COMPILER_CLANG)
 #    include <thrust/device_ptr.h>
 #    include <thrust/sort.h>
-#  endif // #if (KOKKOS_COMPILER_CLANG < 900)
+#  endif // #if defined(KOKKOS_COMPILER_CLANG)
 #endif   // #if defined(KOKKOS_ENABLE_CUDA)
 // clang-format on
 


### PR DESCRIPTION
I encountered the bug with CUDA-10.0 and LLVM/Clang v10.0.0

Rather than attempting to discriminate combinations of CUDA/Clang versions, I suggest we use the workaround unconditionally for now.