### PR TITLE
Drop initialize leaf nodes dispatch

### DIFF
--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -146,24 +146,16 @@ struct InitializeLeafNodes
     ARBORX_ASSERT(permutation_indices_.extent(0) == n);
     ARBORX_ASSERT(leaf_nodes_.extent(0) == n);
 
-    using Tag = typename AccessTraitsHelper<Access>::tag;
     Kokkos::parallel_for("ArbroX::TreeConstruction::initialize_leaf_nodes",
-                         Kokkos::RangePolicy<ExecutionSpace, Tag>(space, 0, n),
+                         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),
                          *this);
   }
 
-  KOKKOS_FUNCTION void operator()(BoxTag, int i) const
+  KOKKOS_FUNCTION void operator()(int i) const
   {
-    leaf_nodes_(i) =
-        makeLeafNode(permutation_indices_(i),
-                     Access::get(primitives_, permutation_indices_(i)));
-  }
-  KOKKOS_FUNCTION void operator()(PointTag, int i) const
-  {
-    leaf_nodes_(i) =
-        makeLeafNode(permutation_indices_(i),
-                     {Access::get(primitives_, permutation_indices_(i)),
-                      Access::get(primitives_, permutation_indices_(i))});
+    Box bbox{};
+    expand(bbox, Access::get(primitives_, permutation_indices_(i)));
+    leaf_nodes_(i) = makeLeafNode(permutation_indices_(i), std::move(bbox));
   }
 };
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -126,14 +126,11 @@ inline void assignMortonCodes(
                             scene_bounding_box);
 }
 
-template <typename ExecutionSpace, typename Primitives,
-          typename... PermutationIndicesViewProperties,
-          typename... LeafNodesViewProperties>
-inline void initializeLeafNodes(
-    ExecutionSpace const &space, Primitives const &primitives,
-    Kokkos::View<unsigned int *, PermutationIndicesViewProperties...>
-        permutation_indices,
-    Kokkos::View<Node *, LeafNodesViewProperties...> leaf_nodes)
+template <typename ExecutionSpace, typename Primitives, typename Indices,
+          typename Nodes>
+inline void
+initializeLeafNodes(ExecutionSpace const &space, Primitives const &primitives,
+                    Indices const &permutation_indices, Nodes const &leaf_nodes)
 {
   using Access = AccessTraits<Primitives, PrimitivesTag>;
   auto const n = Access::size(primitives);


### PR DESCRIPTION
Rational: If it doesn't impact performance (I haven't checked) this simplifies code and avoid the need to add new overloads if we template the bvh on the bounding volume type.

This is also a "good" change for exploring the fusion of this kernel with the hierarchy generation, regardless of whether we add the template parameter or not.