### PR TITLE
Add MPI guards for test helpers

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -160,9 +160,7 @@ pipeline {
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
-                                    -D ARBORX_ENABLE_MPI=ON \
-                                    -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
-                                    -D MPIEXEC_MAX_NUMPROCS=4 \
+                                    -D ARBORX_ENABLE_MPI=OFF \
                                     -D ARBORX_ENABLE_TESTS=ON \
                                     -D ARBORX_ENABLE_EXAMPLES=ON \
                                     -D ARBORX_ENABLE_BENCHMARKS=ON \

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -141,6 +141,7 @@ zip(ExecutionSpace const &space, Kokkos::View<int *, DeviceType> indices,
   return values;
 }
 
+#ifdef ARBORX_ENABLE_MPI
 template <typename Tree, typename Queries>
 auto query_with_distance(Tree const &tree, Queries const &queries,
                          std::enable_if_t<is_distributed<Tree>{}> * = nullptr)
@@ -162,6 +163,7 @@ auto query_with_distance(Tree const &tree, Queries const &queries,
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, values));
 }
+#endif
 
 #define ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(tree, queries, reference)         \
   BOOST_TEST(query_with_distance(tree, queries) == (reference),                \


### PR DESCRIPTION
I don't understand how this slipped through. We have CI testing with `ARBORX_ENABLE_MPI=OFF`. But it did not catch it? This was immediately caught on my workstation.