### PR TITLE
Do not build benchmark tests when building container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,7 +120,6 @@ ENV BENCHMARK_DIR=/opt/benchmark
 RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     git clone https://github.com/google/benchmark.git -b v1.4.1 && \
     cd benchmark && \
-    git clone https://github.com/google/googletest.git -b release-1.8.1 && \
     mkdir build && cd build && \
     cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} -D BENCHMARK_ENABLE_TESTING=OFF .. && \
     make -j${NPROCS} && make install && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -122,7 +122,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     cd benchmark && \
     git clone https://github.com/google/googletest.git -b release-1.8.1 && \
     mkdir build && cd build && \
-    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} .. && \
+    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} -D BENCHMARK_ENABLE_TESTING=OFF .. && \
     make -j${NPROCS} && make install && \
     rm -rf ${SCRATCH_DIR}
 

--- a/docker/Dockerfile.pgi
+++ b/docker/Dockerfile.pgi
@@ -89,7 +89,6 @@ ENV BENCHMARK_DIR=/opt/benchmark
 RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     git clone https://github.com/google/benchmark.git -b v1.4.1 && \
     cd benchmark && \
-    git clone https://github.com/google/googletest.git -b release-1.8.1 && \
     mkdir build && cd build && \
     cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} -D BENCHMARK_ENABLE_TESTING=OFF .. && \
     make -j${NPROCS} && make install && \

--- a/docker/Dockerfile.pgi
+++ b/docker/Dockerfile.pgi
@@ -91,7 +91,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     cd benchmark && \
     git clone https://github.com/google/googletest.git -b release-1.8.1 && \
     mkdir build && cd build && \
-    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} .. && \
+    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} -D BENCHMARK_ENABLE_TESTING=OFF .. && \
     make -j${NPROCS} && make install && \
     rm -rf ${SCRATCH_DIR}
 


### PR DESCRIPTION
It also tries to find gtest when tests are enabled, which fails on
CADES, for example.