### PR TITLE
Drop QUIET option when finding Kokkos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(ArborX CXX)
 
-find_package(Kokkos 3.1 REQUIRED QUIET)
+find_package(Kokkos 3.1 REQUIRED)
 if(Kokkos_ENABLE_CUDA)
   kokkos_check(OPTIONS CUDA_LAMBDA)
 endif()


### PR DESCRIPTION
* Per our discussion this is a left over from pre 3.0 Kokkos and was not intentional
* The `QUIET` option makes little sense when combined with `REQUIRED`
* This will print the messages from Kokkos including what backend was enabled