### PR TITLE
Fix profiling region in BVH constructor

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -161,6 +161,7 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
 
   if (empty())
   {
+    Kokkos::Profiling::popRegion();
     return;
   }
 
@@ -178,6 +179,7 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
         Kokkos::view_alloc("permute", space), 1);
     Details::TreeConstruction::initializeLeafNodes(
         space, primitives, permutation_indices, getLeafNodes());
+    Kokkos::Profiling::popRegion();
     return;
   }
 


### PR DESCRIPTION
Fix #376.

The issue was reported by @uhetmaniuk

We call `Kokkos::Profiling::pushRegion()` at the very top of the constructor and when zero primitives are passed we are exiting early and forget to call `Kokkos::Profiling::popRegion()`.

Having a local empty tree is not uncommon with the distributed tree and this was causing the Space Time Stack tool to crash with `Program ended before "ArborX:BVH:construction" ended`.
