### PR TITLE
Let BVH::bounds() be a KOKKOS_FUNCTION

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -46,10 +46,10 @@ public:
   BoundingVolumeHierarchy(ExecutionSpace const &space,
                           Primitives const &primitives);
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   size_type size() const noexcept { return _size; }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   bool empty() const noexcept { return size() == 0; }
 
   bounding_volume_type bounds() const noexcept { return _bounds; }
@@ -99,22 +99,22 @@ private:
                            std::make_pair(size() - 1, 2 * size() - 1));
   }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   Node const *getRoot() const { return _internal_and_leaf_nodes.data(); }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   Node *getRoot() { return _internal_and_leaf_nodes.data(); }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   Node const *getNodePtr(int i) const { return &_internal_and_leaf_nodes(i); }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   bounding_volume_type const &getBoundingVolume(Node const *node) const
   {
     return node->bounding_box;
   }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   bounding_volume_type &getBoundingVolume(Node *node)
   {
     return node->bounding_box;

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -19,7 +19,6 @@
 #include <ArborX_DetailsKokkosExt.hpp>
 #include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsSortUtils.hpp>
-#include <ArborX_DetailsTags.hpp>
 #include <ArborX_DetailsTreeConstruction.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -52,6 +52,7 @@ public:
   KOKKOS_FUNCTION
   bool empty() const noexcept { return size() == 0; }
 
+  KOKKOS_FUNCTION
   bounding_volume_type bounds() const noexcept { return _bounds; }
 
   template <typename ExecutionSpace, typename Predicates,

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -53,17 +53,6 @@ public:
                               Box const &scene_bounding_box,
                               Predicates const &predicates)
   {
-    Kokkos::View<Box, DeviceType> bounds("bounds");
-    Kokkos::deep_copy(space, bounds, scene_bounding_box);
-    return sortQueriesAlongZOrderCurve(space, bounds, predicates);
-  }
-
-  template <typename ExecutionSpace, typename Predicates>
-  static Kokkos::View<unsigned int *, DeviceType>
-  sortQueriesAlongZOrderCurve(ExecutionSpace const &space,
-                              Kokkos::View<Box const, DeviceType> bounds,
-                              Predicates const &predicates)
-  {
     using Access = Traits::Access<Predicates, Traits::PredicatesTag>;
     auto const n_queries = Access::size(predicates);
 
@@ -75,7 +64,7 @@ public:
         KOKKOS_LAMBDA(int i) {
           Point xyz =
               Details::returnCentroid(getGeometry(Access::get(predicates, i)));
-          translateAndScale(xyz, xyz, bounds());
+          translateAndScale(xyz, xyz, scene_bounding_box);
           morton_codes(i) = morton3D(xyz[0], xyz[1], xyz[2]);
         });
 


### PR DESCRIPTION
As I was going over the API, I realized I that `BVH::bounds` was currently not annotated `__host__ __device__` and I could not think of a good reason not to.
I considered returning a const reference to the bounding volume but I don't think this is a good idea because I don't have evidence that this improve performance and it would enable memory access violations.

When looking for places we call that member function, I stumbled over the two overloads of `sortQueriesAlongZOrderCurve` and I think this was a mistake.