### PR TITLE
Apetrei's construction algorithm

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -101,13 +101,10 @@ private:
   }
 
   KOKKOS_FUNCTION
-  Node const *getRoot() const
-  {
-    return _internal_and_leaf_nodes.data() + _root_node_index;
-  }
+  Node const *getRoot() const { return _internal_and_leaf_nodes.data(); }
 
   KOKKOS_FUNCTION
-  Node *getRoot() { return _internal_and_leaf_nodes.data() + _root_node_index; }
+  Node *getRoot() { return _internal_and_leaf_nodes.data(); }
 
   KOKKOS_FUNCTION
   Node const *getNodePtr(int i) const { return &_internal_and_leaf_nodes(i); }
@@ -127,7 +124,6 @@ private:
   size_t _size;
   bounding_volume_type _bounds;
   Kokkos::View<Node *, MemorySpace> _internal_and_leaf_nodes;
-  int _root_node_index;
 };
 
 template <typename DeviceType>
@@ -191,7 +187,6 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
         Kokkos::view_alloc("permute", space), 1);
     Details::TreeConstruction::initializeLeafNodes(
         space, primitives, permutation_indices, getLeafNodes());
-    _root_node_index = 0;
     return;
   }
 
@@ -220,8 +215,8 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
   Kokkos::Profiling::pushRegion("ArborX:BVH:generate_hierarchy");
 
   // generate bounding volume hierarchy
-  _root_node_index = Details::TreeConstruction::generateHierarchy(
-      space, morton_indices, getInternalNodes());
+  Details::TreeConstruction::generateHierarchy(space, morton_indices,
+                                               getInternalNodes());
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::popRegion();

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -215,8 +215,8 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
   Kokkos::Profiling::pushRegion("ArborX:BVH:generate_hierarchy");
 
   // generate bounding volume hierarchy
-  Details::TreeConstruction::generateHierarchy(space, morton_indices,
-                                               getInternalNodes());
+  Details::TreeConstruction::generateHierarchy(
+      space, morton_indices, getLeafNodes(), getInternalNodes());
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::popRegion();

--- a/src/details/ArborX_DetailsKokkosExt.hpp
+++ b/src/details/ArborX_DetailsKokkosExt.hpp
@@ -43,40 +43,6 @@ struct is_accessible_from_host
   static_assert(Kokkos::is_view<View>::value, "");
 };
 
-/** Count the number of consecutive leading zero bits in 32 bit integer
- * @param x
- */
-KOKKOS_INLINE_FUNCTION
-int clz(uint32_t x)
-{
-#if defined(__CUDA_ARCH__)
-  // Note that the __clz() CUDA intrinsic function takes a signed integer
-  // as input parameter.  This is fine but would need to be adjusted if
-  // we were to change expandBits() and morton3D() to subdivide [0, 1]^3
-  // into more 1024^3 bins.
-  return __clz(x);
-#elif defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_CLANG >= 500)
-  // According to https://en.wikipedia.org/wiki/Find_first_set
-  // Clang 5.X supports the builtin function with the same syntax as GCC
-  return (x == 0) ? 32 : __builtin_clz(x);
-#else
-  if (x == 0)
-    return 32;
-  // The following is taken from:
-  // http://stackoverflow.com/questions/23856596/counting-leading-zeros-in-a-32-bit-unsigned-integer-with-best-algorithm-in-c-pro
-  const char debruijn32[32] = {0,  31, 9,  30, 3,  8,  13, 29, 2,  5, 7,
-                               21, 12, 24, 28, 19, 1,  10, 4,  14, 6, 22,
-                               25, 20, 11, 15, 23, 26, 16, 27, 17, 18};
-  x |= x >> 1;
-  x |= x >> 2;
-  x |= x >> 4;
-  x |= x >> 8;
-  x |= x >> 16;
-  x++;
-  return debruijn32[x * 0x076be629 >> 27];
-#endif
-}
-
 //! Compute the maximum of two values.
 template <typename T>
 KOKKOS_INLINE_FUNCTION constexpr T const &max(T const &a, T const &b)
@@ -89,16 +55,6 @@ template <typename T>
 KOKKOS_INLINE_FUNCTION constexpr T const &min(T const &a, T const &b)
 {
   return (a < b) ? a : b;
-}
-
-/**
- * Branchless sign function. Return 1 if @param x is greater than zero, 0 if
- * @param x is zero, and -1 if @param x is less than zero.
- */
-template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
-KOKKOS_INLINE_FUNCTION int sgn(T x)
-{
-  return (x > 0) - (x < 0);
 }
 
 /** Determine whether the given floating point argument @param x has finite

--- a/src/details/ArborX_DetailsMortonCode.hpp
+++ b/src/details/ArborX_DetailsMortonCode.hpp
@@ -43,10 +43,7 @@ unsigned int morton3D(double x, double y, double z)
 
   // The interval [0,1] is subdivided into 1024 bins (in each direction).
   // If we were to use more bits to encode the Morton code, we would need
-  // to reflect these changes in expandBits() as well as in the clz()
-  // function that returns the number of leading zero bits since it
-  // currently assumes that the code can be represented by a 32 bit
-  // integer.
+  // to reflect these changes in expandBits()
   x = min(max(x * 1024.0, 0.0), 1023.0);
   y = min(max(y * 1024.0, 0.0), 1023.0);
   z = min(max(z * 1024.0, 0.0), 1023.0);

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -262,6 +262,10 @@ public:
     int &range_left = range[0];
     int &range_right = range[1];
 
+    int deltas[2] = {delta(range_left - 1), delta(range_right)};
+    int &delta_left = deltas[0];
+    int &delta_right = deltas[1];
+
     // Walk toward the root and do process it even though technically its
     // bounding box has already been computed (bounding box of the scene)
     do
@@ -269,7 +273,7 @@ public:
       // Determine whether this node is left or right child of its parent
       //   direction_index == 1: left child
       //   direction_index == 0: right child
-      int direction_index = (delta(range_right) < delta(range_left - 1));
+      int direction_index = (delta_right < delta_left);
 
       // Per Apetrei, the parent node index is either `range_left - 1` or
       // `range_right`.
@@ -293,11 +297,15 @@ public:
       if (range[direction_index] == -1)
         break;
 
+      // Update deltas
+      deltas[direction_index] =
+          delta(range[direction_index] - (1 - direction_index));
+
       // We now have the full range for the parent, stored in `range`, and can
       // compute the Karras index.
       // NOTE: `range` was updated above, so this check is different from the
       // one above, despite looking exactly the same.
-      int x = (delta(range_right) < delta(range_left - 1));
+      int x = (delta_right < delta_left);
       int karras_index = (1 - x) * range_left + x * range_right;
 
       Node *node = &_internal_nodes(karras_index);

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -21,6 +21,7 @@
 #include <ArborX_Macros.hpp>
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_OffsetView.hpp>
 
 #include <cassert>
 
@@ -214,61 +215,26 @@ template <typename MemorySpace>
 class GenerateHierarchyFunctor
 {
 public:
-  template <typename ExecutionSpace, typename... MortonCodesViewProperties,
+  template <typename ExecutionSpace, typename... DeltasViewProperties,
             typename... LeafNodesViewProperties,
             typename... InternalNodesViewProperties>
   GenerateHierarchyFunctor(
       ExecutionSpace const &space,
-      Kokkos::View<unsigned int const *, MortonCodesViewProperties...>
-          sorted_morton_codes,
+      Kokkos::Experimental::OffsetView<int *, DeltasViewProperties...> deltas,
       Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes,
       Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes)
-      : _sorted_morton_codes(sorted_morton_codes)
+      : _delta(deltas)
       , _leaf_nodes(leaf_nodes)
       , _internal_nodes(internal_nodes)
       , _ranges(Kokkos::ViewAllocateWithoutInitializing("ranges"),
                 internal_nodes.extent(0))
-      , _num_internal_nodes(_internal_nodes.extent_int(0))
   {
     Kokkos::deep_copy(space, _ranges, UNTOUCHED_NODE);
   }
 
-  KOKKOS_FUNCTION
-  int delta(int const i) const
-  {
-    // Per Apetrei:
-    //   Because we already know where the highest differing bit is for each
-    //   internal node, the delta function basically represents a distance
-    //   metric between two keys. Unlike the delta used by Karras, we are
-    //   interested in the index of the highest differing bit and not the length
-    //   of the common prefix. In practice, logical xor can be used instead of
-    //   finding the index of the highest differing bit as we can compare the
-    //   numbers. The higher the index of the differing bit, the larger the
-    //   number.
-
-    // This check is here simply to avoid code complications in the main
-    // operator
-    if (i < 0 || i >= _num_internal_nodes)
-      return INT_MAX;
-
-    // The Apetrei's paper does not mention dealing with duplicate indices. We
-    // follow the original Karras idea in this situation:
-    //   The case of duplicate Morton codes has to be handled explicitly, since
-    //   our construction algorithm relies on the keys being unique. We
-    //   accomplish this by augmenting each key with a bit representation of
-    //   its index, i.e. k_i = k_i <+> i, where <+> indicates string
-    //   concatenation.
-    // In this case, if the Morton indices are the same, we want to compare is.
-    // We also want the result in this situation to always be less than any
-    // Morton comparison. Thus, we add INT_MIN to it.
-    // We also avoid if/else statement by doing a "x + !x*<blah>" trick.
-    auto x = _sorted_morton_codes(i) ^ _sorted_morton_codes(i + 1);
-    return x + (!x) * (INT_MIN + (i ^ (i + 1)));
-  }
-
   KOKKOS_FUNCTION void operator()(int i) const
   {
-    auto const n = _num_internal_nodes;
+    auto const n = _internal_nodes.extent_int(0);
     auto const leaf_nodes_shift = n;
 
     // For a leaf node, the range is just one index
@@ -276,7 +242,7 @@ public:
     int &range_left = range[0];
     int &range_right = range[1];
 
-    int deltas[2] = {delta(range_left - 1), delta(range_right)};
+    int deltas[2] = {_delta(range_left - 1), _delta(range_right)};
     int &delta_left = deltas[0];
     int &delta_right = deltas[1];
 
@@ -313,7 +279,7 @@ public:
 
       // Update deltas
       deltas[direction_index] =
-          delta(range[direction_index] - (1 - direction_index));
+          _delta(range[direction_index] - (1 - direction_index));
 
       // We now have the full range for the parent, stored in `range`, and can
       // compute the Karras index.
@@ -363,13 +329,69 @@ public:
   }
 
 private:
-  Kokkos::View<unsigned int const *, MemorySpace> _sorted_morton_codes;
+  Kokkos::Experimental::OffsetView<int *, MemorySpace> _delta;
   Kokkos::View<Node *, MemorySpace> _leaf_nodes;
   Kokkos::View<Node *, MemorySpace> _internal_nodes;
   // Use int instead of bool because CAS (Compare And Swap) on CUDA does not
   // support boolean
   Kokkos::View<int *, MemorySpace> _ranges;
-  int _num_internal_nodes;
+};
+
+template <typename MemorySpace>
+class ComputeDeltasFunctor
+{
+public:
+  template <typename... MortonCodesViewProperties,
+            typename... DeltasViewProperties>
+  ComputeDeltasFunctor(
+      Kokkos::View<unsigned int const *, MortonCodesViewProperties...>
+          sorted_morton_codes,
+      Kokkos::Experimental::OffsetView<int *, DeltasViewProperties...> delta)
+      : _sorted_morton_codes(sorted_morton_codes)
+      , _delta(delta)
+      , _n_leaf_nodes(sorted_morton_codes.extent_int(0))
+  {
+  }
+
+  KOKKOS_FUNCTION void operator()(int i) const
+  {
+    // Per Apetrei:
+    //   Because we already know where the highest differing bit is for each
+    //   internal node, the delta function basically represents a distance
+    //   metric between two keys. Unlike the delta used by Karras, we are
+    //   interested in the index of the highest differing bit and not the
+    //   length of the common prefix. In practice, logical xor can be used
+    //   instead of finding the index of the highest differing bit as we can
+    //   compare the numbers. The higher the index of the differing bit, the
+    //   larger the number.
+
+    // This check is here simply to avoid code complications in the main
+    // operator
+    if (i == -1 || i == _n_leaf_nodes - 1)
+    {
+      _delta(i) = INT_MAX;
+      return;
+    }
+
+    // The Apetrei's paper does not mention dealing with duplicate indices.
+    // We follow the original Karras idea in this situation:
+    //   The case of duplicate Morton codes has to be handled explicitly,
+    //   since our construction algorithm relies on the keys being unique.
+    //   We accomplish this by augmenting each key with a bit representation
+    //   of its index, i.e. k_i = k_i <+> i, where <+> indicates string
+    //   concatenation.
+    // In this case, if the Morton indices are the same, we want to compare
+    // is. We also want the result in this situation to always be less than
+    // any Morton comparison. Thus, we add INT_MIN to it. We also avoid
+    // if/else statement by doing a "x + !x*<blah>" trick.
+    auto x = _sorted_morton_codes(i) ^ _sorted_morton_codes(i + 1);
+    _delta(i) = x + (!x) * (INT_MIN + (i ^ (i + 1)));
+  }
+
+private:
+  Kokkos::View<unsigned const *, MemorySpace> _sorted_morton_codes;
+  Kokkos::Experimental::OffsetView<int *, MemorySpace> _delta;
+  int _n_leaf_nodes;
 };
 
 template <typename ExecutionSpace, typename... MortonCodesViewProperties,
@@ -383,14 +405,30 @@ void generateHierarchy(
     Kokkos::View<Node *, InternalNodesViewProperties...> internal_nodes)
 {
   using MemorySpace = typename decltype(internal_nodes)::memory_space;
-  auto const n_internal_nodes = internal_nodes.extent(0);
+  auto const n_leaf_nodes = leaf_nodes.extent_int(0);
+  auto const leaf_nodes_shift = n_leaf_nodes - 1;
+
+  // Use Kokkos::View for a workaround for the fact that Kokkos::OffsetView
+  // does not support ViewAllocateWithoutInitializing
+  Kokkos::View<int *, MemorySpace> delta_storage(
+      Kokkos::ViewAllocateWithoutInitializing("delta"), n_leaf_nodes + 1);
+  Kokkos::Experimental::OffsetView<int *, MemorySpace> delta(delta_storage,
+                                                             {-1});
+
+  // NOTE: for some reason, KOKKOS_LAMBDA with CUDA does not here. It seems to
+  // be unable to take the pointer of the generateHierarchy function.
+  Kokkos::parallel_for(
+      ARBORX_MARK_REGION("precompute_deltas"),
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<int>>(space, -1,
+                                                                  n_leaf_nodes),
+      ComputeDeltasFunctor<MemorySpace>(sorted_morton_codes, delta));
 
   Kokkos::parallel_for(
       ARBORX_MARK_REGION("generate_hierarchy"),
-      Kokkos::RangePolicy<ExecutionSpace>(space, n_internal_nodes,
-                                          2 * n_internal_nodes + 1),
-      GenerateHierarchyFunctor<MemorySpace>(space, sorted_morton_codes,
-                                            leaf_nodes, internal_nodes));
+      Kokkos::RangePolicy<ExecutionSpace>(space, leaf_nodes_shift,
+                                          leaf_nodes_shift + n_leaf_nodes),
+      GenerateHierarchyFunctor<MemorySpace>(space, delta, leaf_nodes,
+                                            internal_nodes));
 }
 
 template <typename ExecutionSpace, typename... MortonCodesViewProperties,

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -11,7 +11,6 @@
 #include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
 #include "ArborX_EnableViewComparison.hpp"
 #include <ArborX_DetailsAlgorithms.hpp>
-#include <ArborX_DetailsKokkosExt.hpp>  // clz
 #include <ArborX_DetailsMortonCode.hpp> // expandBits, morton3D
 #include <ArborX_DetailsSortUtils.hpp>  // sortObjects
 #include <ArborX_DetailsTreeConstruction.hpp>
@@ -125,121 +124,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(indirect_sort, DeviceType, ARBORX_DEVICE_TYPES)
   BOOST_TEST(ids_host == ref, tt::per_element());
 }
 
-BOOST_AUTO_TEST_CASE(number_of_leading_zero_bits)
-{
-  using KokkosExt::clz;
-  BOOST_TEST(clz(0) == 32);
-  BOOST_TEST(clz(1) == 31);
-  BOOST_TEST(clz(2) == 30);
-  BOOST_TEST(clz(3) == 30);
-  BOOST_TEST(clz(4) == 29);
-  BOOST_TEST(clz(5) == 29);
-  BOOST_TEST(clz(6) == 29);
-  BOOST_TEST(clz(7) == 29);
-  BOOST_TEST(clz(8) == 28);
-  BOOST_TEST(clz(9) == 28);
-  // bitwise exclusive OR operator to compare bits
-  BOOST_TEST(clz(1 ^ 0) == 31);
-  BOOST_TEST(clz(2 ^ 0) == 30);
-  BOOST_TEST(clz(2 ^ 1) == 30);
-  BOOST_TEST(clz(3 ^ 0) == 30);
-  BOOST_TEST(clz(3 ^ 1) == 30);
-  BOOST_TEST(clz(3 ^ 2) == 31);
-  BOOST_TEST(clz(4 ^ 0) == 29);
-  BOOST_TEST(clz(4 ^ 1) == 29);
-  BOOST_TEST(clz(4 ^ 2) == 29);
-  BOOST_TEST(clz(4 ^ 3) == 29);
-}
-
-template <typename DeviceType>
-class FillFi
-{
-public:
-  KOKKOS_INLINE_FUNCTION
-  FillFi(Kokkos::View<unsigned int *, DeviceType> fi)
-      : _fi(fi)
-  {
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(int const i) const
-  {
-    // NOTE: Morton codes below are **not** unique
-    unsigned int fi_array[] = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144};
-
-    _fi[i] = fi_array[i];
-  }
-
-private:
-  Kokkos::View<unsigned int *, DeviceType> _fi;
-};
-
-template <typename DeviceType>
-class ComputeResults
-{
-public:
-  KOKKOS_INLINE_FUNCTION
-  ComputeResults(Kokkos::View<unsigned int *, DeviceType> fi,
-                 Kokkos::View<int *, DeviceType> results)
-      : _fi(fi)
-      , _results(results)
-  {
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(int const i) const
-  {
-    int index_1[] = {0, 0, 1, 1, 1, 2, 2, 0, 12, 12};
-    int index_2[] = {0, 1, 0, 1, 2, 1, 2, -1, 12, 13};
-
-    _results[i] = ArborX::Details::TreeConstruction::commonPrefix(
-        _fi, index_1[i], index_2[i]);
-  }
-
-private:
-  Kokkos::View<unsigned int *, DeviceType> _fi;
-  Kokkos::View<int *, DeviceType> _results;
-};
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(common_prefix, DeviceType, ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  int const n = 13;
-  Kokkos::View<unsigned int *, DeviceType> fi("fi", n);
-  FillFi<DeviceType> fill_fi_functor(fi);
-  Kokkos::parallel_for("fill_fi", Kokkos::RangePolicy<ExecutionSpace>(0, n),
-                       fill_fi_functor);
-
-  int const n_tests = 10;
-  Kokkos::View<int *, DeviceType> results("results", n_tests);
-
-  ComputeResults<DeviceType> compute_results_functor(fi, results);
-  Kokkos::parallel_for("compute_results",
-                       Kokkos::RangePolicy<ExecutionSpace>(0, n_tests),
-                       compute_results_functor);
-
-  auto results_host = Kokkos::create_mirror_view(results);
-  Kokkos::deep_copy(results_host, results);
-
-  auto fi_host = Kokkos::create_mirror_view(fi);
-  Kokkos::deep_copy(fi_host, fi);
-
-  BOOST_TEST(results_host[0] == 32 + 32);
-  BOOST_TEST(results_host[1] == 31);
-  BOOST_TEST(results_host[2] == 31);
-  // duplicate Morton codes
-  BOOST_TEST(fi_host[1] == 1);
-  BOOST_TEST(fi_host[1] == fi_host[2]);
-  BOOST_TEST(results_host[3] == 64);
-  BOOST_TEST(results_host[4] == 32 + 30);
-  BOOST_TEST(results_host[5] == 62);
-  BOOST_TEST(results_host[6] == 64);
-  // by definition \delta(i, j) = -1 when j \notin [0, n-1]
-  BOOST_TEST(results_host[7] == -1);
-  BOOST_TEST(results_host[8] == 64);
-  BOOST_TEST(results_host[9] == -1);
-}
-
 BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
@@ -266,9 +150,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   // reference solution for a recursive traversal from top to bottom
   // starting from root, visiting first the left child and then the right one
   std::ostringstream ref;
-  ref << "I0"
-      << "I3"
+  ref << "I3"
       << "I1"
+      << "I0"
       << "L0"
       << "L1"
       << "I2"
@@ -276,8 +160,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
       << "L3"
       << "I4"
       << "L4"
-      << "I5"
       << "I6"
+      << "I5"
       << "L5"
       << "L6"
       << "L7";
@@ -310,16 +194,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
     }
   };
 
-  Kokkos::View<int *, DeviceType> parents("parents", 2 * n + 1);
-  Kokkos::deep_copy(parents, -1);
-
   typename DeviceType::execution_space space{};
-  ArborX::Details::TreeConstruction::generateHierarchy(
-      space, sorted_morton_codes, leaf_nodes, internal_nodes, parents);
+  int root_node_index = ArborX::Details::TreeConstruction::generateHierarchy(
+      space, sorted_morton_codes, internal_nodes);
 
-  BOOST_TEST(parents(0) == -1);
-
-  Node const *root = internal_nodes.data();
+  Node const *root = internal_nodes.data() + root_node_index;
 
   std::ostringstream sol;
   traverseRecursive(root, sol);

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -150,9 +150,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   // reference solution for a recursive traversal from top to bottom
   // starting from root, visiting first the left child and then the right one
   std::ostringstream ref;
-  ref << "I3"
+  ref << "I0"
+      << "I3"
       << "I1"
-      << "I0"
       << "L0"
       << "L1"
       << "I2"
@@ -160,8 +160,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
       << "L3"
       << "I4"
       << "L4"
-      << "I6"
       << "I5"
+      << "I6"
       << "L5"
       << "L6"
       << "L7";
@@ -195,10 +195,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   };
 
   typename DeviceType::execution_space space{};
-  int root_node_index = ArborX::Details::TreeConstruction::generateHierarchy(
+  ArborX::Details::TreeConstruction::generateHierarchy(
       space, sorted_morton_codes, internal_nodes);
 
-  Node const *root = internal_nodes.data() + root_node_index;
+  Node const *root = internal_nodes.data();
 
   std::ostringstream sol;
   traverseRecursive(root, sol);

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
 
   typename DeviceType::execution_space space{};
   ArborX::Details::TreeConstruction::generateHierarchy(
-      space, sorted_morton_codes, internal_nodes);
+      space, sorted_morton_codes, leaf_nodes, internal_nodes);
 
   Node const *root = internal_nodes.data();
 


### PR DESCRIPTION
I'm opening this PR just to document the work, share my thoughts and solicit feedback.

This is an alternative simpler implementation of the Karras algorithm as described in the paper:
  Apetrei, C. (2014). Fast and simple agglomerative LBVH construction.
It gets rid of some heavy machinery, and constructs the hierarchy in a single bottom-up pass, keeping track of the ranges for each internal node.

~The current implementation work and produces correct result. It also, as expected, speeds up the construction. However, it also affects traversal, sometimes negatively (+15% on large problems for Cuda when queries are unsorted).~

~My current understanding is that the hierarchy is identical, but the internal node numbering is a permutation of Karras. In the original Karras, the children node have consecutive indices and are next to each other. In Apetrei, they are not. And I think this may be the key to the slowdown, as accessing internal nodes is a bit more random. It is also possible that something else is going on, as sorted queries run OK for Cuda.~

~It is annoying that Apetrei's paper did not provide any traversal timings, so there is nothing to compare against.~

~I don’t see a way to solve it at the moment. I am hoping that sharing it here would produce some insight that I have not thought about.~ 

Found a way to fix this, see below.