### PR TITLE
Add batch mode to bvh on-node driver

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,7 +113,25 @@ RunBenchmarks:
     - export OMP_PROC_BIND=spread
     - export OMP_PLACES=threads
     - export JSRUN_OPTIONS="-n 1 -a 1 -c 42 -g 1 -r 1 -l CPU-CPU -d packed -b packed:42"
-    - export BENCHMARK_OPTIONS="--benchmark_format=json --no-header --benchmark_repetitions=15"
+    - export BENCHMARK_OPTIONS="--benchmark_format=json --no-header --benchmark_repetitions=15
+                                --exact-spec serial/1000/1000/10/1/0/0/2
+                                --exact-spec serial/10000/10000/10/1/0/0/2
+                                --exact-spec serial/100000/100000/10/1/0/0/2
+                                --exact-spec serial/1000/1000/10/1/0/1/3
+                                --exact-spec serial/10000/10000/10/1/0/1/3
+                                --exact-spec serial/100000/100000/10/1/0/1/3
+                                --exact-spec openmp/1000/1000/10/1/0/0/2
+                                --exact-spec openmp/10000/10000/10/1/0/0/2
+                                --exact-spec openmp/100000/100000/10/1/0/0/2
+                                --exact-spec openmp/1000/1000/10/1/0/1/3
+                                --exact-spec openmp/10000/10000/10/1/0/1/3
+                                --exact-spec openmp/100000/100000/10/1/0/1/3
+                                --exact-spec cuda/10000/10000/10/1/0/0/2
+                                --exact-spec cuda/100000/100000/10/1/0/0/2
+                                --exact-spec cuda/1000000/1000000/10/1/0/0/2
+                                --exact-spec cuda/10000/10000/10/1/0/1/3
+                                --exact-spec cuda/100000/100000/10/1/0/1/3
+                                --exact-spec cuda/1000000/1000000/10/1/0/1/3"
     - jsrun ${JSRUN_OPTIONS} /ccsopen/proj/csc333/ArborX_BoundingVolumeHierarchyBranch${BRANCH_HASH}.exe ${BENCHMARK_OPTIONS} | tee /ccsopen/proj/csc333/arborx-branch${BRANCH_HASH}.json
     - jsrun ${JSRUN_OPTIONS} /ccsopen/proj/csc333/ArborX_BoundingVolumeHierarchyMaster${MASTER_HASH}.exe ${BENCHMARK_OPTIONS} | tee /ccsopen/proj/csc333/arborx-master${MASTER_HASH}.json
     - rm /ccsopen/proj/csc333/ArborX_BoundingVolumeHierarchyBranch${BRANCH_HASH}.exe /ccsopen/proj/csc333/ArborX_BoundingVolumeHierarchyMaster${MASTER_HASH}.exe

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -400,6 +400,7 @@ int main(int argc, char *argv[])
           .run();
 
   std::vector<Spec> specs;
+  specs.reserve(exact_specs.size());
   for (auto const &spec_string : exact_specs)
     specs.emplace_back(spec_string);
 

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -84,7 +84,7 @@ Spec create_spec_from_string(std::string const &spec_string)
     getline(ss, token, '/');  spec.n_values = std::stoi(token);
     getline(ss, token, '/');  spec.n_queries = std::stoi(token);
     getline(ss, token, '/');  spec.n_neighbors = std::stoi(token);
-    getline(ss, token, '/');  spec.sort_predicates = std::stoi(token);
+    getline(ss, token, '/');  spec.sort_predicates = static_cast<bool>(std::stoi(token));
     getline(ss, token, '/');  spec.buffer_size = std::stoi(token);
     getline(ss, token, '/');  spec.source_point_cloud_type = static_cast<PointCloudType>(std::stoi(token));
     getline(ss, token, '/');  spec.target_point_cloud_type = static_cast<PointCloudType>(std::stoi(token));

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -294,7 +294,6 @@ int main(int argc, char *argv[])
 
   namespace bpo = boost::program_options;
   bpo::options_description desc("Allowed options");
-  std::string backends;
   int n_values;
   int n_queries;
   int n_neighbors;
@@ -306,7 +305,6 @@ int main(int argc, char *argv[])
   // clang-format off
     desc.add_options()
         ( "help", "produce help message" )
-	( "backends", bpo::value<std::string>(&backends)->default_value("all"), "backends to run on can be 'all', 'serial', 'openmp', or 'cuda'" )
         ( "values", bpo::value<int>(&n_values)->default_value(50000), "number of indexable values (source)" )
         ( "queries", bpo::value<int>(&n_queries)->default_value(20000), "number of queries (target)" )
         ( "predicate-sort", bpo::value<bool>(&sort_predicates)->default_value(true), "sort predicates" )
@@ -390,7 +388,7 @@ int main(int argc, char *argv[])
   {
     exact_specs.resize(1);
     auto &spec = exact_specs[0];
-    spec = backends;
+    spec = "all";
     for (auto const &var :
          {n_values, n_queries, n_neighbors, sort_predicates_int, buffer_size,
           (int)source_point_cloud_type, (int)target_point_cloud_type})
@@ -407,43 +405,43 @@ int main(int argc, char *argv[])
       throw std::runtime_error("Backend " + spec.backends + " invalid!");
 
 #ifdef KOKKOS_ENABLE_SERIAL
-    if (backends == "all" || backends == "serial")
+    if (spec.backends == "all" || spec.backends == "serial")
       register_benchmark<ArborX::BVH<Kokkos::Serial::device_type>>(
           "ArborX::BVH<Serial>", spec);
 #else
-    if (backends == "serial")
+    if (spec.backends == "serial")
       throw std::runtime_error("Serial backend not available!");
 #endif
 
 #ifdef KOKKOS_ENABLE_OPENMP
-    if (backends == "all" || backends == "openmp")
+    if (spec.backends == "all" || spec.backends == "openmp")
       register_benchmark<ArborX::BVH<Kokkos::OpenMP::device_type>>(
           "ArborX::BVH<OpenMP>", spec);
 #else
-    if (backends == "openmp")
+    if (spec.backends == "openmp")
       throw std::runtime_error("OpenMP backend not available!");
 #endif
 
 #ifdef KOKKOS_ENABLE_THREADS
-    if (backends == "all" || backends == "threads")
+    if (spec.backends == "all" || spec.backends == "threads")
       register_benchmark<ArborX::BVH<Kokkos::Threads::device_type>>(
           "ArborX::BVH<Threads>", spec);
 #else
-    if (backends == "threads")
+    if (spec.backends == "threads")
       throw std::runtime_error("Threads backend not available!");
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
-    if (backends == "all" || backends == "cuda")
+    if (spec.backends == "all" || spec.backends == "cuda")
       register_benchmark<ArborX::BVH<Kokkos::Cuda::device_type>>(
           "ArborX::BVH<Cuda>", spec);
 #else
-    if (backends == "cuda")
+    if (spec.backends == "cuda")
       throw std::runtime_error("CUDA backend not available!");
 #endif
 
 #if defined(KOKKOS_ENABLE_SERIAL)
-    if (backends == "all" || backends == "rtree")
+    if (spec.backends == "all" || spec.backends == "rtree")
     {
       using BoostRTree = BoostExt::RTree<ArborX::Point>;
       register_benchmark<BoostRTree>("BoostRTree", spec);

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -174,7 +174,7 @@ public:
 };
 
 template <typename TreeType>
-void register_benchmark(const std::string description, int const n_values,
+void register_benchmark(std::string const &description, int const n_values,
                         int const n_queries, int const n_neighbors,
                         int const sort_predicates_int, int const buffer_size,
                         PointCloudType const &source_point_cloud_type,
@@ -182,25 +182,25 @@ void register_benchmark(const std::string description, int const n_values,
 {
   auto label_construction = [&](std::string const &tree_name) -> std::string {
     std::string s = std::string("BM_construction<") + tree_name + ">";
-    for (auto &var : {n_values, (int)source_point_cloud_type})
+    for (auto const &var : {n_values, (int)source_point_cloud_type})
       s += "/" + std::to_string(var);
-    return s.c_str();
+    return s;
   };
   auto label_knn_search = [&](std::string const &tree_name) -> std::string {
     std::string s = std::string("BM_knn_search<") + tree_name + ">";
-    for (auto &var :
+    for (auto const &var :
          {n_values, n_queries, n_neighbors, sort_predicates_int,
           (int)source_point_cloud_type, (int)target_point_cloud_type})
       s += "/" + std::to_string(var);
-    return s.c_str();
+    return s;
   };
   auto label_radius_search = [&](std::string const &tree_name) -> std::string {
     std::string s = std::string("BM_radius_search<") + tree_name + ">";
-    for (auto &var :
+    for (auto const &var :
          {n_values, n_queries, n_neighbors, sort_predicates_int, buffer_size,
           (int)source_point_cloud_type, (int)target_point_cloud_type})
       s += "/" + std::to_string(var);
-    return s.c_str();
+    return s;
   };
 
   benchmark::RegisterBenchmark(label_construction(description).c_str(),
@@ -349,8 +349,8 @@ int main(int argc, char *argv[])
     {
       if (!vm[option].defaulted())
       {
-        std::cout << "Conflicting options: \"exact-spec\" and \"" << option
-                  << "\", exiting..." << std::endl;
+        std::cout << "Conflicting options: 'exact-spec' and '" << option
+                  << "', exiting..." << std::endl;
         return EXIT_FAILURE;
       }
     }
@@ -369,15 +369,18 @@ int main(int argc, char *argv[])
   to_point_cloud_enum["filled_sphere"] = PointCloudType::filled_sphere;
   to_point_cloud_enum["hollow_sphere"] = PointCloudType::hollow_sphere;
 
-  PointCloudType source_point_cloud_type;
-  PointCloudType target_point_cloud_type;
+  PointCloudType source_point_cloud_type =
+      to_point_cloud_enum.at(source_pt_cloud);
+  PointCloudType target_point_cloud_type =
+      to_point_cloud_enum.at(target_pt_cloud);
+  ;
 
   if (vm.count("exact-spec") == 0)
   {
     exact_specs.resize(1);
     auto &spec = exact_specs[0];
     spec = backends;
-    for (auto &var :
+    for (auto const &var :
          {n_values, n_queries, n_neighbors, sort_predicates_int, buffer_size,
           (int)source_point_cloud_type, (int)target_point_cloud_type})
       spec += "/" + std::to_string(var);
@@ -395,8 +398,8 @@ int main(int argc, char *argv[])
     getline(ss, token, '/');  n_neighbors = std::stoi(token);
     getline(ss, token, '/');  sort_predicates_int = std::stoi(token);
     getline(ss, token, '/');  buffer_size = std::stoi(token);
-    getline(ss, token, '/');  source_point_cloud_type = to_point_cloud_enum[token];
-    getline(ss, token, '/');  target_point_cloud_type = to_point_cloud_enum[token];
+    getline(ss, token, '/');  source_point_cloud_type = static_cast<PointCloudType>(std::stoi(token));
+    getline(ss, token, '/');  target_point_cloud_type = static_cast<PointCloudType>(std::stoi(token));
     // clang-format on
 
     if (!(backends == "all" || backends == "serial" || backends == "openmp" ||

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -399,48 +399,52 @@ int main(int argc, char *argv[])
     getline(ss, token, '/');  target_point_cloud_type = to_point_cloud_enum[token];
     // clang-format on
 
+    if (!(backends == "all" || backends == "serial" || backends == "openmp" ||
+          backends == "threads" || backends == "cuda" || backends == "rtree"))
+      throw std::runtime_error("Backend " + backends + " invalid!");
+
 #ifdef KOKKOS_ENABLE_SERIAL
     if (backends == "all" || backends == "serial")
-    {
-      using Serial = Kokkos::Serial::device_type;
-      register_benchmark<ArborX::BVH<Serial>>(
+      register_benchmark<ArborX::BVH<Kokkos::Serial::device_type>>(
           "ArborX::BVH<Serial>", n_values, n_queries, n_neighbors,
           sort_predicates_int, buffer_size, source_point_cloud_type,
           target_point_cloud_type);
-    }
+#else
+    if (backends == "serial")
+      throw std::runtime_error("Serial backend not available!");
 #endif
 
 #ifdef KOKKOS_ENABLE_OPENMP
     if (backends == "all" || backends == "openmp")
-    {
-      using OpenMP = Kokkos::OpenMP::device_type;
-      register_benchmark<ArborX::BVH<OpenMP>>(
+      register_benchmark<ArborX::BVH<Kokkos::OpenMP::device_type>>(
           "ArborX::BVH<OpenMP>", n_values, n_queries, n_neighbors,
           sort_predicates_int, buffer_size, source_point_cloud_type,
           target_point_cloud_type);
-    }
+#else
+    if (backends == "openmp")
+      throw std::runtime_error("OpenMP backend not available!");
 #endif
 
 #ifdef KOKKOS_ENABLE_THREADS
     if (backends == "all" || backends == "threads")
-    {
-      using Threads = Kokkos::Threads::device_type;
-      register_benchmark<ArborX::BVH<Threads>>(
+      register_benchmark<ArborX::BVH<Kokkos::Threads::device_type>>(
           "ArborX::BVH<Threads>", n_values, n_queries, n_neighbors,
           sort_predicates_int, buffer_size, source_point_cloud_type,
           target_point_cloud_type);
-    }
+#else
+    if (backends == "threads")
+      throw std::runtime_error("Threads backend not available!");
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
     if (backends == "all" || backends == "cuda")
-    {
-      using Cuda = Kokkos::Cuda::device_type;
-      register_benchmark<ArborX::BVH<Cuda>>(
+      register_benchmark<ArborX::BVH<Kokkos::Cuda::device_type>>(
           "ArborX::BVH<Cuda>", n_values, n_queries, n_neighbors,
           sort_predicates_int, buffer_size, source_point_cloud_type,
           target_point_cloud_type);
-    }
+#else
+    if (backends == "cuda")
+      throw std::runtime_error("CUDA backend not available!");
 #endif
 
 #if defined(KOKKOS_ENABLE_SERIAL)

--- a/benchmarks/point_clouds/point_clouds.hpp
+++ b/benchmarks/point_clouds/point_clouds.hpp
@@ -19,13 +19,27 @@
 #include <fstream>
 #include <random>
 
-enum PointCloudType
+enum class PointCloudType
 {
   filled_box,
   hollow_box,
   filled_sphere,
   hollow_sphere
 };
+
+PointCloudType to_point_cloud_enum(std::string const &str)
+{
+  if (str == "filled_box")
+    return PointCloudType::filled_box;
+  if (str == "hollow_box")
+    return PointCloudType::hollow_box;
+  if (str == "filled_sphere")
+    return PointCloudType::filled_sphere;
+  if (str == "hollow_sphere")
+    return PointCloudType::hollow_sphere;
+  throw std::runtime_error(str +
+                           " doesn't correspond to any known PointCloudType!");
+}
 
 template <typename Layout, typename DeviceType>
 void filledBoxCloud(

--- a/benchmarks/point_clouds/point_clouds.hpp
+++ b/benchmarks/point_clouds/point_clouds.hpp
@@ -181,24 +181,21 @@ void generatePointCloud(PointCloudType const point_cloud_type,
                         Kokkos::View<ArborX::Point *, DeviceType> random_points)
 {
   auto random_points_host = Kokkos::create_mirror_view(random_points);
-  if (point_cloud_type == PointCloudType::filled_box)
+  switch (point_cloud_type)
   {
+  case PointCloudType::filled_box:
     filledBoxCloud(length, random_points_host);
-  }
-  else if (point_cloud_type == PointCloudType::hollow_box)
-  {
+    break;
+  case PointCloudType::hollow_box:
     hollowBoxCloud(length, random_points_host);
-  }
-  else if (point_cloud_type == PointCloudType::filled_sphere)
-  {
+    break;
+  case PointCloudType::filled_sphere:
     filledSphereCloud(length, random_points_host);
-  }
-  else if (point_cloud_type == PointCloudType::hollow_sphere)
-  {
+    break;
+  case PointCloudType::hollow_sphere:
     hollowSphereCloud(length, random_points_host);
-  }
-  else
-  {
+    break;
+  default:
     throw ArborX::SearchException("not implemented");
   }
   Kokkos::deep_copy(random_points, random_points_host);


### PR DESCRIPTION
The main motivation is to not carry the hardcoded configuration for performance benchmark, allowing faster turnaround for testing. In addition, this would allow the paper branch to only have nanoflann related changes.

It needs some pruning and maybe improving interface. It works, at least. Would appreciate some help in improving the code, as it has several ugly places.

As an example, one would run this as
```shell
./ArborX_BoundingVolumeHierarchy.exe \
  --exact-spec '10000/10000/10/0/0/1/3' \
  --exact-spec '10000/1000/10/0/0/0/2'  \
  ....
```
Also, because of not using `BENCHMARK_TEMPLATE`, we are no longer married to just integers, so we could actually replace some `0` and `1` by `filled`, `hollow` and `sort/no_sort` in the right places, or make that string more readable in general.