### PR TITLE
Ignore #pragma-messages warnings in CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -394,7 +394,7 @@ pipeline {
                     enabledForFailure: true,
                     tools: [cmake(), gcc(), clang(), clangTidy()],
                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                    filters: [excludeFile('/usr/local/cuda.*')]
+                    filters: [excludeFile('/usr/local/cuda.*'), excludeCategory('#pragma-messages')]
                 )
             }
         }


### PR DESCRIPTION
This pull request tries to just ignore the #pragma-message warning generated for `ArborX_DistributedSearchTree.hpp` in the Jenkins plugin.