### PR TITLE
Remove deprecated nearest traversals

### DIFF
--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -25,17 +25,6 @@
 
 namespace ArborX
 {
-namespace Details
-{
-
-// Silly name to discourage misuse...
-enum class NearestQueryAlgorithm
-{
-  StackBased_Default,
-  PriorityQueueBased_Deprecated
-};
-
-} // namespace Details
 
 namespace Experimental
 {
@@ -56,25 +45,12 @@ struct TraversalPolicy
   // Sort predicates allows disabling predicate sorting.
   bool _sort_predicates = true;
 
-  // This parameter lets the developer choose from two different tree
-  // traversal algorithms. With the default argument, the nearest queries are
-  // performed using a stack. This was deemed to be slightly more efficient
-  // than the other alternative that uses a priority queue. The existence of
-  // the parameter shall not be advertised to the user.
-  Details::NearestQueryAlgorithm _traversal_algorithm =
-      Details::NearestQueryAlgorithm::StackBased_Default;
-
   TraversalPolicy &setBufferSize(int buffer_size)
   {
     _buffer_size = buffer_size;
     return *this;
   }
-  TraversalPolicy &
-  setTraversalAlgorithm(Details::NearestQueryAlgorithm traversal_algorithm)
-  {
-    _traversal_algorithm = traversal_algorithm;
-    return *this;
-  }
+
   TraversalPolicy &setPredicateSorting(bool sort_predicates)
   {
     _sort_predicates = sort_predicates;
@@ -223,11 +199,6 @@ queryDispatch(NearestPredicateTag, BVH const &bvh, ExecutionSpace const &space,
 
   using Access = AccessTraits<Predicates, Traits::PredicatesTag>;
   auto const n_queries = Access::size(predicates);
-
-  bool const use_deprecated_nearest_query_algorithm =
-      (policy._traversal_algorithm ==
-       NearestQueryAlgorithm::PriorityQueueBased_Deprecated);
-  std::ignore = use_deprecated_nearest_query_algorithm;
 
   Kokkos::Profiling::pushRegion("ArborX:BVH:nearest_queries:init_and_alloc");
 

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -16,6 +16,7 @@
 #include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsStack.hpp>
+#include <ArborX_DetailsUtils.hpp>
 #include <ArborX_Exception.hpp>
 #include <ArborX_Macros.hpp>
 #include <ArborX_Predicates.hpp>
@@ -123,9 +124,6 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
   }
 };
 
-// NOTE using tuple as a workaround
-// Error: class template partial specialization contains a template parameter
-// that cannot be deduced
 template <typename BVH, typename Predicates, typename Callback>
 struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
 {
@@ -354,200 +352,6 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
       int const leaf_index = (heap.data() + i)->first;
       auto const leaf_distance = (heap.data() + i)->second;
       callback_(predicate, leaf_index, leaf_distance);
-    }
-    return heap.size();
-  }
-
-  struct Deprecated
-  {
-  };
-
-  // This is the older version of the nearest traversal that uses a priority
-  // queue and that was deemed less performant than the newer version with a
-  // stack.
-  KOKKOS_FUNCTION int operator()(Deprecated, int queryIndex) const
-  {
-    auto const &predicate = Access::get(predicates_, queryIndex);
-    auto const k = getK(predicate);
-    auto const distance = [geometry = getGeometry(predicate),
-                           bvh = bvh_](Node const *node) {
-      return Details::distance(geometry, bvh.getBoundingVolume(node));
-    };
-
-    // NOTE thinking about making this a precondition
-    if (k < 1)
-      return 0;
-
-    using PairNodePtrDistance = Kokkos::pair<Node const *, float>;
-    struct CompareDistance
-    {
-      KOKKOS_INLINE_FUNCTION bool
-      operator()(PairNodePtrDistance const &lhs,
-                 PairNodePtrDistance const &rhs) const
-      {
-        // Reverse order (larger distance means lower priority)
-        return lhs.second > rhs.second;
-      }
-    };
-    PriorityQueue<PairNodePtrDistance, CompareDistance,
-                  StaticVector<PairNodePtrDistance, 256>>
-        queue;
-
-    // Do not bother computing the distance to the root node since it is
-    // immediately popped out of the stack and processed.
-    queue.emplace(bvh_.getRoot(), 0.);
-    decltype(k) count = 0;
-
-    while (!queue.empty() && count < k)
-    {
-      // Get the node that is on top of the priority list (i.e. the
-      // one that is closest to the query point)
-      Node const *node = queue.top().first;
-      auto const node_distance = queue.top().second;
-
-      if (node->isLeaf())
-      {
-        queue.pop();
-        callback_(predicate, node->getLeafPermutationIndex(), node_distance);
-        ++count;
-      }
-      else
-      {
-        // Insert children into the priority queue
-        Node const *left_child = bvh_.getNodePtr(node->children.first);
-        Node const *right_child = bvh_.getNodePtr(node->children.second);
-        auto const left_child_distance = distance(left_child);
-        auto const right_child_distance = distance(right_child);
-        queue.popPush(left_child, left_child_distance);
-        queue.emplace(right_child, right_child_distance);
-      }
-    }
-    return count;
-  }
-};
-
-template <typename BVH>
-using DeprecatedTreeTraversal = TreeTraversal<BVH, void, void, void>;
-
-template <typename BVH>
-struct TreeTraversal<BVH, void, void, void>
-{
-  // WARNING deprecated will be removed soon
-  // still used in TreeVisualization
-  template <typename Distance, typename Insert, typename Buffer>
-  KOKKOS_FUNCTION static int
-  nearestQuery(BVH const &bvh, Distance const &distance, std::size_t k,
-               Insert const &insert, Buffer const &buffer)
-  {
-    if (bvh.empty() || k < 1)
-      return 0;
-
-    if (bvh.size() == 1)
-    {
-      insert(0, distance(bvh.getRoot()));
-      return 1;
-    }
-
-    // Nodes with a distance that exceed that radius can safely be
-    // discarded. Initialize the radius to infinity and tighten it once k
-    // neighbors have been found.
-    auto radius = KokkosExt::ArithmeticTraits::infinity<float>::value;
-
-    using PairIndexDistance = Kokkos::pair<int, float>;
-    static_assert(
-        std::is_same<typename Buffer::value_type, PairIndexDistance>::value,
-        "Type of the elements stored in the buffer passed as argument to "
-        "TreeTraversal::nearestQuery is not right");
-    struct CompareDistance
-    {
-      KOKKOS_INLINE_FUNCTION bool operator()(PairIndexDistance const &lhs,
-                                             PairIndexDistance const &rhs) const
-      {
-        return lhs.second < rhs.second;
-      }
-    };
-    // Use a priority queue for convenience to store the results and
-    // preserve the heap structure internally at all time.  There is no
-    // memory allocation, elements are stored in the buffer passed as an
-    // argument. The farthest leaf node is on top.
-    assert(k == buffer.size());
-    PriorityQueue<PairIndexDistance, CompareDistance,
-                  UnmanagedStaticVector<PairIndexDistance>>
-        heap(UnmanagedStaticVector<PairIndexDistance>(buffer.data(),
-                                                      buffer.size()));
-
-    using PairNodePtrDistance = Kokkos::pair<Node const *, float>;
-    Stack<PairNodePtrDistance> stack;
-    // Do not bother computing the distance to the root node since it is
-    // immediately popped out of the stack and processed.
-    stack.emplace(bvh.getRoot(), 0.);
-
-    while (!stack.empty())
-    {
-      Node const *node = stack.top().first;
-      auto const node_distance = stack.top().second;
-      stack.pop();
-
-      if (node_distance < radius)
-      {
-        if (node->isLeaf())
-        {
-          int const leaf_index = node->getLeafPermutationIndex();
-          auto const leaf_distance = node_distance;
-          if (heap.size() < k)
-          {
-            // Insert leaf node and update radius if it was the kth
-            // one.
-            heap.push(Kokkos::make_pair(leaf_index, leaf_distance));
-            if (heap.size() == k)
-              radius = heap.top().second;
-          }
-          else
-          {
-            // Replace top element in the heap and update radius.
-            heap.popPush(Kokkos::make_pair(leaf_index, leaf_distance));
-            radius = heap.top().second;
-          }
-        }
-        else
-        {
-          // Insert children into the stack and make sure that the
-          // closest one ends on top.
-          Node const *left_child = bvh.getNodePtr(node->children.first);
-          Node const *right_child = bvh.getNodePtr(node->children.second);
-          auto const left_child_distance = distance(left_child);
-          auto const right_child_distance = distance(right_child);
-          if (left_child_distance < right_child_distance)
-          {
-            // NOTE not really sure why but it performed better with
-            // the conditional insertion on the device and without
-            // it on the host (~5% improvement for both)
-#if defined(__CUDA_ARCH__)
-            if (right_child_distance < radius)
-#endif
-              stack.emplace(right_child, right_child_distance);
-            stack.emplace(left_child, left_child_distance);
-          }
-          else
-          {
-#if defined(__CUDA_ARCH__)
-            if (left_child_distance < radius)
-#endif
-              stack.emplace(left_child, left_child_distance);
-            stack.emplace(right_child, right_child_distance);
-          }
-        }
-      }
-    }
-    // Sort the leaf nodes and output the results.
-    // NOTE: Do not try this at home.  Messing with the underlying container
-    // invalidates the state of the PriorityQueue.
-    sortHeap(heap.data(), heap.data() + heap.size(), heap.valueComp());
-    for (decltype(heap.size()) i = 0; i < heap.size(); ++i)
-    {
-      int const leaf_index = (heap.data() + i)->first;
-      auto const leaf_distance = (heap.data() + i)->second;
-      insert(leaf_index, leaf_distance);
     }
     return heap.size();
   }


### PR DESCRIPTION
Main motivation is reduce maintenance cost prior to integrating
stackless traversals. The code remains in history, and could be easily
resurrected if desired.