### PR TITLE
Add check for labels in kernels for DistributedSearchTree

### DIFF
--- a/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedSearchTreeImpl.hpp
@@ -706,7 +706,7 @@ void DistributedSearchTreeImpl<DeviceType>::communicateResultsBack(
   Kokkos::View<int *, DeviceType> export_ids(
       Kokkos::ViewAllocateWithoutInitializing(ids.label()), n_exports);
   Kokkos::parallel_for(
-      "AborX::DistributedTree::query::fill_buffer",
+      "ArborX::DistributedTree::query::fill_buffer",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_fwd_queries),
       KOKKOS_LAMBDA(int q) {
         for (int i = offset(q); i < offset(q + 1); ++i)

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -41,6 +41,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     distributed_search_tree_distributed_search_tree_allocations_prefixed,
     DeviceType, ARBORX_DEVICE_TYPES)
 {
+  auto tree = makeDistributedSearchTree<DeviceType>(
+      MPI_COMM_WORLD, {
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                      });
+
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle handle, const char *label,
          void const *ptr, uint64_t size) {
@@ -98,6 +104,42 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
               }));
 
   Kokkos::Tools::Experimental::set_allocate_data_callback(nullptr);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  auto const callback = [](char const *label, uint32_t, uint64_t *) {
+    std::cout << label << '\n';
+    BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
+                isPrefixedWith(label, "Kokkos::")));
+  };
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(callback);
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(callback);
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(callback);
+
+  // DistributedSearchTree::query
+
+  auto tree = makeDistributedSearchTree<DeviceType>(
+      MPI_COMM_WORLD, {
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                          {{{0, 0, 0}}, {{1, 1, 1}}},
+                      });
+
+  // spatial predicates
+  query(tree, makeIntersectsBoxQueries<DeviceType>({
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+                  {{{0, 0, 0}}, {{1, 1, 1}}},
+              }));
+
+  // nearest predicates
+  query(tree, makeNearestQueries<DeviceType>({
+                  {{{0, 0, 0}}, 1},
+                  {{{0, 0, 0}}, 2},
+              }));
+
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(nullptr);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)


### PR DESCRIPTION
While preparing this pull request, I realized that we are both using `DistributedTree` and `DistributedSearchTree`. We should probably just choose one of them and would slightly lean towards `DistributedSearchTree` (or an abbreviation like DST) since this is the actual name of the class.
Maybe, in another pull request.