### PR TITLE
Temporary workaround for failures in HIP CI build

### DIFF
--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -1038,6 +1038,10 @@ std::vector<std::array<double, 3>> make_random_cloud(double Lx, double Ly,
   return cloud;
 }
 
+// FIXME temporary workaround
+#ifdef KOKKOS_ENABLE_HIP
+BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(2))
+#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
 {
   // construct a cloud of points (nodes of a structured grid)

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -1038,7 +1038,7 @@ std::vector<std::array<double, 3>> make_random_cloud(double Lx, double Ly,
   return cloud;
 }
 
-// FIXME temporary workaround
+// FIXME temporary workaround bug in HIP-Clang (register spill)
 #ifdef KOKKOS_ENABLE_HIP
 BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(2))
 #endif
@@ -1136,9 +1136,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
 
   BoostExt::RTree<ArborX::Box> rtree(bounding_boxes_host);
 
+  // FIXME check currently sporadically fails when using the HIP backend
   ARBORX_TEST_QUERY_TREE(bvh, nearest_queries,
                          query(rtree, nearest_queries_host));
 
+  // FIXME ditto
   ARBORX_TEST_QUERY_TREE(bvh, within_queries,
                          query(rtree, within_queries_host));
 }


### PR DESCRIPTION
Using Boost.Test native expected failures specification when the HIP backend is enabled.

Other options were to handle the failure on the CMake or even Jenkins side.  I am proposing this solution because it is most concise and fine-grained.