### PR TITLE
Reduce number of places that need to see the node type definition

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -75,16 +75,16 @@ private:
   friend struct Details::TreeTraversal;
   template <typename DeviceType>
   friend struct Details::TreeVisualization;
-  using Node = Details::Node;
+  using node_type = Details::Node;
 
-  Kokkos::View<Node *, MemorySpace> getInternalNodes()
+  Kokkos::View<node_type *, MemorySpace> getInternalNodes()
   {
     assert(!empty());
     return Kokkos::subview(_internal_and_leaf_nodes,
                            std::make_pair(size_type{0}, size() - 1));
   }
 
-  Kokkos::View<Node *, MemorySpace> getLeafNodes()
+  Kokkos::View<node_type *, MemorySpace> getLeafNodes()
   {
     assert(!empty());
     return Kokkos::subview(_internal_and_leaf_nodes,
@@ -92,29 +92,32 @@ private:
   }
 
   KOKKOS_FUNCTION
-  Node const *getRoot() const { return _internal_and_leaf_nodes.data(); }
+  node_type const *getRoot() const { return _internal_and_leaf_nodes.data(); }
 
   KOKKOS_FUNCTION
-  Node *getRoot() { return _internal_and_leaf_nodes.data(); }
+  node_type *getRoot() { return _internal_and_leaf_nodes.data(); }
 
   KOKKOS_FUNCTION
-  Node const *getNodePtr(int i) const { return &_internal_and_leaf_nodes(i); }
+  node_type const *getNodePtr(int i) const
+  {
+    return &_internal_and_leaf_nodes(i);
+  }
 
   KOKKOS_FUNCTION
-  bounding_volume_type const &getBoundingVolume(Node const *node) const
+  bounding_volume_type const &getBoundingVolume(node_type const *node) const
   {
     return node->bounding_box;
   }
 
   KOKKOS_FUNCTION
-  bounding_volume_type &getBoundingVolume(Node *node)
+  bounding_volume_type &getBoundingVolume(node_type *node)
   {
     return node->bounding_box;
   }
 
   size_t _size;
   bounding_volume_type _bounds;
-  Kokkos::View<Node *, MemorySpace> _internal_and_leaf_nodes;
+  Kokkos::View<node_type *, MemorySpace> _internal_and_leaf_nodes;
 };
 
 template <typename DeviceType>

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -16,7 +16,6 @@
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsAlgorithms.hpp> // expand
 #include <ArborX_DetailsMortonCode.hpp> // morton3D
-#include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsTags.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -16,6 +16,7 @@
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsAlgorithms.hpp> // expand
 #include <ArborX_DetailsMortonCode.hpp> // morton3D
+#include <ArborX_DetailsNode.hpp>       // makeLeafNode
 #include <ArborX_DetailsTags.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -155,7 +155,7 @@ namespace
 int constexpr UNTOUCHED_NODE = -1;
 } // namespace
 
-template <typename Primitives, typename MemorySpace>
+template <typename Primitives, typename MemorySpace, typename Node>
 class GenerateHierarchy
 {
 public:
@@ -345,7 +345,7 @@ private:
 
 template <typename ExecutionSpace, typename Primitives,
           typename... PermutationIndicesViewProperties,
-          typename... MortonCodesViewProperties,
+          typename... MortonCodesViewProperties, typename Node,
           typename... LeafNodesViewProperties,
           typename... InternalNodesViewProperties>
 void generateHierarchy(
@@ -364,7 +364,7 @@ void generateHierarchy(
 
   using MemorySpace = typename decltype(internal_nodes)::memory_space;
 
-  GenerateHierarchy<Primitives, MemorySpace>(
+  GenerateHierarchy<Primitives, MemorySpace, Node>(
       space, primitives, ConstPermutationIndices(permutation_indices),
       ConstMortonCodes(sorted_morton_codes), leaf_nodes, internal_nodes);
 }

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -13,7 +13,6 @@
 
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_DetailsAlgorithms.hpp>
-#include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsStack.hpp>
 #include <ArborX_DetailsUtils.hpp>
@@ -38,6 +37,7 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
   Callback callback_;
 
   using Access = AccessTraits<Predicates, PredicatesTag>;
+  using Node = typename BVH::node_type;
 
   template <typename ExecutionSpace>
   TreeTraversal(ExecutionSpace const &space, BVH const &bvh,
@@ -133,6 +133,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
   Callback callback_;
 
   using Access = AccessTraits<Predicates, PredicatesTag>;
+  using Node = typename BVH::node_type;
 
   using Buffer = Kokkos::View<Kokkos::pair<int, float> *, MemorySpace>;
   using Offset = Kokkos::View<int *, MemorySpace>;

--- a/src/details/ArborX_Predicates.hpp
+++ b/src/details/ArborX_Predicates.hpp
@@ -12,7 +12,6 @@
 #define ARBORX_PREDICATE_HPP
 
 #include <ArborX_DetailsAlgorithms.hpp>
-#include <ArborX_DetailsNode.hpp>
 
 namespace ArborX
 {

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -12,7 +12,8 @@
 #include "ArborX_EnableViewComparison.hpp"
 #include <ArborX_DetailsAlgorithms.hpp>
 #include <ArborX_DetailsMortonCode.hpp> // expandBits, morton3D
-#include <ArborX_DetailsSortUtils.hpp>  // sortObjects
+#include <ArborX_DetailsNode.hpp>
+#include <ArborX_DetailsSortUtils.hpp> // sortObjects
 #include <ArborX_DetailsTreeConstruction.hpp>
 
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
This is the uncontroversial part of #386 that is needed by #364 
Essentially deducing the node type from the bvh or making it a template parameter depending on the context.

I renamed `BVH::{Node -> node_type}` for consistency with the `BVH::bounding_volume_type` member type and to avoid ambiguities with the actual type.