### PR TITLE
Allow using HIP in BVH benchmark

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -92,7 +92,8 @@ Spec create_spec_from_string(std::string const &spec_string)
 
   if (!(spec.backends == "all" || spec.backends == "serial" ||
         spec.backends == "openmp" || spec.backends == "threads" ||
-        spec.backends == "cuda" || spec.backends == "rtree"))
+        spec.backends == "cuda" || spec.backends == "rtree" ||
+        spec.backends == "hip"))
     throw std::runtime_error("Backend " + spec.backends + " invalid!");
 
   return spec;


### PR DESCRIPTION
Only the check for valid backends was incomplete.