### PR TITLE
Fix one missed label

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -106,7 +106,8 @@ sortObjects(Kokkos::Cuda const &space, ViewType &view)
       "");
 
   Kokkos::View<SizeType *, typename ViewType::device_type> permute(
-      Kokkos::ViewAllocateWithoutInitializing("permutation"), n);
+      Kokkos::ViewAllocateWithoutInitializing("ArborX::Sorting::permutation"),
+      n);
   ArborX::iota(space, permute);
 
   auto const execution_policy = thrust::cuda::par.on(space.cuda_stream());


### PR DESCRIPTION
This one sneaked in as a combination of a) @dalg24 not testing with Cuda, and b) Kokkos 3.2 not used in CI (and thus labels are not checked).