### PR TITLE
Change GitHub workflow base

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Mirror + trigger CI
-      uses: SvanBoxel/gitlab-mirror-and-ci-action@master
+    - name: Trigger GitLab CI
+      uses: masterleinad/gitlab-mirror-and-ci-action@master
       with:
         args: "https://code.ornl.gov/ecpcitest/alexa/"
       env:


### PR DESCRIPTION
As discussed with @aprokop, it is useful to prepend the branch name with the repository name when pushing to `GitLab` since the CI is triggered from the forks. This pull request for example corresponds to https://code.ornl.gov/ecpcitest/alexa/-/tree/masterleinad/ArborX/change_github_workflow_base

Do we want to keep the modified workflow (currently in https://github.com/masterleinad/gitlab-mirror-and-ci-action) in https://github.com/arborx instead?