### PR TITLE
Check that MPI is not finalized before freeing the communicator

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -42,7 +42,16 @@ public:
   DistributedSearchTree(MPI_Comm comm, ExecutionSpace const &space,
                         Primitives const &primitives);
 
-  ~DistributedSearchTree() { MPI_Comm_free(&_comm); }
+  ~DistributedSearchTree()
+  {
+    int mpi_is_finalized;
+    MPI_Finalized(&mpi_is_finalized);
+    if (!mpi_is_finalized)
+    {
+      MPI_Comm_free(&_comm);
+    }
+    _comm = MPI_COMM_NULL;
+  }
 
   /** Returns the smallest axis-aligned box able to contain all the objects
    *  stored in the tree or an invalid box if the tree is empty.


### PR DESCRIPTION
Fix #346.

This PR still needs a test. A bit tricky as we need an alternative to `utf_main.cpp`.