### PR TITLE
Prefix view names allocated from BVH

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -147,9 +147,9 @@ template <typename ExecutionSpace, typename Primitives>
 BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
     ExecutionSpace const &space, Primitives const &primitives)
     : _size(AccessTraits<Primitives, PrimitivesTag>::size(primitives))
-    , _internal_and_leaf_nodes(
-          Kokkos::ViewAllocateWithoutInitializing("internal_and_leaf_nodes"),
-          _size > 0 ? 2 * _size - 1 : 0)
+    , _internal_and_leaf_nodes(Kokkos::ViewAllocateWithoutInitializing(
+                                   "ArborX::BVH::BVH::internal_and_leaf_nodes"),
+                               _size > 0 ? 2 * _size - 1 : 0)
 {
   Kokkos::Profiling::pushRegion("ArborX:BVH:construction");
 
@@ -176,7 +176,7 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
   if (size() == 1)
   {
     Kokkos::View<unsigned int *, MemorySpace> permutation_indices(
-        Kokkos::view_alloc("permute", space), 1);
+        Kokkos::view_alloc("ArborX::BVH::BVH::permute", space), 1);
     Details::TreeConstruction::initializeLeafNodes(
         space, primitives, permutation_indices, getLeafNodes());
     Kokkos::Profiling::popRegion();
@@ -187,7 +187,8 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
 
   // calculate Morton codes of all objects
   Kokkos::View<unsigned int *, MemorySpace> morton_indices(
-      Kokkos::ViewAllocateWithoutInitializing("morton"), size());
+      Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::BVH::morton"),
+      size());
   Details::TreeConstruction::assignMortonCodes(space, primitives,
                                                morton_indices, _bounds);
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -148,7 +148,7 @@ BoundingVolumeHierarchy<MemorySpace, Enable>::BoundingVolumeHierarchy(
     ExecutionSpace const &space, Primitives const &primitives)
     : _size(AccessTraits<Primitives, PrimitivesTag>::size(primitives))
     , _internal_and_leaf_nodes(Kokkos::ViewAllocateWithoutInitializing(
-                                   "ArborX::BVH::BVH::internal_and_leaf_nodes"),
+                                   "ArborX::BVH::internal_and_leaf_nodes"),
                                _size > 0 ? 2 * _size - 1 : 0)
 {
   Kokkos::Profiling::pushRegion("ArborX:BVH:construction");

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -57,7 +57,8 @@ public:
     auto const n_queries = Access::size(predicates);
 
     Kokkos::View<unsigned int *, DeviceType> morton_codes(
-        Kokkos::ViewAllocateWithoutInitializing("morton"), n_queries);
+        Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::query::morton"),
+        n_queries);
     Kokkos::parallel_for(
         ARBORX_MARK_REGION("assign_morton_codes_to_queries"),
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),

--- a/src/details/ArborX_DetailsBufferOptimization.hpp
+++ b/src/details/ArborX_DetailsBufferOptimization.hpp
@@ -246,7 +246,8 @@ void queryImpl(ExecutionSpace const &space, TreeTraversal const &tree_traversal,
   Kokkos::Profiling::pushRegion("ArborX:BVH:two_pass");
 
   using CountView = OffsetView;
-  CountView counts(Kokkos::view_alloc("counts", space), n_queries);
+  CountView counts(Kokkos::view_alloc("ArborX::BVH::query::counts", space),
+                   n_queries);
 
   using PermutedPredicates =
       PermutedData<Predicates, PermuteType, true /*AttachIndices*/>;
@@ -308,7 +309,7 @@ void queryImpl(ExecutionSpace const &space, TreeTraversal const &tree_traversal,
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion("ArborX:BVH:two_pass:first_pass_postprocess");
 
-  OffsetView preallocated_offset("offset_copy", 0);
+  OffsetView preallocated_offset("ArborX::BVH::query::offset_copy", 0);
   if (underflow)
   {
     // Store a copy of the original offset. We'll need it for compression.

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -78,7 +78,7 @@ sortObjects(ExecutionSpace const &space, ViewType &view)
   if (result.min_val == result.max_val)
   {
     Kokkos::View<SizeType *, typename ViewType::device_type> permute(
-        Kokkos::ViewAllocateWithoutInitializing("permute"), n);
+        Kokkos::ViewAllocateWithoutInitializing("ArborX::Sorting::permute"), n);
     iota(space, permute);
     return permute;
   }

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -226,8 +226,9 @@ public:
       : _sorted_morton_codes(sorted_morton_codes)
       , _leaf_nodes(leaf_nodes)
       , _internal_nodes(internal_nodes)
-      , _ranges(Kokkos::ViewAllocateWithoutInitializing("ranges"),
-                internal_nodes.extent(0))
+      , _ranges(
+            Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::BVH::ranges"),
+            internal_nodes.extent(0))
       , _num_internal_nodes(_internal_nodes.extent_int(0))
   {
     Kokkos::deep_copy(space, _ranges, UNTOUCHED_NODE);

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -157,8 +157,9 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
   {
     auto const n_queries = Access::size(predicates_);
 
-    Offset offset(Kokkos::ViewAllocateWithoutInitializing("offset"),
-                  n_queries + 1);
+    Offset offset(
+        Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::query::offset"),
+        n_queries + 1);
     // NOTE workaround to avoid implicit capture of *this
     auto const &predicates = predicates_;
     Kokkos::parallel_for(
@@ -172,8 +173,9 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     // It is not possible to anticipate how much memory to allocate since the
     // number of nearest neighbors k is only known at runtime.
 
-    Buffer buffer(Kokkos::ViewAllocateWithoutInitializing("buffer"),
-                  buffer_size);
+    Buffer buffer(
+        Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::query::buffer"),
+        buffer_size);
     buffer_ = BufferProvider{buffer, offset};
   }
 

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -94,8 +94,8 @@ auto query(Tree const &tree, Queries const &queries)
   using device_type = typename Tree::device_type;
   using value_type =
       std::conditional_t<is_distributed<Tree>{}, Kokkos::pair<int, int>, int>;
-  Kokkos::View<value_type *, device_type> values("values", 0);
-  Kokkos::View<int *, device_type> offsets("offsets", 0);
+  Kokkos::View<value_type *, device_type> values("Testing::values", 0);
+  Kokkos::View<int *, device_type> offsets("Testing::offsets", 0);
   tree.query(queries, values, offsets);
   return make_compressed_storage(
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
@@ -111,8 +111,9 @@ auto query_with_distance(Tree const &tree, Queries const &queries,
                          std::enable_if_t<!is_distributed<Tree>{}> * = nullptr)
 {
   using device_type = typename Tree::device_type;
-  Kokkos::View<Kokkos::pair<int, float> *, device_type> values("values", 0);
-  Kokkos::View<int *, device_type> offsets("offsets", 0);
+  Kokkos::View<Kokkos::pair<int, float> *, device_type> values(
+      "Testing::values", 0);
+  Kokkos::View<int *, device_type> offsets("Testing::offsets", 0);
   tree.query(queries,
              ArborX::Details::CallbackDefaultNearestPredicateWithDistance{},
              values, offsets);
@@ -132,7 +133,8 @@ zip(ExecutionSpace const &space, Kokkos::View<int *, DeviceType> indices,
 {
   auto const n = indices.extent(0);
   Kokkos::View<Kokkos::pair<Kokkos::pair<int, int>, float> *, DeviceType>
-      values(Kokkos::view_alloc(Kokkos::WithoutInitializing, "values"), n);
+      values(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::values"),
+             n);
   Kokkos::parallel_for("ArborX:UnitTestSupport:zip",
                        Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),
                        KOKKOS_LAMBDA(int i) {
@@ -147,10 +149,10 @@ auto query_with_distance(Tree const &tree, Queries const &queries,
                          std::enable_if_t<is_distributed<Tree>{}> * = nullptr)
 {
   using device_type = typename Tree::device_type;
-  Kokkos::View<int *, device_type> offsets("offsets", 0);
-  Kokkos::View<int *, device_type> indices("indices", 0);
-  Kokkos::View<int *, device_type> ranks("ranks", 0);
-  Kokkos::View<float *, device_type> distances("distances", 0);
+  Kokkos::View<int *, device_type> offsets("Testing::offsets", 0);
+  Kokkos::View<int *, device_type> indices("Testing::indices", 0);
+  Kokkos::View<int *, device_type> ranks("Testing::ranks", 0);
+  Kokkos::View<float *, device_type> distances("Testing::distances", 0);
   using ExecutionSpace = typename device_type::execution_space;
   ExecutionSpace space;
   ArborX::Details::DistributedSearchTreeImpl<device_type>::queryDispatchImpl(
@@ -173,7 +175,8 @@ template <typename Tree>
 auto make(std::vector<ArborX::Box> const &b)
 {
   int const n = b.size();
-  Kokkos::View<ArborX::Box *, typename Tree::device_type> boxes("boxes", n);
+  Kokkos::View<ArborX::Box *, typename Tree::device_type> boxes(
+      "Testing::boxes", n);
   auto boxes_host = Kokkos::create_mirror_view(boxes);
   for (int i = 0; i < n; ++i)
     boxes_host(i) = b[i];
@@ -187,7 +190,7 @@ ArborX::DistributedSearchTree<DeviceType>
 makeDistributedSearchTree(MPI_Comm comm, std::vector<ArborX::Box> const &b)
 {
   int const n = b.size();
-  Kokkos::View<ArborX::Box *, DeviceType> boxes("boxes", n);
+  Kokkos::View<ArborX::Box *, DeviceType> boxes("Testing::boxes", n);
   auto boxes_host = Kokkos::create_mirror_view(boxes);
   for (int i = 0; i < n; ++i)
     boxes_host(i) = b[i];
@@ -201,7 +204,7 @@ auto makeIntersectsBoxQueries(std::vector<ArborX::Box> const &boxes)
 {
   int const n = boxes.size();
   Kokkos::View<decltype(ArborX::intersects(ArborX::Box{})) *, DeviceType>
-      queries("intersecting_with_box_predicates", n);
+      queries("Testing::intersecting_with_box_predicates", n);
   auto queries_host = Kokkos::create_mirror_view(queries);
   for (int i = 0; i < n; ++i)
     queries_host(i) = ArborX::intersects(boxes[i]);
@@ -217,7 +220,7 @@ auto makeIntersectsBoxWithAttachmentQueries(
   Kokkos::View<decltype(
                    ArborX::attach(ArborX::intersects(ArborX::Box{}), Data{})) *,
                DeviceType>
-      queries("intersecting_with_box_with_attachment_predicates", n);
+      queries("Testing::intersecting_with_box_with_attachment_predicates", n);
   auto queries_host = Kokkos::create_mirror_view(queries);
   for (int i = 0; i < n; ++i)
     queries_host(i) = ArborX::attach(ArborX::intersects(boxes[i]), data[i]);
@@ -233,7 +236,7 @@ auto makeNearestQueries(
   // actual point and the number k of neighbors to query for.
   int const n = points.size();
   Kokkos::View<ArborX::Nearest<ArborX::Point> *, DeviceType> queries(
-      "nearest_queries", n);
+      "Testing::nearest_queries", n);
   auto queries_host = Kokkos::create_mirror_view(queries);
   for (int i = 0; i < n; ++i)
     queries_host(i) = ArborX::nearest(points[i].first, points[i].second);
@@ -252,7 +255,7 @@ auto makeNearestWithAttachmentQueries(
   Kokkos::View<decltype(
                    ArborX::attach(ArborX::Nearest<ArborX::Point>{}, Data{})) *,
                DeviceType>
-      queries("nearest_queries", n);
+      queries("Testing::nearest_queries", n);
   auto queries_host = Kokkos::create_mirror_view(queries);
   for (int i = 0; i < n; ++i)
     queries_host(i) = ArborX::attach(
@@ -270,7 +273,7 @@ makeIntersectsSphereQueries(
   // actual point and the radius for the search around that point.
   int const n = points.size();
   Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
-      queries("intersecting_with_sphere_predicates", n);
+      queries("Testing::intersecting_with_sphere_predicates", n);
   auto queries_host = Kokkos::create_mirror_view(queries);
   for (int i = 0; i < n; ++i)
     queries_host(i) =


### PR DESCRIPTION
Will need to be rebased onto #380 

Using
* `ArborX::BVH::BVH::` for all views allocated from the constructor
* `ArborX::BVH::queries::` for all views allocated during the search
* `ArborX::Sorting::` for the view with the permutation indices from the sorting utility function
* `Testing::` for all view allocated from the unit tests

Partially addressing #362