### PR TITLE
Fixup: Do not let lastElement() return type be const-qualified

### DIFF
--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -132,7 +132,7 @@ template <typename T, typename... P>
  *  \pre \c v is of rank 1 and not empty.
  */
 template <typename T, typename... P>
-typename Kokkos::ViewTraits<T, P...>::value_type
+typename Kokkos::ViewTraits<T, P...>::non_const_value_type
 lastElement(Kokkos::View<T, P...> const &v)
 {
   static_assert((unsigned(Kokkos::ViewTraits<T, P...>::rank) == unsigned(1)),


### PR DESCRIPTION
Fix for clang-tidy warning:
```
src/details/ArborX_DetailsUtils.hpp:135:1: warning: return type 'typename Kokkos::ViewTraits<const int *, Device<Threads, HostSpace>>::value_type' (aka 'const int') is 'const'-qualified at the top level, which may reduce code readability without improving const correctness [readability-const-return-type]
```

This was an oversight on my part.