### PR TITLE
Drop double underscore prefix in bubble{Down,Up}

### DIFF
--- a/src/details/ArborX_DetailsHeap.hpp
+++ b/src/details/ArborX_DetailsHeap.hpp
@@ -39,9 +39,9 @@ KOKKOS_INLINE_FUNCTION bool isHeap(RandomIterator first, RandomIterator last,
 
 template <typename RandomIterator, typename DistanceType, typename ValueType,
           typename Compare>
-KOKKOS_INLINE_FUNCTION void __bubbleUp(RandomIterator first, DistanceType pos,
-                                       DistanceType top, ValueType val,
-                                       Compare comp)
+KOKKOS_INLINE_FUNCTION void bubbleUp(RandomIterator first, DistanceType pos,
+                                     DistanceType top, ValueType val,
+                                     Compare comp)
 {
   DistanceType parent = (pos - 1) / 2;
   while (pos > top && comp(*(first + parent), val))
@@ -63,16 +63,16 @@ KOKKOS_INLINE_FUNCTION void pushHeap(RandomIterator first, RandomIterator last,
   if (last - first > 1)
   {
     ValueType value = std::move(*(last - 1));
-    __bubbleUp(first, DistanceType((last - first) - 1), DistanceType(0),
-               std::move(value), comp);
+    bubbleUp(first, DistanceType((last - first) - 1), DistanceType(0),
+             std::move(value), comp);
   }
 }
 
 template <typename RandomIterator, typename DistanceType, typename ValueType,
           typename Compare>
-KOKKOS_INLINE_FUNCTION void __bubbleDown(RandomIterator first, DistanceType pos,
-                                         DistanceType len, ValueType val,
-                                         Compare comp)
+KOKKOS_INLINE_FUNCTION void bubbleDown(RandomIterator first, DistanceType pos,
+                                       DistanceType len, ValueType val,
+                                       Compare comp)
 {
   DistanceType child = 2 * pos + 1;
   // if right child exists and compares greater than left child
@@ -100,8 +100,8 @@ KOKKOS_INLINE_FUNCTION void popHeap(RandomIterator first, RandomIterator last,
   if (last - first > 1)
   {
     ValueType value = std::move(*first);
-    __bubbleDown(first, DistanceType(0), DistanceType((last - first) - 1),
-                 std::move(*(last - 1)), comp);
+    bubbleDown(first, DistanceType(0), DistanceType((last - first) - 1),
+               std::move(*(last - 1)), comp);
     *(last - 1) = std::move(value);
   }
 }

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -106,8 +106,8 @@ public:
   KOKKOS_INLINE_FUNCTION void popPush(Args &&... args)
   {
     assert(_c.size() > 0);
-    __bubbleDown(_c.data(), std::ptrdiff_t(0), std::ptrdiff_t(_c.size()),
-                 T{std::forward<Args>(args)...}, _compare);
+    bubbleDown(_c.data(), std::ptrdiff_t(0), std::ptrdiff_t(_c.size()),
+               T{std::forward<Args>(args)...}, _compare);
   }
 
   // Accessors that shouldn't be there but that are convenient in


### PR DESCRIPTION
The identifiers with a double underscore anywhere are reserved.  I knew I would have to change this one day or the other and kept kicking the can down the road.  I was experimenting with clang-tidy and it choked on it.