### PR TITLE
Remove BVH forward declaration in viz

### DIFF
--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -20,9 +20,6 @@
 namespace ArborX
 {
 
-template <typename DeviceType, typename Enable>
-class BoundingVolumeHierarchy;
-
 namespace Details
 {
 std::ostream &operator<<(std::ostream &os, Point const &p)

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -39,13 +39,11 @@ struct TreeVisualization
                 "tree visualization only available on the host");
   struct TreeAccess
   {
-    KOKKOS_INLINE_FUNCTION
-    static Node const *getLeaf(
-        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
-            &bvh,
-        size_t index)
+    template <typename Tree>
+    KOKKOS_INLINE_FUNCTION static Node const *getLeaf(Tree const &tree,
+                                                      size_t index)
     {
-      auto leaf_nodes = bvh.getLeafNodes();
+      auto leaf_nodes = tree.getLeafNodes();
       Node const *first = leaf_nodes.data();
       Node const *last = first + static_cast<ptrdiff_t>(leaf_nodes.size());
       for (; first != last; ++first)
@@ -54,31 +52,25 @@ struct TreeVisualization
       return nullptr;
     }
 
-    KOKKOS_INLINE_FUNCTION
-    static int getIndex(
-        Node const *node,
-        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
-            &bvh)
+    template <typename Tree>
+    KOKKOS_INLINE_FUNCTION static int getIndex(Node const *node,
+                                               Tree const &tree)
     {
       return node->isLeaf() ? node->getLeafPermutationIndex()
-                            : node - bvh.getRoot();
+                            : node - tree.getRoot();
     }
 
-    KOKKOS_INLINE_FUNCTION
-    static Node const *getRoot(
-        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
-            &bvh)
+    template <typename Tree>
+    KOKKOS_INLINE_FUNCTION static Node const *getRoot(Tree const &tree)
     {
-      return bvh.getRoot();
+      return tree.getRoot();
     }
 
-    KOKKOS_INLINE_FUNCTION
-    static Node const *getNodePtr(
-        BoundingVolumeHierarchy<typename DeviceType::memory_space, void> const
-            &bvh,
-        int index)
+    template <typename Tree>
+    KOKKOS_INLINE_FUNCTION static Node const *getNodePtr(Tree const &tree,
+                                                         int index)
     {
-      return bvh.getNodePtr(index);
+      return tree.getNodePtr(index);
     }
 
     template <typename Tree>

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -117,7 +117,7 @@ static ParallelRTree<typename View::value_type> makeRTree(MPI_Comm comm,
     offsets[i + 1] = counts[i] + offsets[i];
   decltype(buffer) all_buffers(offsets.back());
   auto const bytes_per_element = sizeof(typename decltype(buffer)::value_type);
-  for (auto pv : {&counts, &offsets})
+  for (auto *pv : {&counts, &offsets})
     for (auto &x : *pv)
       x *= bytes_per_element;
   MPI_Allgatherv(buffer.data(), counts[comm_rank], MPI_BYTE, all_buffers.data(),


### PR DESCRIPTION
This is consistent with what we did in TreeConstruction, TreeTraversal, and other implementation details.
I ran into this issue when prototyping templating the bounding volume type in the BVH.  I had the choice between updating the forward declaration or removing it, I chose the latter.