### PR TITLE
Fix some more narrowing conversion warnings

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -62,7 +62,7 @@ struct AccessTraits<
   // Returns by value
   KOKKOS_FUNCTION static Point get(View const &v, int i)
   {
-    return {v(i, 0), v(i, 1), v(i, 2)};
+    return {{v(i, 0), v(i, 1), v(i, 2)}};
   }
 
   static typename View::size_type size(View const &v) { return v.extent(0); }


### PR DESCRIPTION
These currently show up in DTK. An alternative to provide another constructor to `Point` that takes `double` arguments.