### PR TITLE
Ensure that all kernels from BVH are properly marked

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,7 +63,7 @@ target_compile_definitions(ArborX_DetailsAlgorithms.exe PRIVATE BOOST_TEST_MAIN 
 target_include_directories(ArborX_DetailsAlgorithms.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME ArborX_DetailsAlgorithms_Test COMMAND ./ArborX_DetailsAlgorithms.exe)
 
-add_executable(ArborX_LinearBVH.exe tstLinearBVH.cpp utf_main.cpp)
+add_executable(ArborX_LinearBVH.exe tstLinearBVH.cpp tstKokkosToolsAnnotations.cpp utf_main.cpp)
 target_link_libraries(ArborX_LinearBVH.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_LinearBVH.exe PRIVATE BOOST_TEST_DYN_LINK)
 target_include_directories(ArborX_LinearBVH.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/VectorOfTuples.hpp
+++ b/test/VectorOfTuples.hpp
@@ -31,7 +31,7 @@ struct ArrayTraits
   static value_type const &access(array_type const &, std::size_t);
 };
 
-void checkProperlySized(std::size_t, std::size_t) {}
+inline void checkProperlySized(std::size_t, std::size_t) {}
 
 // Checks that all the arrays have size s. The only sensible value for pos is 1
 // to get the appropriate error message when not calling it recursively.

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * Copyright (c) 2012-2020 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include <ArborX_LinearBVH.hpp>
+
+#include <impl/Kokkos_Profiling.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+#include "Search_UnitTestHelpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(KokkosToolsAnnotations)
+
+namespace tt = boost::test_tools;
+
+template <typename T>
+struct TreeTypeTraits;
+
+template <typename... DeviceTypes>
+struct TreeTypeTraits<std::tuple<DeviceTypes...>>
+{
+  using type = std::tuple<ArborX::BVH<DeviceTypes>...>;
+};
+
+using TreeTypes = typename TreeTypeTraits<ARBORX_DEVICE_TYPES>::type;
+
+bool isPrefixedWith(std::string const &s, std::string const &prefix)
+{
+  return s.find(prefix) == 0;
+}
+
+BOOST_AUTO_TEST_CASE(is_prefixed_with)
+{
+  BOOST_TEST(isPrefixedWith("ArborX::Whatever", "ArborX"));
+  BOOST_TEST(!isPrefixedWith("Nope", "ArborX"));
+  BOOST_TEST(!isPrefixedWith("Nope::ArborX", "ArborX"));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, Tree, TreeTypes)
+{
+  auto const callback = [](char const *label, uint32_t, uint64_t *) {
+    std::cout << label << '\n';
+    BOOST_TEST((isPrefixedWith(label, "ArborX_") ||
+                isPrefixedWith(label, "Kokkos::")));
+  };
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(callback);
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(callback);
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(callback);
+
+  // BVH::BVH
+
+  { // default constructed
+    Tree tree;
+  }
+
+  { // empty
+    auto tree = make<Tree>({});
+  }
+
+  { // one leaf
+    auto tree = make<Tree>({
+        {{{0, 0, 0}}, {{1, 1, 1}}},
+    });
+  }
+
+  { // two leaves
+    auto tree = make<Tree>({
+        {{{0, 0, 0}}, {{1, 1, 1}}},
+        {{{0, 0, 0}}, {{1, 1, 1}}},
+    });
+  }
+
+  // BVH::query
+
+  auto tree = make<Tree>({
+      {{{0, 0, 0}}, {{1, 1, 1}}},
+      {{{0, 0, 0}}, {{1, 1, 1}}},
+  });
+
+  using DeviceType = typename Tree::device_type;
+
+  // spatial predicates
+  query(tree, makeIntersectsBoxQueries<DeviceType>({
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+              }));
+
+  // nearest predicates
+  query(tree, makeNearestQueries<DeviceType>({
+                  {{{0, 0, 0}}, 1},
+                  {{{0, 0, 0}}, 2},
+              }));
+
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -12,13 +12,14 @@
 #include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
 #include <ArborX_LinearBVH.hpp>
 
-#include <impl/Kokkos_Profiling.hpp>
-
 #include <boost/test/unit_test.hpp>
 
 #include <string>
 
 #include "Search_UnitTestHelpers.hpp"
+
+#if (KOKKOS_VERSION >= 30200) // callback registriation from within the program
+                              // was added in Kokkkos v3.2
 
 BOOST_AUTO_TEST_SUITE(KokkosToolsAnnotations)
 
@@ -108,3 +109,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, Tree, TreeTypes)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#endif


### PR DESCRIPTION
Related #362 except that it focus on enforcement and does not apply any change yet.

This is going to fail because it requires Kokkos 3.2
Should I insert an `#if KOKKOS_VERSION >= 30200` or conditionally add from CMake?