### PR TITLE
Profiling regions for DistributedSearchTree

### DIFF
--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -115,7 +115,8 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
     MPI_Comm comm, ExecutionSpace const &space, Primitives const &primitives)
     : _bottom_tree{space, primitives}
 {
-  Kokkos::Profiling::pushRegion("ArborX::DistributedSearchTree::construction");
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::DistributedSearchTree");
 
   static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
 

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -115,6 +115,8 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
     MPI_Comm comm, ExecutionSpace const &space, Primitives const &primitives)
     : _bottom_tree{space, primitives}
 {
+  Kokkos::Profiling::pushRegion("ArborX:DistributedSearchTree:construction");
+
   static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
 
   // Create new context for the library to isolate library's communication from
@@ -163,6 +165,8 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
   Kokkos::deep_copy(space, _bottom_tree_sizes, bottom_tree_sizes_host);
 
   _top_tree_size = accumulate(space, _bottom_tree_sizes, 0);
+
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -115,7 +115,7 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
     MPI_Comm comm, ExecutionSpace const &space, Primitives const &primitives)
     : _bottom_tree{space, primitives}
 {
-  Kokkos::Profiling::pushRegion("ArborX:DistributedSearchTree:construction");
+  Kokkos::Profiling::pushRegion("ArborX::DistributedSearchTree::construction");
 
   static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
 

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -275,6 +275,9 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
     ExecutionSpace const &space, Predicates const &queries,
     DistributedTree const &tree, Indices &indices, Offset &offset, Distances &)
 {
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::deviseStrategy");
+
   auto const &top_tree = tree._top_tree;
   auto const &bottom_tree_sizes = tree._bottom_tree_sizes;
 
@@ -322,6 +325,8 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
 
   offset = new_offset;
   indices = new_indices;
+
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>
@@ -333,6 +338,9 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
     DistributedTree const &tree, Indices &indices, Offset &offset,
     Distances &distances)
 {
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::reassessStrategy");
+
   auto const &top_tree = tree._top_tree;
   using Access = AccessTraits<Predicates, PredicatesTag>;
   auto const n_queries = Access::size(queries);
@@ -366,6 +374,8 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
   top_tree.query(space, radius_searches, indices, offset);
   // NOTE: in principle, we could perform radius searches on the bottom_tree
   // rather than nearest queries.
+
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>
@@ -379,6 +389,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
     ExecutionSpace const &space, Predicates const &queries, Indices &indices,
     Offset &offset, Ranks &ranks, Distances *distances_ptr)
 {
+  Kokkos::Profiling::pushRegion("ArborX::DistributedSearchTree::nearest_query");
+
   auto const &bottom_tree = tree._bottom_tree;
   auto comm = tree.getComm();
 
@@ -439,6 +451,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
       filterResults(space, queries, distances, indices, offset, ranks);
     }
   }
+
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>
@@ -451,6 +465,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     ExecutionSpace const &space, Predicates const &queries,
     Callback const &callback, OutputView &out, OffsetView &offset)
 {
+  Kokkos::Profiling::pushRegion("ArborX::DistributedSearchTree::spatial_query");
+
   auto const &top_tree = tree._top_tree;
   auto const &bottom_tree = tree._bottom_tree;
   auto comm = tree.getComm();
@@ -486,6 +502,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     countResults(space, n_queries, ids, offset);
     sortResults(space, ids, out);
   }
+
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>
@@ -546,6 +564,9 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
     Kokkos::View<Query *, DeviceType> &fwd_queries,
     Kokkos::View<int *, DeviceType> &fwd_ids, Ranks &fwd_ranks)
 {
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::forwardQueries");
+
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
 
@@ -601,6 +622,8 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
   fwd_queries = imports;
   fwd_ids = import_ids;
   fwd_ranks = import_ranks;
+
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>
@@ -611,6 +634,9 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
     Kokkos::View<int *, DeviceType> offset, Ranks &ranks,
     Kokkos::View<int *, DeviceType> &ids, Distances *distances_ptr)
 {
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::communicateResultsBack");
+
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
 
@@ -668,6 +694,8 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
     sendAcrossNetwork(space, distributor, export_distances, import_distances);
     distances = import_distances;
   }
+
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -228,6 +228,8 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
     ExecutionSpace const &space, Distributor<DeviceType> const &distributor,
     View exports, typename View::non_const_type imports)
 {
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::sendAcrossNetwork");
   ARBORX_ASSERT((exports.extent(0) == distributor.getTotalSendLength()) &&
                 (imports.extent(0) == distributor.getTotalReceiveLength()) &&
                 (exports.extent(1) == imports.extent(1)) &&
@@ -265,6 +267,7 @@ DistributedSearchTreeImpl<DeviceType>::sendAcrossNetwork(
   auto tmp_view =
       Kokkos::create_mirror_view_and_copy(space, imports_layout_right);
   Kokkos::deep_copy(space, imports, tmp_view);
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -389,7 +389,7 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
     Offset &offset, Ranks &ranks, Distances *distances_ptr)
 {
   Kokkos::Profiling::pushRegion(
-      "ArborX::DistributedSearchTree::nearest_queries");
+      "ArborX::DistributedSearchTree::query::nearest");
 
   auto const &bottom_tree = tree._bottom_tree;
   auto comm = tree.getComm();
@@ -471,7 +471,7 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     Callback const &callback, OutputView &out, OffsetView &offset)
 {
   Kokkos::Profiling::pushRegion(
-      "ArborX::DistributedSearchTree::spatial_queries");
+      "ArborX::DistributedSearchTree::query::spatial");
 
   auto const &top_tree = tree._top_tree;
   auto const &bottom_tree = tree._bottom_tree;

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -325,8 +325,6 @@ void DistributedSearchTreeImpl<DeviceType>::deviseStrategy(
 
   offset = new_offset;
   indices = new_indices;
-
-  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>
@@ -374,8 +372,6 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
   top_tree.query(space, radius_searches, indices, offset);
   // NOTE: in principle, we could perform radius searches on the bottom_tree
   // rather than nearest queries.
-
-  Kokkos::Profiling::popRegion();
 }
 
 template <typename DeviceType>
@@ -449,6 +445,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
       countResults(space, n_queries, ids, offset);
       sortResults(space, ids, indices, ranks, distances);
       filterResults(space, queries, distances, indices, offset, ranks);
+
+      Kokkos::Profiling::popRegion();
     }
   }
 

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -441,10 +441,13 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
                              &distances);
 
       // Merge results
+      Kokkos::Profiling::pushRegion(
+          "ArborX::DistributedSearchTree::postprocess_results");
       int const n_queries = Access::size(queries);
       countResults(space, n_queries, ids, offset);
       sortResults(space, ids, indices, ranks, distances);
       filterResults(space, queries, distances, indices, offset, ranks);
+      Kokkos::Profiling::popRegion();
 
       Kokkos::Profiling::popRegion();
     }
@@ -496,9 +499,12 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     communicateResultsBack(comm, space, out, offset, ranks, ids);
 
     // Merge results
+    Kokkos::Profiling::pushRegion(
+        "ArborX::DistributedSearchTree::postprocess_results");
     int const n_queries = Access::size(queries);
     countResults(space, n_queries, ids, offset);
     sortResults(space, ids, out);
+    Kokkos::Profiling::popRegion();
   }
 
   Kokkos::Profiling::popRegion();

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -385,7 +385,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
     ExecutionSpace const &space, Predicates const &queries, Indices &indices,
     Offset &offset, Ranks &ranks, Distances *distances_ptr)
 {
-  Kokkos::Profiling::pushRegion("ArborX::DistributedSearchTree::nearest_query");
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::nearest_queries");
 
   auto const &bottom_tree = tree._bottom_tree;
   auto comm = tree.getComm();
@@ -466,7 +467,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     ExecutionSpace const &space, Predicates const &queries,
     Callback const &callback, OutputView &out, OffsetView &offset)
 {
-  Kokkos::Profiling::pushRegion("ArborX::DistributedSearchTree::spatial_query");
+  Kokkos::Profiling::pushRegion(
+      "ArborX::DistributedSearchTree::spatial_queries");
 
   auto const &top_tree = tree._top_tree;
   auto const &bottom_tree = tree._bottom_tree;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,7 +98,7 @@ target_include_directories(ArborX_DetailsBufferOptimization.exe PRIVATE ${CMAKE_
 add_test(NAME ArborX_DetailsBufferOptimization_Test COMMAND ./ArborX_DetailsBufferOptimization.exe)
 
 if(ARBORX_ENABLE_MPI)
-  add_executable(ArborX_DistributedSearchTree.exe tstDistributedSearchTree.cpp utf_main.cpp)
+  add_executable(ArborX_DistributedSearchTree.exe tstDistributedSearchTree.cpp tstDistributedKokkosToolsAnnotations.cpp utf_main.cpp)
   target_link_libraries(ArborX_DistributedSearchTree.exe PRIVATE ArborX Boost::unit_test_framework)
   target_compile_definitions(ArborX_DistributedSearchTree.exe PRIVATE BOOST_TEST_DYN_LINK ARBORX_MPI_UNIT_TEST)
   target_include_directories(ArborX_DistributedSearchTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,7 +98,7 @@ target_include_directories(ArborX_DetailsBufferOptimization.exe PRIVATE ${CMAKE_
 add_test(NAME ArborX_DetailsBufferOptimization_Test COMMAND ./ArborX_DetailsBufferOptimization.exe)
 
 if(ARBORX_ENABLE_MPI)
-  add_executable(ArborX_DistributedSearchTree.exe tstDistributedSearchTree.cpp tstDistributedKokkosToolsAnnotations.cpp utf_main.cpp)
+  add_executable(ArborX_DistributedSearchTree.exe tstDistributedSearchTree.cpp tstKokkosToolsDistributedAnnotations.cpp utf_main.cpp)
   target_link_libraries(ArborX_DistributedSearchTree.exe PRIVATE ArborX Boost::unit_test_framework)
   target_compile_definitions(ArborX_DistributedSearchTree.exe PRIVATE BOOST_TEST_DYN_LINK ARBORX_MPI_UNIT_TEST)
   target_include_directories(ArborX_DistributedSearchTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/tstDistributedKokkosToolsAnnotations.cpp
+++ b/test/tstDistributedKokkosToolsAnnotations.cpp
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * Copyright (c) 2012-2020 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include <ArborX_DistributedSearchTree.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+#include "Search_UnitTestHelpers.hpp"
+
+#if (KOKKOS_VERSION >= 30200) // callback registriation from within the program
+                              // was added in Kokkkos v3.2
+
+BOOST_AUTO_TEST_SUITE(KokkosDistributedToolsAnnotations)
+
+namespace tt = boost::test_tools;
+
+bool isPrefixedWith(std::string const &s, std::string const &prefix)
+{
+  return s.find(prefix) == 0;
+}
+
+BOOST_AUTO_TEST_CASE(is_prefixed_with)
+{
+  BOOST_TEST(isPrefixedWith("ArborX::Whatever", "ArborX"));
+  BOOST_TEST(!isPrefixedWith("Nope", "ArborX"));
+  BOOST_TEST(!isPrefixedWith("Nope::ArborX", "ArborX"));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
+    std::cout << label << '\n';
+    BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
+                isPrefixedWith(label, "Kokkos::")));
+  });
+
+  // DistributedSearchTree::DistriibutedSearchTree
+
+  { // empty
+    auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
+  }
+
+  { // one leaf
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {{{{0, 0, 0}}, {{1, 1, 1}}}});
+  }
+
+  { // two leaves
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                        });
+  }
+
+  // DistributedSearchTree::query
+
+  auto tree = makeDistributedSearchTree<DeviceType>(
+      MPI_COMM_WORLD, {
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                      });
+
+  // spatial predicates
+  query(tree, makeIntersectsBoxQueries<DeviceType>({
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+              }));
+
+  // nearest predicates
+  query(tree, makeNearestQueries<DeviceType>({
+                  {{{0, 0, 0}}, 1},
+                  {{{0, 0, 0}}, 2},
+              }));
+
+  Kokkos::Tools::Experimental::set_push_region_callback(nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -21,7 +21,7 @@
 #if (KOKKOS_VERSION >= 30200) // callback registriation from within the program
                               // was added in Kokkkos v3.2
 
-BOOST_AUTO_TEST_SUITE(KokkosDistributedToolsAnnotations)
+BOOST_AUTO_TEST_SUITE(KokkosToolsDistributedAnnotations)
 
 namespace tt = boost::test_tools;
 
@@ -49,19 +49,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 
   { // empty
     auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
-  }
-
-  { // one leaf
-    auto tree = makeDistributedSearchTree<DeviceType>(
-        MPI_COMM_WORLD, {{{{0, 0, 0}}, {{1, 1, 1}}}});
-  }
-
-  { // two leaves
-    auto tree = makeDistributedSearchTree<DeviceType>(
-        MPI_COMM_WORLD, {
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                        });
   }
 
   // DistributedSearchTree::query


### PR DESCRIPTION
Fixes #377. The output for `ArborX_DistributedTree.exe` using `space-time-stack` is
```
[...]
TOP-DOWN TIME TREE:
<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
=================== 
|-> 3.65e-02 sec 57.1% 102.6% 0.0% 0.0% 7.13e+03 1 ArborX::DistributedSearchTree::nearest_query [region]
|   |-> 2.22e-02 sec 34.8% 101.9% 0.0% 0.6% 5.94e+03 1 ArborX::DistributedSearchTree::deviseStrategy [region]
|   |   |-> 1.73e-02 sec 27.1% 97.9% 0.0% 0.1% 2.84e+03 2 ArborX:BVH:nearest_queries [region]
|   |   |   |-> 1.58e-02 sec 24.7% 98.5% 0.0% 0.1% 1.27e+03 2 ArborX:BVH:two_pass [region]
|   |   |   |   |-> 1.53e-02 sec 24.0% 99.1% 0.0% 0.9% 6.54e+02 2 ArborX:BVH:two_pass:first_pass [region]
|   |   |   |   |   |-> 1.47e-02 sec 23.0% 100.0% 0.0% ------ 1 ArborX_BVH:nearest_queries [for]
|   |   |   |   |   |-> 3.81e-04 sec 0.6% 100.0% 0.0% ------ 1 ArborX_BVH:nearest_queries_degenerated_one_leaf_tree [for]
|   |   |   |   |-> 2.48e-04 sec 0.4% 92.7% 0.0% 7.3% 2.83e+04 2 ArborX:BVH:two_pass:first_pass_postprocess [region]
|   |   |   |   |   |-> 1.20e-04 sec 0.2% 100.0% 0.0% ------ 2 ArborX_copy_counts_to_offsets [for]
|   |   |   |   |   |-> 9.61e-05 sec 0.2% 100.0% 0.0% ------ 2 ArborX_exclusive_scan [scan]
|   |   |   |   |-> 1.84e-04 sec 0.3% 62.9% 0.0% 37.1% 5.44e+03 1 ArborX:BVH:two_pass:copy_values [region]
|   |   |   |   |   |-> 1.16e-04 sec 0.2% 100.0% 0.0% ------ 1 ArborX_copy_valid_values [for]
|   |   |   |-> 1.36e-03 sec 2.1% 95.1% 0.0% 5.6% 1.62e+04 2 ArborX:BVH:nearest_queries:compute_permutation [region]
|   |   |   |   |-> 4.41e-04 sec 0.7% 100.0% 0.0% ------ 2 Kokkos::Sort::BinBinning [for]
|   |   |   |   |-> 3.50e-04 sec 0.5% 100.0% 0.0% ------ 2 Kokkos::Sort::BinCount [for]
|   |   |   |   |-> 2.46e-04 sec 0.4% 100.0% 0.0% ------ 2 ArborX_assign_morton_codes_to_queries [for]
|   |   |   |   |-> 1.35e-04 sec 0.2% 100.0% 0.0% ------ 2 Kokkos::Sort::BinSort [for]
|   |   |   |-> 1.50e-04 sec 0.2% 61.5% 0.0% 38.5% 4.68e+04 2 ArborX:BVH:nearest_queries:init_and_alloc [region]
|   |   |       |-> 6.95e-05 sec 0.1% 100.0% 0.0% ------ 2 ArborX_exclusive_scan [scan]
|   |   |-> 3.26e-03 sec 5.1% 111.2% 0.0% 5.3% 1.01e+04 1 ArborX::DistributedSearchTree::postprocess_results [region]
|   |   |   |-> 8.08e-04 sec 1.3% 100.0% 0.0% ------ 1 ArborX_truncate_results [for]
|   |   |   |-> 3.42e-04 sec 0.5% 100.0% 0.0% ------ 1 Kokkos::Sort::BinBinning [for]
|   |   |   |-> 3.41e-04 sec 0.5% 100.0% 0.0% ------ 1 Kokkos::Sort::BinCount [for]
|   |   |   |-> 3.21e-04 sec 0.5% 100.0% 0.0% ------ 1 ArborX_count_results_per_query [for]
|   |   |   |-> 2.88e-04 sec 0.5% 100.0% 0.0% ------ 1 Kokkos::Sort::BinSort [for]
|   |   |   |-> 2.63e-04 sec 0.4% 199.5% 0.0% ------ 1 "distances"="distances" [copy]
|   |   |   |   |-> 2.62e-04 sec 0.4% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 9.82e-05 sec 0.2% 100.0% 0.0% ------ 3 ArborX_permute [for]
|   |   |   |-> 9.47e-05 sec 0.1% 100.0% 0.0% ------ 5 Kokkos::View::initialization [for]
|   |   |   |-> 9.14e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Sort::CopyPermute [for]
|   |   |   |-> 9.07e-05 sec 0.1% 198.6% 0.0% ------ 1 "indices"="indices" [copy]
|   |   |   |   |-> 8.95e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 8.90e-05 sec 0.1% 199.2% 0.0% ------ 1 "import_ranks"="import_ranks" [copy]
|   |   |   |   |-> 8.83e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 8.89e-05 sec 0.1% 198.6% 0.0% ------ 1 "keys"="import_ids" [copy]
|   |   |   |   |-> 8.77e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |-> 7.82e-04 sec 1.2% 169.9% 0.0% 8.4% 2.30e+04 1 ArborX::DistributedSearchTree::communicateResultsBack [region]
|   |   |   |-> 5.43e-04 sec 0.9% 199.1% 0.0% ------ 4 ""="" [copy]
|   |   |   |   |-> 5.38e-04 sec 0.8% 100.0% 0.0% ------ 4 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 8.07e-05 sec 0.1% 100.0% 0.0% ------ 1 ArborX_fill_buffer [for]
|   |   |   |-> 7.52e-05 sec 0.1% 198.6% 0.0% ------ 1 "import_ranks"="(none)" [copy]
|   |   |   |   |-> 7.42e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::ViewFill-1D [for]
|   |   |-> 5.07e-04 sec 0.8% 105.3% 0.0% 19.1% 4.53e+04 1 ArborX::DistributedSearchTree::forwardQueries [region]
|   |   |   |-> 1.46e-04 sec 0.2% 180.2% 0.0% ------ 3 ""="" [copy]
|   |   |   |   |-> 1.17e-04 sec 0.2% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 7.72e-05 sec 0.1% 100.0% 0.0% ------ 1 ArborX_forward_queries_fill_buffer [for]
|   |   |   |-> 7.66e-05 sec 0.1% 100.0% 0.0% ------ 3 ArborX_inverse_permute [for]
|   |   |-> 1.57e-04 sec 0.2% 100.0% 0.0% ------ 1 ArborX_split_pairs [for]
|   |-> 1.42e-02 sec 22.3% 103.8% 0.0% 0.2% 8.86e+03 1 ArborX::DistributedSearchTree::reassessStrategy [region]
|   |   |-> 9.77e-03 sec 15.3% 99.5% 0.0% 0.0% 2.66e+03 1 ArborX:BVH:nearest_queries [region]
|   |   |   |-> 9.42e-03 sec 14.7% 99.7% 0.0% 0.0% 1.17e+03 1 ArborX:BVH:two_pass [region]
|   |   |   |   |-> 9.36e-03 sec 14.7% 99.8% 0.0% 0.2% 7.48e+02 1 ArborX:BVH:two_pass:first_pass [region]
|   |   |   |   |   |-> 9.12e-03 sec 14.3% 100.0% 0.0% ------ 1 ArborX_BVH:nearest_queries [for]
|   |   |   |   |   |-> 1.90e-04 sec 0.3% 100.0% 0.0% ------ 1 Kokkos::View::destruction [for]
|   |   |   |-> 3.30e-04 sec 0.5% 96.7% 0.0% 4.0% 3.33e+04 1 ArborX:BVH:nearest_queries:compute_permutation [region]
|   |   |   |   |-> 1.07e-04 sec 0.2% 100.0% 0.0% ------ 1 Kokkos::Sort::BinBinning [for]
|   |   |   |   |-> 8.59e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Sort::BinCount [for]
|   |   |-> 2.80e-03 sec 4.4% 108.9% 0.0% 2.0% 1.18e+04 1 ArborX::DistributedSearchTree::postprocess_results [region]
|   |   |   |-> 6.89e-04 sec 1.1% 100.0% 0.0% ------ 1 ArborX_truncate_results [for]
|   |   |   |-> 3.21e-04 sec 0.5% 100.0% 0.0% ------ 1 Kokkos::Sort::BinBinning [for]
|   |   |   |-> 2.94e-04 sec 0.5% 100.0% 0.0% ------ 1 Kokkos::Sort::CopyPermute [for]
|   |   |   |-> 2.89e-04 sec 0.5% 100.0% 0.0% ------ 1 Kokkos::Sort::BinCount [for]
|   |   |   |-> 2.74e-04 sec 0.4% 100.0% 0.0% ------ 1 Kokkos::Sort::BinSort [for]
|   |   |   |-> 2.72e-04 sec 0.4% 100.0% 0.0% ------ 1 ArborX_count_results_per_query [for]
|   |   |   |-> 8.27e-05 sec 0.1% 100.0% 0.0% ------ 3 ArborX_permute [for]
|   |   |   |-> 7.91e-05 sec 0.1% 100.0% 0.0% ------ 5 Kokkos::View::initialization [for]
|   |   |   |-> 7.57e-05 sec 0.1% 199.1% 0.0% ------ 1 "distances"="distances" [copy]
|   |   |   |   |-> 7.50e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 7.53e-05 sec 0.1% 198.9% 0.0% ------ 1 "indices"="indices" [copy]
|   |   |   |   |-> 7.44e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 7.53e-05 sec 0.1% 199.4% 0.0% ------ 1 "import_ranks"="import_ranks" [copy]
|   |   |   |   |-> 7.48e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 7.44e-05 sec 0.1% 198.5% 0.0% ------ 1 "keys"="import_ids" [copy]
|   |   |   |   |-> 7.33e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |-> 6.96e-04 sec 1.1% 95.9% 0.0% 0.5% 2.87e+04 1 ArborX:BVH:spatial_queries [region]
|   |   |   |-> 4.78e-04 sec 0.7% 96.7% 0.0% 3.7% 2.30e+04 1 ArborX:BVH:spatial_queries:compute_permutation [region]
|   |   |   |   |-> 2.09e-04 sec 0.3% 100.0% 0.0% ------ 1 Kokkos::Sort::BinCount [for]
|   |   |   |   |-> 1.09e-04 sec 0.2% 100.0% 0.0% ------ 1 Kokkos::Sort::BinBinning [for]
|   |   |   |   |-> 7.33e-05 sec 0.1% 100.0% 0.0% ------ 1 ArborX_assign_morton_codes_to_queries [for]
|   |   |   |-> 2.02e-04 sec 0.3% 93.8% 0.0% 1.3% 3.46e+04 1 ArborX:BVH:two_pass [region]
|   |   |   |   |-> 8.98e-05 sec 0.1% 95.0% 0.0% 5.0% 2.23e+04 1 ArborX:BVH:two_pass:second_pass [region]
|   |   |   |   |   |-> 7.90e-05 sec 0.1% 100.0% 0.0% ------ 1 ArborX_BVH:spatial_queries_degenerated_one_leaf_tree [for]
|   |   |-> 5.50e-04 sec 0.9% 170.3% 0.0% 6.4% 3.27e+04 1 ArborX::DistributedSearchTree::communicateResultsBack [region]
|   |   |   |-> 4.09e-04 sec 0.6% 198.8% 0.0% ------ 4 ""="" [copy]
|   |   |   |   |-> 4.03e-04 sec 0.6% 100.0% 0.0% ------ 4 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |   |-> 7.12e-05 sec 0.1% 100.0% 0.0% ------ 1 ArborX_fill_buffer [for]
|   |   |-> 1.77e-04 sec 0.3% 101.2% 0.0% 19.5% 1.30e+05 1 ArborX::DistributedSearchTree::forwardQueries [region]
|   |   |-> 1.13e-04 sec 0.2% 100.0% 0.0% ------ 1 ArborX_split_pairs [for]
|-> 1.52e-02 sec 23.8% 106.0% 0.0% 0.2% 6.71e+03 1 ArborX::DistributedSearchTree::spatial_query [region]
|   |-> 1.14e-02 sec 17.9% 99.4% 0.0% 0.1% 3.59e+03 2 ArborX:BVH:spatial_queries [region]
|   |   |-> 1.03e-02 sec 16.1% 99.7% 0.0% 0.1% 1.46e+03 2 ArborX:BVH:two_pass [region]
|   |   |   |-> 5.13e-03 sec 8.0% 99.9% 0.0% 0.1% 3.90e+02 2 ArborX:BVH:two_pass:first_pass [region]
|   |   |   |   |-> 5.07e-03 sec 7.9% 100.0% 0.0% ------ 1 ArborX_BVH:spatial_queries [for]
|   |   |   |-> 5.03e-03 sec 7.9% 99.8% 0.0% 0.2% 9.94e+02 2 ArborX:BVH:two_pass:second_pass [region]
|   |   |   |   |-> 4.93e-03 sec 7.7% 100.0% 0.0% ------ 1 ArborX_BVH:spatial_queries [for]
|   |   |   |   |-> 7.72e-05 sec 0.1% 100.0% 0.0% ------ 1 ArborX_BVH:spatial_queries_degenerated_one_leaf_tree [for]
|   |   |   |-> 9.67e-05 sec 0.2% 93.5% 0.0% 6.5% 6.20e+04 2 ArborX:BVH:two_pass:first_pass_postprocess [region]
|   |   |   |   |-> 7.04e-05 sec 0.1% 100.0% 0.0% ------ 2 ArborX_copy_counts_to_offsets [for]
|   |   |-> 1.12e-03 sec 1.8% 97.8% 0.0% 2.6% 1.96e+04 2 ArborX:BVH:spatial_queries:compute_permutation [region]
|   |   |   |-> 4.79e-04 sec 0.8% 100.0% 0.0% ------ 2 Kokkos::Sort::CopyPermute [for]
|   |   |   |-> 2.06e-04 sec 0.3% 100.0% 0.0% ------ 2 Kokkos::Sort::BinBinning [for]
|   |   |   |-> 1.64e-04 sec 0.3% 100.0% 0.0% ------ 2 Kokkos::Sort::BinCount [for]
|   |   |   |-> 1.06e-04 sec 0.2% 100.0% 0.0% ------ 2 ArborX_assign_morton_codes_to_queries [for]
|   |   |   |-> 9.35e-05 sec 0.1% 100.0% 0.0% ------ 2 Kokkos::Sort::BinSort [for]
|   |-> 2.72e-03 sec 4.3% 114.0% 0.0% 1.4% 6.99e+03 1 ArborX::DistributedSearchTree::postprocess_results [region]
|   |   |-> 5.08e-04 sec 0.8% 100.0% 0.0% ------ 1 Kokkos::Sort::BinSort [for]
|   |   |-> 3.63e-04 sec 0.6% 100.0% 0.0% ------ 1 Kokkos::Sort::BinBinning [for]
|   |   |-> 3.62e-04 sec 0.6% 100.0% 0.0% ------ 1 ArborX_count_results_per_query [for]
|   |   |-> 3.60e-04 sec 0.6% 100.0% 0.0% ------ 1 Kokkos::Sort::BinCount [for]
|   |   |-> 3.18e-04 sec 0.5% 199.6% 0.0% ------ 1 "values"="values" [copy]
|   |   |   |-> 3.17e-04 sec 0.5% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |-> 2.27e-04 sec 0.4% 100.0% 0.0% ------ 1 ArborX_exclusive_scan [scan]
|   |   |-> 1.50e-04 sec 0.2% 100.0% 0.0% ------ 1 ArborX_permute [for]
|   |   |-> 9.32e-05 sec 0.1% 198.7% 0.0% ------ 1 "keys"="import_ids" [copy]
|   |   |   |-> 9.20e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |-> 8.02e-05 sec 0.1% 100.0% 0.0% ------ 1 ArborX_find_min_max_view [reduce]
|   |   |-> 7.60e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Sort::CopyPermute [for]
|   |-> 8.75e-04 sec 1.4% 171.6% 0.0% 6.0% 1.83e+04 1 ArborX::DistributedSearchTree::communicateResultsBack [region]
|   |   |-> 5.70e-04 sec 0.9% 199.3% 0.0% ------ 3 ""="" [copy]
|   |   |   |-> 5.66e-04 sec 0.9% 100.0% 0.0% ------ 3 Kokkos::Impl::host_space_deepcopy_double [for]
|   |   |-> 1.21e-04 sec 0.2% 100.0% 0.0% ------ 1 ArborX_fill_buffer [for]
|   |   |-> 1.13e-04 sec 0.2% 199.4% 0.0% ------ 1 "import_ranks"="(none)" [copy]
|   |   |   |-> 1.13e-04 sec 0.2% 100.0% 0.0% ------ 1 Kokkos::ViewFill-1D [for]
|   |-> 1.61e-04 sec 0.3% 101.7% 0.0% 19.9% 1.43e+05 1 ArborX::DistributedSearchTree::forwardQueries [region]
|-> 3.76e-03 sec 5.9% 97.4% 0.0% 0.2% 4.26e+03 1 ArborX:BVH:construction [region]
|   |-> 1.83e-03 sec 2.9% 96.2% 0.0% 4.4% 5.46e+03 1 ArborX:BVH:sort_morton_codes [region]
|   |   |-> 7.13e-04 sec 1.1% 100.0% 0.0% ------ 1 Kokkos::Sort::BinBinning [for]
|   |   |-> 5.86e-04 sec 0.9% 100.0% 0.0% ------ 1 Kokkos::Sort::BinCount [for]
|   |   |-> 2.06e-04 sec 0.3% 100.0% 0.0% ------ 1 Kokkos::Sort::BinSort [for]
|   |   |-> 8.38e-05 sec 0.1% 100.0% 0.0% ------ 1 Kokkos::Sort::BinOffset [scan]
|   |-> 8.95e-04 sec 1.4% 100.4% 0.0% 1.2% 3.35e+03 1 ArborX:BVH:generate_hierarchy [region]
|   |   |-> 8.68e-04 sec 1.4% 100.0% 0.0% ------ 1 ArborX_generate_hierarchy [for]
|   |-> 5.09e-04 sec 0.8% 96.6% 0.0% 3.4% 1.97e+03 1 ArborX:BVH:assign_morton_codes [region]
|   |   |-> 4.91e-04 sec 0.8% 100.0% 0.0% ------ 1 ArborX_assign_morton_codes [for]
|   |-> 3.43e-04 sec 0.5% 99.0% 0.0% 1.0% 2.91e+03 1 ArborX:BVH:init_leaves [region]
|   |   |-> 3.40e-04 sec 0.5% 100.0% 0.0% ------ 1 ArborX_initialize_leaf_nodes [for]
|   |-> 1.71e-04 sec 0.3% 98.3% 0.0% 1.7% 5.86e+03 1 ArborX:BVH:calculate_scene_bounding_box [region]
|       |-> 1.68e-04 sec 0.3% 100.0% 0.0% ------ 1 ArborX_calculate_bounding_box_of_the_scene [reduce]
|-> 4.63e-04 sec 0.7% 73.5% 0.0% 24.8% 1.29e+04 1 ArborX::DistributedSearchTree::construction [region]
|   |-> 3.44e-04 sec 0.5% 97.7% 0.0% 1.7% 8.73e+03 1 ArborX:BVH:construction [region]
|   |   |-> 3.30e-04 sec 0.5% 99.4% 0.0% 0.6% 3.03e+03 1 ArborX:BVH:calculate_scene_bounding_box [region]
|   |   |   |-> 3.28e-04 sec 0.5% 100.0% 0.0% ------ 1 ArborX_calculate_bounding_box_of_the_scene [reduce]
|-> 4.17e-04 sec 0.7% 194.4% 0.0% ------ 1 "values"="points" [copy]
|   |-> 3.94e-04 sec 0.6% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
|-> 3.21e-04 sec 0.5% 100.0% 0.0% ------ 1 bvh_driver:construct_bounding_boxes [for]
|-> 1.32e-04 sec 0.2% 100.0% 0.0% ------ 10 Kokkos::View::destruction [for]
|-> 1.26e-04 sec 0.2% 100.0% 0.0% ------ 1 ArborX_zip_indices_and_ranks [for]
|-> 1.23e-04 sec 0.2% 197.4% 0.0% ------ 1 "queries"="points" [copy]
|   |-> 1.20e-04 sec 0.2% 100.0% 0.0% ------ 1 Kokkos::Impl::host_space_deepcopy_double [for]
[...]
```