### PR TITLE
Add knobs to control occupancy in bvh traversal algorithms

### DIFF
--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -64,6 +64,12 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
                            Kokkos::RangePolicy<ExecutionSpace>(
                                space, 0, Access::size(predicates)),
                            *this);
+      // KokkosExt::DoNotTryThisAtHome::parallel_for(
+      //    ARBORX_MARK_REGION("BVH:spatial_queries"),
+      //    Kokkos::RangePolicy<ExecutionSpace>(space, 0,
+      //                                        Access::size(predicates)),
+      //    *this, KokkosExt::DoNotTryThisAtHome::BlockSize{128},
+      //    KokkosExt::DoNotTryThisAtHome::SharedMemSize{2 * 1024});
     }
   }
 

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -60,16 +60,11 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
     }
     else
     {
-      Kokkos::parallel_for(ARBORX_MARK_REGION("BVH:spatial_queries"),
-                           Kokkos::RangePolicy<ExecutionSpace>(
-                               space, 0, Access::size(predicates)),
-                           *this);
-      // KokkosExt::DoNotTryThisAtHome::parallel_for(
-      //    ARBORX_MARK_REGION("BVH:spatial_queries"),
-      //    Kokkos::RangePolicy<ExecutionSpace>(space, 0,
-      //                                        Access::size(predicates)),
-      //    *this, KokkosExt::DoNotTryThisAtHome::BlockSize{128},
-      //    KokkosExt::DoNotTryThisAtHome::SharedMemSize{2 * 1024});
+      KokkosExt::DoNotTryThisAtHome::parallel_for(
+          ARBORX_MARK_REGION("BVH:spatial_queries"),
+          Kokkos::RangePolicy<ExecutionSpace>(space, 0,
+                                              Access::size(predicates)),
+          *this, KokkosExt::DoNotTryThisAtHome::Occupancy{25});
     }
   }
 
@@ -208,10 +203,11 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     {
       allocateBuffer(space);
 
-      Kokkos::parallel_for(ARBORX_MARK_REGION("BVH:nearest_queries"),
-                           Kokkos::RangePolicy<ExecutionSpace>(
-                               space, 0, Access::size(predicates)),
-                           *this);
+      KokkosExt::DoNotTryThisAtHome::parallel_for(
+          ARBORX_MARK_REGION("BVH:nearest_queries"),
+          Kokkos::RangePolicy<ExecutionSpace>(space, 0,
+                                              Access::size(predicates)),
+          *this, KokkosExt::DoNotTryThisAtHome::Occupancy{25});
     }
   }
 


### PR DESCRIPTION
Lowering occupancy produces a lot better results for bvh traversal algorithm. Currently, Kokkos does not expose the tools required to do that properly. This PR introduces a somewhat hacky way for us to give us some control through accessing Kokkos internal functions. This approach may break at any point if incompatible changes are made to Kokkos internals. The benefits, however, are worth it.

Items to be completed prior to merge:
- [x] Parameter sweep on Summit
- [x] Parameter sweep on P100
- [x] Deciding on the block size and shared memory values
  This is likely to be platform dependent
- [x] Make it compile with CUDA disabled