### PR TITLE
Apply clang-tidy also to header files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -76,7 +76,7 @@ CheckOptions:
   - key:             performance-inefficient-vector-operation.VectorLikeClasses
     value:           '::std::vector'
   - key:             performance-move-const-arg.CheckTriviallyCopyableMove
-    value:           '1'
+    value:           '0'
   - key:             performance-move-constructor-init.IncludeStyle
     value:           llvm
   - key:             performance-type-promotion-in-math-fn.IncludeStyle

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix'
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
+HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:    

--- a/examples/halo_finder/ArborX_HaloFinder.hpp
+++ b/examples/halo_finder/ArborX_HaloFinder.hpp
@@ -229,7 +229,8 @@ struct CCSCallback
     int curr = stat_(i);
     if (curr != i)
     {
-      int next, prev = i;
+      int next;
+      int prev = i;
       while (curr > (next = stat_(curr)))
       {
         stat_(prev) = next;
@@ -372,7 +373,8 @@ void findHalos(ExecutionSpace exec_space, Primitives const &primitives,
                        Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
                        KOKKOS_LAMBDA(int const i) {
                          // ##### ECL license (see LICENSE.ECL) #####
-                         int next, vstat = stat(i);
+                         int next;
+                         int vstat = stat(i);
                          int const old = vstat;
                          while (vstat > (next = stat(vstat)))
                          {

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -192,7 +192,7 @@ struct DistributedSearchTreeImpl
   template <typename ExecutionSpace, typename OutputView, typename Ranks,
             typename Distances = Kokkos::View<float *, DeviceType>>
   static void communicateResultsBack(MPI_Comm comm, ExecutionSpace const &space,
-                                     OutputView &view,
+                                     OutputView &out,
                                      Kokkos::View<int *, DeviceType> offset,
                                      Ranks &ranks,
                                      Kokkos::View<int *, DeviceType> &ids,

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -46,7 +46,7 @@ struct Node
 KOKKOS_INLINE_FUNCTION constexpr Node
 makeLeafNode(std::size_t permutation_index, Box box) noexcept
 {
-  return {{-1, static_cast<int>(permutation_index)}, std::move(box)};
+  return {{-1, static_cast<int>(permutation_index)}, box};
 }
 } // namespace Details
 } // namespace ArborX

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -46,7 +46,7 @@ struct Node
 KOKKOS_INLINE_FUNCTION constexpr Node
 makeLeafNode(std::size_t permutation_index, Box box) noexcept
 {
-  return {{-1, static_cast<int>(permutation_index)}, box};
+  return {{-1, static_cast<int>(permutation_index)}, std::move(box)};
 }
 } // namespace Details
 } // namespace ArborX

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -105,7 +105,7 @@ public:
   template <typename... Args>
   KOKKOS_INLINE_FUNCTION void popPush(Args &&... args)
   {
-    assert(_c.size() > 0);
+    assert(!_c.empty());
     bubbleDown(_c.data(), std::ptrdiff_t(0), std::ptrdiff_t(_c.size()),
                T{std::forward<Args>(args)...}, _compare);
   }

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -57,7 +57,7 @@ create_layout_right_mirror_view(
                                            Kokkos::LayoutStride>::value)) &&
         std::is_same<typename View::traits::memory_space,
                      typename ExecutionSpace::memory_space>::value)>::type * =
-        0)
+        nullptr)
 {
   constexpr int pointer_depth =
       internal::PointerDepth<typename View::traits::data_type>::value;
@@ -83,7 +83,7 @@ inline auto create_layout_right_mirror_view(
                                             Kokkos::LayoutStride>::value)) &&
          std::is_same<typename View::traits::memory_space,
                       typename ExecutionSpace::memory_space>::value)>::type * =
-        0)
+        nullptr)
 {
   return src;
 }
@@ -138,7 +138,7 @@ inline auto create_layout_right_mirror_view_and_copy(
                                             Kokkos::LayoutStride>::value)) &&
          std::is_same<typename View::traits::memory_space,
                       typename ExecutionSpace::memory_space>::value)>::type * =
-        0)
+        nullptr)
 {
   return src;
 }

--- a/test/ArborX_BoostGeometryAdapters.hpp
+++ b/test/ArborX_BoostGeometryAdapters.hpp
@@ -27,19 +27,19 @@ namespace traits
 template <>
 struct tag<ArborX::Point>
 {
-  typedef point_tag type;
+  using type = point_tag;
 };
 
 template <>
 struct coordinate_type<ArborX::Point>
 {
-  typedef float type;
+  using type = float;
 };
 
 template <>
 struct coordinate_system<ArborX::Point>
 {
-  typedef cs::cartesian type;
+  using type = cs::cartesian;
 };
 
 template <>
@@ -59,13 +59,13 @@ struct access<ArborX::Point, D>
 template <>
 struct tag<ArborX::Box>
 {
-  typedef box_tag type;
+  using type = box_tag;
 };
 
 template <>
 struct point_type<ArborX::Box>
 {
-  typedef ArborX::Point type;
+  using type = ArborX::Point;
 };
 
 template <size_t D>

--- a/test/ArborX_BoostRangeAdapters.hpp
+++ b/test/ArborX_BoostRangeAdapters.hpp
@@ -38,8 +38,8 @@ struct range_iterator<Kokkos::View<T, P...>>
 {
   using View = Kokkos::View<T, P...>;
   ARBORX_ASSERT_VIEW_COMPATIBLE(View)
-  typedef typename std::add_pointer<
-      typename Kokkos::ViewTraits<T, P...>::value_type>::type type;
+  using type = typename std::add_pointer<
+      typename Kokkos::ViewTraits<T, P...>::value_type>::type;
 };
 
 template <typename T, typename... P>
@@ -47,8 +47,8 @@ struct range_const_iterator<Kokkos::View<T, P...>>
 {
   using View = Kokkos::View<T, P...>;
   ARBORX_ASSERT_VIEW_COMPATIBLE(View)
-  typedef typename std::add_pointer<
-      typename Kokkos::ViewTraits<T, P...>::const_value_type>::type type;
+  using type = typename std::add_pointer<
+      typename Kokkos::ViewTraits<T, P...>::const_value_type>::type;
 };
 
 template <typename T, typename... P>
@@ -56,7 +56,7 @@ struct range_value<Kokkos::View<T, P...>>
 {
   using View = Kokkos::View<T, P...>;
   ARBORX_ASSERT_VIEW_COMPATIBLE(View)
-  typedef typename Kokkos::ViewTraits<T, P...>::value_type type;
+  using type = typename Kokkos::ViewTraits<T, P...>::value_type;
 };
 
 template <typename T, typename... P>
@@ -64,7 +64,7 @@ struct range_reference<Kokkos::View<T, P...>>
 {
   using View = Kokkos::View<T, P...>;
   ARBORX_ASSERT_VIEW_COMPATIBLE(View)
-  typedef typename Kokkos::ViewTraits<T, P...>::reference_type type;
+  using type = typename Kokkos::ViewTraits<T, P...>::reference_type;
 };
 
 template <typename T, typename... P>
@@ -72,7 +72,7 @@ struct range_size<Kokkos::View<T, P...>>
 {
   using View = Kokkos::View<T, P...>;
   ARBORX_ASSERT_VIEW_COMPATIBLE(View)
-  typedef typename Kokkos::ViewTraits<T, P...>::size_type type;
+  using type = typename Kokkos::ViewTraits<T, P...>::size_type;
 };
 
 } // namespace boost


### PR DESCRIPTION
We forgot to set the header filter so no header files were checked. This pull requests fixes all `clang-tidy 9` complains.