### PR TITLE
Avoid double free in distributed tree

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -120,11 +120,14 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
   // Create new context for the library to isolate library's communication from
   // user's
   _comm_ptr.reset(
+      // duplicate the communicator and store it in a std::shared_ptr so that
+      // all copies of the distributed tree point to the same object
       [comm]() {
         auto p = std::make_unique<MPI_Comm>();
         MPI_Comm_dup(comm, p.get());
         return p.release();
       }(),
+      // custom deleter to mark the communicator object for deallocation
       [](MPI_Comm *p) {
         MPI_Comm_free(p);
         delete p;

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -54,7 +54,7 @@ struct DistributedSearchTreeImpl
                 IndicesAndRanks &values, Offset &offset)
   {
     int comm_rank;
-    MPI_Comm_rank(tree._comm, &comm_rank);
+    MPI_Comm_rank(tree.getComm(), &comm_rank);
     queryDispatch(SpatialPredicateTag{}, tree, space, queries,
                   CallbackDefaultSpatialPredicateWithRank{comm_rank}, values,
                   offset);
@@ -379,7 +379,7 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
     Offset &offset, Ranks &ranks, Distances *distances_ptr)
 {
   auto const &bottom_tree = tree._bottom_tree;
-  auto comm = tree._comm;
+  auto comm = tree.getComm();
 
   Distances distances("distances", 0);
   if (distances_ptr)
@@ -452,7 +452,7 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
 {
   auto const &top_tree = tree._top_tree;
   auto const &bottom_tree = tree._bottom_tree;
-  auto comm = tree._comm;
+  auto comm = tree.getComm();
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> ranks("ranks", 0);


### PR DESCRIPTION
Proposed resolution for #368
Stores the duplicated comm in a smart pointer with a custom deleter.