### PR TITLE
Profiling distributed search tree views

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -294,9 +294,9 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   }
 
   Kokkos::View<ArborX::Point *, DeviceType> random_values(
-      Kokkos::ViewAllocateWithoutInitializing("values"), n_values);
+      Kokkos::ViewAllocateWithoutInitializing("Testing::values"), n_values);
   Kokkos::View<ArborX::Point *, DeviceType> random_queries(
-      Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
+      Kokkos::ViewAllocateWithoutInitializing("Testing::queries"), n_queries);
   {
     double a = 0.;
     double offset_x = 0.;
@@ -357,7 +357,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     // The boxes in which the points are placed have side length two, centered
     // around offset_[xyz] and scaled by a.
     Kokkos::View<ArborX::Point *, DeviceType> random_points(
-        Kokkos::ViewAllocateWithoutInitializing("points"),
+        Kokkos::ViewAllocateWithoutInitializing("Testing::points"),
         std::max(n_values, n_queries));
     auto random_points_host = Kokkos::create_mirror_view(random_points);
     for (int i = 0; i < random_points.extent_int(0); ++i)
@@ -398,7 +398,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   }
 
   Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes(
-      Kokkos::ViewAllocateWithoutInitializing("bounding_boxes"), n_values);
+      Kokkos::ViewAllocateWithoutInitializing("Testing::bounding_boxes"),
+      n_values);
   Kokkos::parallel_for("bvh_driver:construct_bounding_boxes",
                        Kokkos::RangePolicy<ExecutionSpace>(0, n_values),
                        KOKKOS_LAMBDA(int i) {
@@ -424,8 +425,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
 
   if (perform_knn_search)
   {
-    Kokkos::View<int *, DeviceType> offsets("offsets", 0);
-    Kokkos::View<PairIndexRank *, DeviceType> values("values", 0);
+    Kokkos::View<int *, DeviceType> offsets("Testing::offsets", 0);
+    Kokkos::View<PairIndexRank *, DeviceType> values("Testing::values", 0);
 
     auto knn = time_monitor.getNewTimer("knn");
     MPI_Barrier(comm);
@@ -468,8 +469,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
       break;
     }
 
-    Kokkos::View<int *, DeviceType> offsets("offsets", 0);
-    Kokkos::View<PairIndexRank *, DeviceType> values("values", 0);
+    Kokkos::View<int *, DeviceType> offsets("Testing::offsets", 0);
+    Kokkos::View<PairIndexRank *, DeviceType> values("Testing::values", 0);
 
     auto radius = time_monitor.getNewTimer("radius");
     MPI_Barrier(comm);

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -174,7 +174,7 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
 
   _bottom_tree_sizes = Kokkos::View<size_type *, MemorySpace>(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::DistributedSearchTree::leave_count_"
+          "ArborX::DistributedSearchTree::leave_count_"
           "in_local_trees"),
       comm_size);
   auto bottom_tree_sizes_host = Kokkos::create_mirror_view(_bottom_tree_sizes);

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -152,7 +152,9 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
   MPI_Comm_size(getComm(), &comm_size);
 
   Kokkos::View<Box *, MemorySpace> boxes(
-      Kokkos::ViewAllocateWithoutInitializing("rank_bounding_boxes"),
+      Kokkos::ViewAllocateWithoutInitializing(
+          "ArborX::DistributedSearchTree::DistributedSearchTree::rank_bounding_"
+          "boxes"),
       comm_size);
   // FIXME when we move to MPI with CUDA-aware support, we will not need to
   // copy from the device to the host
@@ -171,7 +173,9 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
       "size_calculation");
 
   _bottom_tree_sizes = Kokkos::View<size_type *, MemorySpace>(
-      Kokkos::ViewAllocateWithoutInitializing("leave_count_in_local_trees"),
+      Kokkos::ViewAllocateWithoutInitializing(
+          "ArborX::DistributedSearchTree::DistributedSearchTree::leave_count_"
+          "in_local_trees"),
       comm_size);
   auto bottom_tree_sizes_host = Kokkos::create_mirror_view(_bottom_tree_sizes);
   bottom_tree_sizes_host(comm_rank) = _bottom_tree.size();

--- a/src/ArborX_DistributedSearchTree.hpp
+++ b/src/ArborX_DistributedSearchTree.hpp
@@ -153,8 +153,8 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
 
   Kokkos::View<Box *, MemorySpace> boxes(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::DistributedSearchTree::rank_bounding_"
-          "boxes"),
+          "ArborX::DistributedSearchTree::DistributedSearchTree::"
+          "rank_bounding_boxes"),
       comm_size);
   // FIXME when we move to MPI with CUDA-aware support, we will not need to
   // copy from the device to the host
@@ -173,9 +173,8 @@ DistributedSearchTree<MemorySpace, Enable>::DistributedSearchTree(
       "size_calculation");
 
   _bottom_tree_sizes = Kokkos::View<size_type *, MemorySpace>(
-      Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::leave_count_"
-          "in_local_trees"),
+      Kokkos::ViewAllocateWithoutInitializing("ArborX::DistributedSearchTree::"
+                                              "leave_count_in_local_trees"),
       comm_size);
   auto bottom_tree_sizes_host = Kokkos::create_mirror_view(_bottom_tree_sizes);
   bottom_tree_sizes_host(comm_rank) = _bottom_tree.size();

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -80,7 +80,7 @@ struct DistributedSearchTreeImpl
                 Indices &indices, Offset &offset, Ranks &ranks)
   {
     Kokkos::View<PairIndexRank *, ExecutionSpace> out(
-        "ArborX::DistributedSearchTree::spatial_queries::pairs_index_rank", 0);
+        "ArborX::DistributedSearchTree::query::spatial::pairs_index_rank", 0);
     queryDispatch(SpatialPredicateTag{}, tree, space, queries, out, offset);
     auto const n = out.extent(0);
     reallocWithoutInitializing(indices, n);
@@ -153,9 +153,9 @@ struct DistributedSearchTreeImpl
   {
     // FIXME avoid zipping when distributed nearest callbacks become availale
     Kokkos::View<int *, ExecutionSpace> indices(
-        "ArborX::DistributedSearchTree::nearest_queries::indices", 0);
+        "ArborX::DistributedSearchTree::query::nearest::indices", 0);
     Kokkos::View<int *, ExecutionSpace> ranks(
-        "ArborX::DistributedSearchTree::nearest_queries::ranks", 0);
+        "ArborX::DistributedSearchTree::query::nearest::ranks", 0);
     queryDispatchImpl(tag, tree, space, queries, indices, offset, ranks);
     auto const n = indices.extent(0);
     reallocWithoutInitializing(values, n);
@@ -408,7 +408,7 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
   auto comm = tree.getComm();
 
   Distances distances(
-      "ArborX::DistributedSearchTree::nearest_queries::distances", 0);
+      "ArborX::DistributedSearchTree::query::nearest::distances", 0);
   if (distances_ptr)
     distances = *distances_ptr;
 
@@ -447,9 +447,9 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
       using Access = AccessTraits<Predicates, PredicatesTag>;
       using Query = typename AccessTraitsHelper<Access>::type;
       Kokkos::View<int *, DeviceType> ids(
-          "ArborX::DistributedSearchTree::nearest_queries::query_ids", 0);
+          "ArborX::DistributedSearchTree::query::nearest::query_ids", 0);
       Kokkos::View<Query *, DeviceType> fwd_queries(
-          "ArborX::DistributedSearchTree::nearest_queries::fwd_queries", 0);
+          "ArborX::DistributedSearchTree::query::nearest::fwd_queries", 0);
       forwardQueries(comm, space, queries, indices, offset, fwd_queries, ids,
                      ranks);
 
@@ -494,9 +494,9 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
   auto comm = tree.getComm();
 
   Kokkos::View<int *, DeviceType> indices(
-      "ArborX::DistributedSearchTree::spatial_queries::indices", 0);
+      "ArborX::DistributedSearchTree::query::spatial::indices", 0);
   Kokkos::View<int *, DeviceType> ranks(
-      "ArborX::DistributedSearchTree::spatial_queries::ranks", 0);
+      "ArborX::DistributedSearchTree::query::spatial::ranks", 0);
   top_tree.query(space, queries, indices, offset);
 
   {
@@ -511,9 +511,9 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     using Access = AccessTraits<Predicates, PredicatesTag>;
     using Query = typename AccessTraitsHelper<Access>::type;
     Kokkos::View<int *, DeviceType> ids(
-        "ArborX::DistributedSearchTree::spatial_queries::query_ids", 0);
+        "ArborX::DistributedSearchTree::query::spatial::query_ids", 0);
     Kokkos::View<Query *, DeviceType> fwd_queries(
-        "ArborX::DistributedSearchTree::spatial_queries::fwd_queries", 0);
+        "ArborX::DistributedSearchTree::query::spatial::fwd_queries", 0);
     forwardQueries(comm, space, queries, indices, offset, fwd_queries, ids,
                    ranks);
 

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -80,7 +80,7 @@ struct DistributedSearchTreeImpl
                 Indices &indices, Offset &offset, Ranks &ranks)
   {
     Kokkos::View<PairIndexRank *, ExecutionSpace> out(
-        "ArborX::DistributedSearchTree::spatial_query::pairs_index_rank", 0);
+        "ArborX::DistributedSearchTree::spatial_queries::pairs_index_rank", 0);
     queryDispatch(SpatialPredicateTag{}, tree, space, queries, out, offset);
     auto const n = out.extent(0);
     reallocWithoutInitializing(indices, n);
@@ -153,9 +153,9 @@ struct DistributedSearchTreeImpl
   {
     // FIXME avoid zipping when distributed nearest callbacks become availale
     Kokkos::View<int *, ExecutionSpace> indices(
-        "ArborX::DistributedSearchTree::nearest_query::indices", 0);
+        "ArborX::DistributedSearchTree::nearest_queries::indices", 0);
     Kokkos::View<int *, ExecutionSpace> ranks(
-        "ArborX::DistributedSearchTree::nearest_query::ranks", 0);
+        "ArborX::DistributedSearchTree::nearest_queries::ranks", 0);
     queryDispatchImpl(tag, tree, space, queries, indices, offset, ranks);
     auto const n = indices.extent(0);
     reallocWithoutInitializing(values, n);
@@ -407,8 +407,8 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
   auto const &bottom_tree = tree._bottom_tree;
   auto comm = tree.getComm();
 
-  Distances distances("ArborX::DistributedSearchTree::nearest_query::distances",
-                      0);
+  Distances distances(
+      "ArborX::DistributedSearchTree::nearest_queries::distances", 0);
   if (distances_ptr)
     distances = *distances_ptr;
 
@@ -447,9 +447,9 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatchImpl(
       using Access = AccessTraits<Predicates, PredicatesTag>;
       using Query = typename AccessTraitsHelper<Access>::type;
       Kokkos::View<int *, DeviceType> ids(
-          "ArborX::DistributedSearchTree::nearest_query::query_ids", 0);
+          "ArborX::DistributedSearchTree::nearest_queries::query_ids", 0);
       Kokkos::View<Query *, DeviceType> fwd_queries(
-          "ArborX::DistributedSearchTree::nearest_query::fwd_queries", 0);
+          "ArborX::DistributedSearchTree::nearest_queries::fwd_queries", 0);
       forwardQueries(comm, space, queries, indices, offset, fwd_queries, ids,
                      ranks);
 
@@ -494,9 +494,9 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
   auto comm = tree.getComm();
 
   Kokkos::View<int *, DeviceType> indices(
-      "ArborX::DistributedSearchTree::spatial_query::indices", 0);
+      "ArborX::DistributedSearchTree::spatial_queries::indices", 0);
   Kokkos::View<int *, DeviceType> ranks(
-      "ArborX::DistributedSearchTree::spatial_query::ranks", 0);
+      "ArborX::DistributedSearchTree::spatial_queries::ranks", 0);
   top_tree.query(space, queries, indices, offset);
 
   {
@@ -511,9 +511,9 @@ DistributedSearchTreeImpl<DeviceType>::queryDispatch(
     using Access = AccessTraits<Predicates, PredicatesTag>;
     using Query = typename AccessTraitsHelper<Access>::type;
     Kokkos::View<int *, DeviceType> ids(
-        "ArborX::DistributedSearchTree::spatial_query::query_ids", 0);
+        "ArborX::DistributedSearchTree::spatial_queries::query_ids", 0);
     Kokkos::View<Query *, DeviceType> fwd_queries(
-        "ArborX::DistributedSearchTree::spatial_query::fwd_queries", 0);
+        "ArborX::DistributedSearchTree::spatial_queries::fwd_queries", 0);
     forwardQueries(comm, space, queries, indices, offset, fwd_queries, ids,
                    ranks);
 

--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -356,7 +356,7 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
   // Determine distance to the farthest neighbor found so far.
   Kokkos::View<float *, DeviceType> farthest_distances(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::reassessStrategy::distances"),
+          "ArborX::DistributedSearchTree::query::reassessStrategy::distances"),
       n_queries);
   // NOTE: in principle distances( j ) are arranged in ascending order for
   // offset( i ) <= j < offset( i + 1 ) so max() is not necessary.
@@ -373,7 +373,7 @@ void DistributedSearchTreeImpl<DeviceType>::reassessStrategy(
   // Identify what ranks may have leaves that are within that distance.
   Kokkos::View<decltype(intersects(Sphere{})) *, DeviceType> radius_searches(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::reassessStrategy::queries"),
+          "ArborX::DistributedSearchTree::query::reassessStrategy::queries"),
       n_queries);
   Kokkos::parallel_for(
       "ArborX::DistributedTree::query::bottom_trees_within_that_distance",
@@ -552,9 +552,10 @@ void DistributedSearchTreeImpl<DeviceType>::sortResults(
   // We only want to get the permutation here, but sortObjects also sorts the
   // elements given to it. Hence, we need to create a copy.
   // TODO try to avoid the copy
-  View keys_clone(Kokkos::ViewAllocateWithoutInitializing(
-                      "ArborX::DistributedSearchTree::sortResults::keys"),
-                  keys.size());
+  View keys_clone(
+      Kokkos::ViewAllocateWithoutInitializing(
+          "ArborX::DistributedSearchTree::query::sortResults::keys"),
+      keys.size());
   Kokkos::deep_copy(space, keys_clone, keys);
   auto const permutation = ArborX::Details::sortObjects(space, keys_clone);
 
@@ -614,7 +615,7 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
       std::is_same<Query, typename AccessTraitsHelper<Access>::type>{}, "");
   Kokkos::View<Query *, DeviceType> exports(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::forwardQueries::queries"),
+          "ArborX::DistributedSearchTree::query::forwardQueries::queries"),
       n_exports);
   Kokkos::parallel_for(
       "ArborX::DistributedTree::query::forward_queries_fill_buffer",
@@ -628,19 +629,19 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
 
   Kokkos::View<int *, DeviceType> export_ranks(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::forwardQueries::export_ranks"),
+          "ArborX::DistributedSearchTree::query::forwardQueries::export_ranks"),
       n_exports);
   Kokkos::deep_copy(space, export_ranks, comm_rank);
 
   Kokkos::View<int *, DeviceType> import_ranks(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::forwardQueries::import_ranks"),
+          "ArborX::DistributedSearchTree::query::forwardQueries::import_ranks"),
       n_imports);
   sendAcrossNetwork(space, distributor, export_ranks, import_ranks);
 
   Kokkos::View<int *, DeviceType> export_ids(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::forwardQueries::export_ids"),
+          "ArborX::DistributedSearchTree::query::forwardQueries::export_ids"),
       n_exports);
   Kokkos::parallel_for(
       "ArborX::DistributedTree::query::forward_queries_fill_ids",
@@ -653,14 +654,14 @@ void DistributedSearchTreeImpl<DeviceType>::forwardQueries(
       });
   Kokkos::View<int *, DeviceType> import_ids(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::forwardQueries::import_ids"),
+          "ArborX::DistributedSearchTree::query::forwardQueries::import_ids"),
       n_imports);
   sendAcrossNetwork(space, distributor, export_ids, import_ids);
 
   // Send queries across the network
   Kokkos::View<Query *, DeviceType> imports(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::forwardQueries::queries"),
+          "ArborX::DistributedSearchTree::query::forwardQueries::queries"),
       n_imports);
   sendAcrossNetwork(space, distributor, exports, imports);
 
@@ -787,7 +788,7 @@ void DistributedSearchTreeImpl<DeviceType>::filterResults(
   int const n_results = lastElement(offset);
   Kokkos::View<PairIndexDistance *, DeviceType> buffer(
       Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedSearchTree::filterResults::buffer"),
+          "ArborX::DistributedSearchTree::query::filterResults::buffer"),
       n_results);
   using PriorityQueue =
       Details::PriorityQueue<PairIndexDistance, CompareDistance,

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -195,7 +195,9 @@ class Distributor
 public:
   Distributor(MPI_Comm comm)
       : _comm(comm)
-      , _permute{Kokkos::ViewAllocateWithoutInitializing("permute"), 0}
+      , _permute{Kokkos::ViewAllocateWithoutInitializing(
+                     "ArborX::Distributor::permute"),
+                 0}
   {
   }
 

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -260,7 +260,8 @@ public:
     // exports.
     bool const permutation_necessary = _permute.size() != 0;
     auto dest_buffer =
-        ExportView("destination_buffer", typename ExportView::array_layout{});
+        ExportView("ArborX::Distributor::doPostsAndWaits::destination_buffer",
+                   typename ExportView::array_layout{});
     if (permutation_necessary)
     {
       reallocWithoutInitializing(dest_buffer, exports.layout());

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -192,7 +192,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     else if (bvh_.size() == 1)
     {
       Kokkos::parallel_for(
-          "ArborX::TreeTraversal::nearest_queries_degenerated_one_leaf_tree",
+          "ArborX::TreeTraversal::query::nearest_degenerated_one_leaf_tree",
           Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(
               space, 0, Access::size(predicates)),
           *this);
@@ -201,7 +201,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     {
       allocateBuffer(space);
 
-      Kokkos::parallel_for("ArborX::TreeTraversal::nearest_queries",
+      Kokkos::parallel_for("ArborX::TreeTraversal::query::nearest",
                            Kokkos::RangePolicy<ExecutionSpace>(
                                space, 0, Access::size(predicates)),
                            *this);

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -192,7 +192,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     else if (bvh_.size() == 1)
     {
       Kokkos::parallel_for(
-          "ArborX::TreeTraversal::query::nearest_degenerated_one_leaf_tree",
+          "ArborX::TreeTraversal::nearest_queries_degenerated_one_leaf_tree",
           Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(
               space, 0, Access::size(predicates)),
           *this);
@@ -201,7 +201,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     {
       allocateBuffer(space);
 
-      Kokkos::parallel_for("ArborX::TreeTraversal::query::nearest",
+      Kokkos::parallel_for("ArborX::TreeTraversal::nearest_queries",
                            Kokkos::RangePolicy<ExecutionSpace>(
                                space, 0, Access::size(predicates)),
                            *this);

--- a/test/tstDetailsBatchedQueries.cpp
+++ b/test/tstDetailsBatchedQueries.cpp
@@ -22,7 +22,7 @@ namespace tt = boost::test_tools;
 template <typename DeviceType, typename ValueType>
 Kokkos::View<ValueType *, DeviceType> toView(std::vector<ValueType> const &v)
 {
-  Kokkos::View<ValueType *, DeviceType> w("whocares", v.size());
+  Kokkos::View<ValueType *, DeviceType> w("Testing::whocares", v.size());
   auto w_host = Kokkos::create_mirror_view(w);
   for (int i = 0; i < w.extent_int(0); ++i)
     w_host(i) = v[i];
@@ -35,10 +35,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(permute_offset_and_indices, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  Kokkos::View<int *, DeviceType> offset("offset", 0);
-  Kokkos::View<int *, DeviceType> indices("indices", 0);
+  Kokkos::View<int *, DeviceType> offset("Testing::offset", 0);
+  Kokkos::View<int *, DeviceType> indices("Testing::indices", 0);
 
-  Kokkos::View<unsigned int *, DeviceType> permute("permute", 0);
+  Kokkos::View<unsigned int *, DeviceType> permute("Testing::permute", 0);
 
   BOOST_CHECK_THROW(
       ArborX::Details::BatchedQueries<DeviceType>::reversePermutation(

--- a/test/tstDetailsBufferOptimization.cpp
+++ b/test/tstDetailsBufferOptimization.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(query_impl, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::deep_copy(offset, buffer_size);
 
   Kokkos::View<unsigned int *, DeviceType> permute(
-      Kokkos::ViewAllocateWithoutInitializing("permute"), n);
+      Kokkos::ViewAllocateWithoutInitializing("Testing::permute"), n);
   ArborX::iota(ExecutionSpace{}, permute);
 
   ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);

--- a/test/tstDistributedSearchTree.cpp
+++ b/test/tstDistributedSearchTree.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   MPI_Comm_size(comm, &comm_size);
 
   int const n = 4;
-  Kokkos::View<ArborX::Point *, DeviceType> points("points", n);
+  Kokkos::View<ArborX::Point *, DeviceType> points("Testing::points", n);
   // [  rank 0       [  rank 1       [  rank 2       [  rank 3       [
   // x---x---x---x---x---x---x---x---x---x---x---x---x---x---x---x---
   // ^   ^   ^   ^
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   // |<------3------>|               |               |               |
   // |               |               |               |               |
   Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
-      queries("queries", 1);
+      queries("Testing::queries", 1);
   auto queries_host = Kokkos::create_mirror_view(queries);
   queries_host(0) = ArborX::intersects(
       ArborX::Sphere{{{0.5 + comm_size - 1 - comm_rank, 0., 0.}}, 0.5});
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   // 3-->            |               |               |               |
   // |               |               |               |               |
   Kokkos::View<ArborX::Nearest<ArborX::Point> *, DeviceType> nearest_queries(
-      "nearest_queries", 1);
+      "Testing::nearest_queries", 1);
   auto nearest_queries_host = Kokkos::create_mirror_view(nearest_queries);
   nearest_queries_host(0) = ArborX::nearest<ArborX::Point>(
       {{0.0 + comm_size - 1 - comm_rank, 0., 0.}},
@@ -335,16 +335,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(do_not_exceed_capacity, DeviceType,
   using ArborX::Point;
   using ExecutionSpace = typename DeviceType::execution_space;
   MPI_Comm comm = MPI_COMM_WORLD;
-  Kokkos::View<Point *, DeviceType> points("points", 512);
+  Kokkos::View<Point *, DeviceType> points("Testing::points", 512);
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, 512),
                        KOKKOS_LAMBDA(int i) {
                          points(i) = {{(float)i, (float)i, (float)i}};
                        });
   ArborX::DistributedSearchTree<DeviceType> tree{comm, points};
-  Kokkos::View<decltype(nearest(Point{})) *, DeviceType> queries("queries", 1);
+  Kokkos::View<decltype(nearest(Point{})) *, DeviceType> queries(
+      "Testing::queries", 1);
   Kokkos::deep_copy(queries, nearest(Point{0, 0, 0}, 512));
-  Kokkos::View<PairIndexRank *, DeviceType> values("values", 0);
-  Kokkos::View<int *, DeviceType> offset("offset", 0);
+  Kokkos::View<PairIndexRank *, DeviceType> values("Testing::values", 0);
+  Kokkos::View<int *, DeviceType> offset("Testing::offset", 0);
   BOOST_CHECK_NO_THROW(tree.query(queries, values, offset));
 }
 
@@ -486,7 +487,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
 
   int const n_queries = 1;
   using ExecutionSpace = typename DeviceType::execution_space;
-  Kokkos::View<ArborX::Point *, DeviceType> points("points", n_queries);
+  Kokkos::View<ArborX::Point *, DeviceType> points("Testing::points",
+                                                   n_queries);
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n_queries),
                        KOKKOS_LAMBDA(int i) {
                          points(i) = {(float)(comm_rank) + 1.5f, 0.f, 0.f};
@@ -504,7 +506,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
   // called on rank 0.
   int const n_results = (comm_rank < comm_size - 1) ? 1 : 0;
   ArborX::Point const origin = {{0., 0., 0.}};
-  Kokkos::View<float *, DeviceType> ref("ref", n_results);
+  Kokkos::View<float *, DeviceType> ref("Testing::ref", n_results);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n_results), KOKKOS_LAMBDA(int i) {
         ref(i) =
@@ -512,8 +514,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
       });
 
   {
-    Kokkos::View<float *, DeviceType> custom("custom", 0);
-    Kokkos::View<int *, DeviceType> offset("offset", 0);
+    Kokkos::View<float *, DeviceType> custom("Testing::custom", 0);
+    Kokkos::View<int *, DeviceType> offset("Testing::offset", 0);
     tree.query(
         makeIntersectsBoxWithAttachmentQueries<DeviceType, int>(
             {{points_host(0), points_host(0)}}, {comm_rank}),
@@ -531,8 +533,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
                tt::per_element());
   }
   {
-    Kokkos::View<float *, DeviceType> custom("custom", 0);
-    Kokkos::View<int *, DeviceType> offset("offset", 0);
+    Kokkos::View<float *, DeviceType> custom("Testing::custom", 0);
+    Kokkos::View<int *, DeviceType> offset("Testing::offset", 0);
     tree.query(makeIntersectsBoxWithAttachmentQueries<DeviceType, int>(
                    {{points_host(0), points_host(0)}}, {comm_rank}),
                CustomPostCallbackAttachmentSpatialPredicate<DeviceType>{points},
@@ -589,8 +591,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
   // The formula is a bit complicated but it does not require n be divisible
   // by comm_size
   int const local_n = (n + comm_size - 1 - comm_rank) / comm_size;
-  Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes("bounding_boxes",
-                                                         local_n);
+  Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes(
+      "Testing::bounding_boxes", local_n);
   auto bounding_boxes_host = Kokkos::create_mirror_view(bounding_boxes);
   for (int i = 0; i < n; ++i)
   {
@@ -611,12 +613,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
 
   // make queries
   using ExecutionSpace = typename DeviceType::execution_space;
-  Kokkos::View<double * [3], ExecutionSpace> point_coords("point_coords",
-                                                          local_n);
+  Kokkos::View<double * [3], ExecutionSpace> point_coords(
+      "Testing::point_coords", local_n);
   auto point_coords_host = Kokkos::create_mirror_view(point_coords);
-  Kokkos::View<double *, ExecutionSpace> radii("radii", local_n);
+  Kokkos::View<double *, ExecutionSpace> radii("Testing::radii", local_n);
   auto radii_host = Kokkos::create_mirror_view(radii);
-  Kokkos::View<int * [2], ExecutionSpace> within_n_pts("within_n_pts", local_n);
+  Kokkos::View<int * [2], ExecutionSpace> within_n_pts("Testing::within_n_pts",
+                                                       local_n);
   std::default_random_engine generator(0);
   std::uniform_real_distribution<double> distribution_radius(
       0.0, std::sqrt(Lx * Lx + Ly * Ly + Lz * Lz));
@@ -641,7 +644,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::deep_copy(radii, radii_host);
 
   Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
-      within_queries("within_queries", local_n);
+      within_queries("Testing::within_queries", local_n);
   Kokkos::parallel_for(
       "register_within_queries",
       Kokkos::RangePolicy<ExecutionSpace>(0, local_n), KOKKOS_LAMBDA(int i) {

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -21,7 +21,7 @@
 #if (KOKKOS_VERSION >= 30200) // callback registriation from within the program
                               // was added in Kokkkos v3.2
 
-BOOST_AUTO_TEST_SUITE(DistributedKokkosToolsAnnotations)
+BOOST_AUTO_TEST_SUITE(KokkosToolsDistributedAnnotations)
 
 namespace tt = boost::test_tools;
 
@@ -51,21 +51,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
                     isPrefixedWith(label, "Testing::")));
       });
 
-  { // empty
-    auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
-  }
-
   { // one leaf per process
     auto tree = makeDistributedSearchTree<DeviceType>(
         MPI_COMM_WORLD, {
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                        });
-  }
-
-  { // two leaves per process
-    auto tree = makeDistributedSearchTree<DeviceType>(
-        MPI_COMM_WORLD, {
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
                             {{{0, 0, 0}}, {{1, 1, 1}}},
                         });
   }
@@ -112,64 +100,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
   Kokkos::Tools::Experimental::set_allocate_data_callback(nullptr);
 }
 
-/*
-BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
-{
-  auto const callback = [](char const *label, uint32_t, uint64_t *) {
-    std::cout << label << '\n';
-    BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
-                isPrefixedWith(label, "Kokkos::")));
-  };
-  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(callback);
-  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(callback);
-  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(callback);
-
-  // DistributedSearchTree::DistributedSearchTree
-
-  { // empty
-    auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
-  }
-
-  { // one leaf
-    auto tree = makeDistributedSearchTree<DeviceType>(
-        MPI_COMM_WORLD, {
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                        });
-  }
-
-  { // two leaves
-    auto tree = makeDistributedSearchTree<DeviceType>(
-        MPI_COMM_WORLD, {
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                        });
-  }
-
-  // DistributedSearchTree::query
-
-  auto tree = makeDistributedSearchTree<DeviceType>(
-      MPI_COMM_WORLD, {
-                          {{{0, 0, 0}}, {{1, 1, 1}}},
-                          {{{0, 0, 0}}, {{1, 1, 1}}},
-                      });
-
-  // spatial predicates
-  query(tree, makeIntersectsBoxQueries<DeviceType>({
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-              }));
-
-  // nearest predicates
-  query(tree, makeNearestQueries<DeviceType>({
-                  {{{0, 0, 0}}, 1},
-                  {{{0, 0, 0}}, 2},
-              }));
-
-  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
-  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
-  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(nullptr);
-}
-
 BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 {
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
@@ -182,19 +112,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 
   { // empty
     auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
-  }
-
-  { // one leaf per process
-    auto tree = makeDistributedSearchTree<DeviceType>(
-        MPI_COMM_WORLD, {{{{0, 0, 0}}, {{1, 1, 1}}}});
-  }
-
-  { // two leaves per process
-    auto tree = makeDistributedSearchTree<DeviceType>(
-        MPI_COMM_WORLD, {
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                            {{{0, 0, 0}}, {{1, 1, 1}}},
-                        });
   }
 
   // DistributedSearchTree::query
@@ -219,7 +136,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 
   Kokkos::Tools::Experimental::set_push_region_callback(nullptr);
 }
-*/
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -21,7 +21,7 @@
 #if (KOKKOS_VERSION >= 30200) // callback registriation from within the program
                               // was added in Kokkkos v3.2
 
-BOOST_AUTO_TEST_SUITE(KokkosToolsDistributedAnnotations)
+BOOST_AUTO_TEST_SUITE(DistributedKokkosToolsAnnotations)
 
 namespace tt = boost::test_tools;
 
@@ -37,6 +37,139 @@ BOOST_AUTO_TEST_CASE(is_prefixed_with)
   BOOST_TEST(!isPrefixedWith("Nope::ArborX", "ArborX"));
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    distributed_search_tree_distributed_search_tree_allocations_prefixed,
+    DeviceType, ARBORX_DEVICE_TYPES)
+{
+  Kokkos::Tools::Experimental::set_allocate_data_callback(
+      [](Kokkos::Profiling::SpaceHandle handle, const char *label,
+         void const *ptr, uint64_t size) {
+        std::cout << label << '\n';
+        BOOST_TEST((isPrefixedWith(label, "ArborX::DistributedSearchTree::") ||
+                    isPrefixedWith(label, "ArborX::BVH::") ||
+                    isPrefixedWith(label, "ArborX::Sorting::") ||
+                    isPrefixedWith(label, "Testing::")));
+      });
+
+  { // empty
+    auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
+  }
+
+  { // one leaf per process
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                        });
+  }
+
+  { // two leaves per process
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                        });
+  }
+
+  Kokkos::Tools::Experimental::set_allocate_data_callback(nullptr);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    distributed_search_tree_query_allocations_prefixed, DeviceType,
+    ARBORX_DEVICE_TYPES)
+{
+  auto tree = makeDistributedSearchTree<DeviceType>(
+      MPI_COMM_WORLD, {
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                      });
+
+  Kokkos::Tools::Experimental::set_allocate_data_callback(
+      [](Kokkos::Profiling::SpaceHandle handle, const char *label,
+         void const *ptr, uint64_t size) {
+        std::cout << label << '\n';
+        BOOST_TEST(
+            (isPrefixedWith(label, "ArborX::DistributedSearchTree::query::") ||
+             isPrefixedWith(label, "ArborX::Distributor::") ||
+             isPrefixedWith(label, "ArborX::BVH::query::") ||
+             isPrefixedWith(label, "ArborX::BufferOptimization::") ||
+             isPrefixedWith(label, "ArborX::Sorting::") ||
+             isPrefixedWith(label, "Kokkos::SortImpl::") ||
+             isPrefixedWith(label, "Testing::")));
+      });
+
+  // spatial predicates
+  query(tree, makeIntersectsBoxQueries<DeviceType>({
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+              }));
+
+  // nearest predicates
+  query(tree, makeNearestQueries<DeviceType>({
+                  {{{0, 0, 0}}, 1},
+                  {{{0, 0, 0}}, 2},
+              }));
+
+  Kokkos::Tools::Experimental::set_allocate_data_callback(nullptr);
+}
+
+/*
+BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  auto const callback = [](char const *label, uint32_t, uint64_t *) {
+    std::cout << label << '\n';
+    BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
+                isPrefixedWith(label, "Kokkos::")));
+  };
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(callback);
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(callback);
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(callback);
+
+  // DistributedSearchTree::DistributedSearchTree
+
+  { // empty
+    auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
+  }
+
+  { // one leaf
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                        });
+  }
+
+  { // two leaves
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                        });
+  }
+
+  // DistributedSearchTree::query
+
+  auto tree = makeDistributedSearchTree<DeviceType>(
+      MPI_COMM_WORLD, {
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                      });
+
+  // spatial predicates
+  query(tree, makeIntersectsBoxQueries<DeviceType>({
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+              }));
+
+  // nearest predicates
+  query(tree, makeNearestQueries<DeviceType>({
+                  {{{0, 0, 0}}, 1},
+                  {{{0, 0, 0}}, 2},
+              }));
+
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(nullptr);
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 {
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
@@ -49,6 +182,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 
   { // empty
     auto tree = makeDistributedSearchTree<DeviceType>(MPI_COMM_WORLD, {});
+  }
+
+  { // one leaf per process
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {{{{0, 0, 0}}, {{1, 1, 1}}}});
+  }
+
+  { // two leaves per process
+    auto tree = makeDistributedSearchTree<DeviceType>(
+        MPI_COMM_WORLD, {
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                        });
   }
 
   // DistributedSearchTree::query
@@ -73,6 +219,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 
   Kokkos::Tools::Experimental::set_push_region_callback(nullptr);
 }
+*/
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Analogon to #381 for DistributedSearchTree. I still like to distinguish between nearest_queries and spatial_queries if we can but won't fight over it. Also, we could append `ArborX::` to `Testing` in both pull requests.

Output for `ArborX_DistributedTree.exe`:
```
ALLOCATIONS AT TIME OF HIGH WATER MARK:
  23.2% internal_and_leaf_nodes
  14.4% ArborX:BVH:spatial_queries/ArborX:BVH:two_pass/ArborX:BVH:two_pass:second_pass/Testing::values
  14.4% Testing::values
  8.7% Testing::bounding_boxes
  7.2% ArborX::DistributedSearchTree::forwardQueries::import_ranks
  7.2% ArborX::DistributedSearchTree::forwardQueries::import_ids
  7.2% ArborX::DistributedSearchTree::forwardQueries::import_ranks
  7.2% ArborX::DistributedSearchTree::forwardQueries::import_ids
  4.3% Testing::values
  2.3% ArborX::DistributedSearchTree::forwardQueries::queries
  1.7% Testing::queries
  0.6% ArborX:BVH:spatial_queries/ArborX:BVH:spatial_queries:init_and_alloc/Testing::offsets
  0.6% ArborX::DistributedSearchTree::forwardQueries::import_ids
  0.6% ArborX:BVH:spatial_queries/ArborX:BVH:two_pass/ArborX:BVH:two_pass:second_pass/ArborX::DistributedSearchTree::spatial_query::indices
  0.6% ArborX::DistributedSearchTree::forwardQueries::import_ranks
```