### PR TITLE
Fix radius calculation for on-node benchmark

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -102,12 +102,10 @@ makeSpatialQueries(int n_values, int n_queries, int n_neighbors,
 
   Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
       queries(Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
-  // radius chosen in order to control the number of results per query
-  // NOTE: minus "1+sqrt(3)/2 \approx 1.37" matches the size of the boxes
-  // inserted into the tree (mid-point between half-edge and half-diagonal)
-  double const r =
-      2. * std::cbrt(static_cast<double>(n_neighbors) * 3. / (4. * M_PI)) -
-      (1. + std::sqrt(3.)) / 2.;
+  // Radius is computed so that the number of results per query for a uniformly
+  // distributed points in a [-a,a]^3 box is approximately n_neighbors.
+  // Calculation: n_values*(4/3*M_PI*r^3)/(2a)^3 = n_neighbors
+  double const r = std::cbrt(static_cast<double>(n_neighbors) * 6. / M_PI);
   using ExecutionSpace = typename DeviceType::execution_space;
   Kokkos::parallel_for(
       "bvh_driver:setup_radius_search_queries",


### PR DESCRIPTION
The code was erroneously subtracting a constant from the radius. That
was a historic artifact coming from the original DTK code (commit
[8610a49d](https://github.com/ORNL-CEES/DataTransferKit/commit/8610a49dd3ae2839a0b267f3f41584c7c859eabe) when we were constructing boxes and not points. This code was
trying to adjust for the box size 1.

As we now construct points, this is not necessary.