### PR TITLE
Add plotting script for benchmark

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+import json
+import re
+
+def load_json(filename):
+    with open(filename) as f:
+        try:
+            # Try loading a file using JSON reader
+            data = json.loads(f.read())['benchmarks']
+        except ValueError:
+            # Try loading a file using ASCII reader
+            data = []
+            f.seek(0)   # reset the file as it was messed up above
+            try:
+                for line in f:
+                    # Try to parse only the lines starting with "BM_"
+                    if re.search('^BM_', line) != None:
+                        for timer in ['manual_time', 'manual_time_mean', 'manual_time_median', 'manual_time_stddev']:
+                            m = re.search('(^.*/' + timer + ') .*rate=([0-9.]*)(.*)$', line)
+                            if m != None:
+                                name = m.group(1)
+                                rate = float(m.group(2))
+                                rate_scale = m.group(3)
+                                if rate_scale == 'k/s':
+                                    rate = rate * 1000
+                                elif rate_scale == 'M/s':
+                                    rate = rate * 1000000
+                                else:
+                                    raise Exception('Unknown rate scaling: "' + rate_scale + '"')
+                                data.append({'name' : name, 'rate' : rate})
+                                break
+
+            except RuntimeError as e:
+                raise RuntimeError("Caught an error while parsing on line " + str(lineno) + ": " + e.args[0])
+
+    return data
+
+allowed_geometries = ['filled_box', 'hollow_box']
+allowed_algorithms = ['construction', 'radius_search', 'radius_callback_search', 'knn_search', 'knn_callback_search']
+
+# Geometry is only checked for the source cloud
+# We do not check target cloud geometry as they come in pairs:
+#   filled_box/filled_sphere or hollow_box/hollow_sphere
+def parse_benchmark(json_data, algorithm, implementation, timer_aggregate, geometry, num_radius_passes = 2):
+    if geometry not in allowed_geometries:
+        raise Exception('Unknown geometry: "' + geometry + '"')
+    if algorithm not in allowed_algorithms:
+        raise Exception('Unknown algorithm: "' + algorithm + '"')
+
+    geometries = { 'filled_box' : '0', 'hollow_box' : '1', 'filled_sphere' : '2', 'hollow_sphere' : '3' }
+
+    # Escape () in implementation string
+    implementation = implementation.translate(str.maketrans({"(" : "\(", ")" : "\)", "%" : "\%" }))
+
+    sorted = 1
+
+    # Templates:
+    # BM_construction<ArborX::BVH<_DeviceType_>>/_num_primitives_/_source_point_cloud_type_
+    construction_template = algorithm + '<.*' + implementation + '[^/]*/([^/]*)/' + geometries[geometry] + '/'
+    # BM_knn_search<ArborX::BVH<_DeviceType_>>/_num_primitives_/_num_predicates_/_n_neighbors_/_sort_predicate_/_source_point_cloud_type_/_target_point_cloud_type_
+    knn_template = algorithm + '<.*' + implementation + '[^/]*/([^/]*)/([^/]*)/[^/]*/' + str(sorted) + '/' + geometries[geometry] + '/'
+    # BM_knn_search<ArborX::BVH<_DeviceType_>>/_num_primitives_/_num_predicates_/_n_neighbors_/_sort_predicates_/_buffer_size_/_source_point_cloud_type_/_target_point_cloud_type_
+    # we consider (2P) to be represented by buffer_size = 0
+    radius_template_1P = algorithm + '<.*' + implementation + '[^/]*/([^/]*)/([^/]*)/[^/]*/' + str(sorted) + '/[^0][^/]+/' + geometries[geometry] + '/'
+    radius_template_2P = algorithm + '<.*' + implementation + '[^/]*/([^/]*)/([^/]*)/[^/]*/' + str(sorted) + '/0/' + geometries[geometry] + '/'
+
+    num_primitives = []
+    num_predicates = []
+    rates    = []
+
+    for benchmark in json_data:
+        name = benchmark['name']
+
+        # For Google Benchmark v1.5, one could do
+        #  if benchmark['run_type'] != 'aggregate' or benchmark['aggregate_name'] != timer_aggregate:
+            #  continue
+        if re.search(timer_aggregate, name) == None:
+            continue
+
+        if algorithm == 'construction' and re.search(algorithm, name) != None:
+            m = re.search(construction_template, name)
+            if m != None:
+                num_primitives.append(int(m.group(1)))
+                rates.append(benchmark['rate'])
+
+        elif (algorithm == 'knn_search' or algorithm == 'knn_callback_search') and re.search(algorithm, name) != None:
+            m = re.search(knn_template, name)
+            if m != None:
+                num_primitives.append(int(m.group(1)))
+                num_predicates.append(int(m.group(2)))
+                rates.append(benchmark['rate'])
+
+        elif (algorithm == 'radius_search' or algorithm == 'radius_callback_search') and re.search(algorithm, name) != None:
+            m = re.search(radius_template_2P if num_radius_passes == 2 else radius_template_1P, name)
+            if m != None:
+                num_primitives.append(int(m.group(1)))
+                num_predicates.append(int(m.group(2)))
+                rates.append(benchmark['rate'])
+
+    return num_primitives, num_predicates, rates

--- a/scripts/benchmark_plot.py
+++ b/scripts/benchmark_plot.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""benchmark_plot.py
+
+Usage:
+  benchmark_plot.py -a ALGORITHM [-b BACKENDS...] -g GEOMETRY -i INPUT... [-n] [-e] [-t TITLE] [-o OUTPUT_FILE]
+  benchmark_plot.py (-h | --help)
+
+Options:
+  -h --help                         Show this screen.
+  -a ALGORITHM --algo ALGORITHM     Algorithm ['construction', 'radius_search', 'radius_callback_search', 'knn_search', 'knn_callback_search']
+  -b BACKENDS --backends BACKENDS   Backends to parse [default: all]
+  -g GEOMETRY --geometry GEOMETRY   Geometry (source cloud) ['filled_box', 'hollow_box']
+  -i FILE --input-files=FILE        Input file(s) containing benchmark results in JSON format
+  -n --numbers                      Plot numbers [default: False]
+  -e --errors                       Plot error bars [default: False]
+  -o FILE --output-file=FILE        Output file
+  -t TITLE --title=TITLE            Plot title
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+import math
+import re
+from docopt import docopt
+
+from benchmark import load_json, parse_benchmark, allowed_algorithms, allowed_geometries
+
+def find_available_backends(input_jsons):
+    arborx_backend_regex = "[^<]*<ArborX::BVH<([^>]*)>.*"
+
+    backends = set()
+    for input_json in input_jsons:
+        for benchmark in input_json:
+            search_result = re.search(arborx_backend_regex, benchmark['name'])
+            if search_result != None:
+                backends.add(search_result.group(1))
+    backends = list(backends)
+    backends.sort()
+
+    return backends
+
+class NotMatchingValuesAndPredicatesSizesException(Exception):
+    def __init__(self, message, i, backend):
+        super().__init__(message)
+        self.i = i
+        self.backend = backend
+
+def populate_data(input_jsons, backends):
+    all_num_primitives  = []
+    all_rates = []
+    all_errors = []
+
+    for i in range(len(backends)):
+        # For every backend, find all (num_primitives, rate, error) in all input files
+        backend = backends[i]
+
+        backend_num_primitives = []
+        backend_rates = []
+        backend_errors = []
+
+        implementation = 'ArborX::BVH<' + backend + '>'
+        for i in range(len(input_jsons)):
+            file_num_primitives, file_num_predicates, file_rates  = parse_benchmark(input_jsons[i], algorithm, implementation, 'median', geometry)
+            _,                   _,                   file_errors = parse_benchmark(input_jsons[i], algorithm, implementation, 'stddev', geometry)
+            if algorithm != 'construction' and file_num_primitives != file_num_predicates:
+                raise NotMatchingValuesAndPredicatesSizesException("", i, backend)
+
+            backend_num_primitives = backend_num_primitives +  file_num_primitives
+            backend_rates = backend_rates + file_rates
+            backend_errors = backend_errors + file_errors
+
+        all_num_primitives.append(backend_num_primitives)
+        all_rates.append(backend_rates)
+        all_errors.append(backend_errors)
+
+    num_unique_primitives = []
+    for i in range(len(all_num_primitives)):
+        num_unique_primitives = num_unique_primitives + all_num_primitives[i]
+    num_unique_primitives = list(set(num_unique_primitives))
+    num_unique_primitives.sort()
+
+    return num_unique_primitives, all_num_primitives, all_rates, all_errors,
+
+def backends_comparison_rate_figure(input_files, algorithm, geometry, backends, plot_numbers = False, plot_errors = True):
+    # Read in files to produce JSON
+    input_jsons = []
+    for input_file in input_files:
+        input_jsons.append(load_json(input_file))
+
+    # Phase 0: parse backends
+    backends = backends
+    if backends[0] == "all":
+        # Figure out a list of available backends by populating a set by
+        # searching a regular expression in all input files
+        backends = find_available_backends(input_jsons)
+
+    # Phase 1: data setup
+    try:
+        num_unique_primitives, all_num_primitives, all_rates, all_errors = populate_data(input_jsons, backends)
+    except NotMatchingValuesAndPredicatesSizesException as e:
+        raise Exception('The number of predicates does not match the number of primitives for "' + e.backend + '" in "' +  input_files[e.i] + "'")
+    n_unique = len(num_unique_primitives)
+
+    # If the same data point (algorithm, backend, num_sources) is present in
+    # multiple files, choose only the last one for plotting
+    y_scaling = 10**6
+    rates = np.zeros([len(backends), n_unique])
+    errors = np.zeros([len(backends), 2, n_unique])
+    for i in range(0, len(backends)):
+        for j in range(0, len(all_num_primitives[i])):
+            index = num_unique_primitives.index(all_num_primitives[i][j])
+            rates[i, index] = all_rates[i][j]/y_scaling
+            errors[i, 0, index] = 1 - all_errors[i][j]/all_rates[i][j]
+            errors[i, 1, index] = 1 + all_errors[i][j]/all_rates[i][j]
+
+    # Phase 2: plot generation
+    plt.figure(figsize=(max(n_unique, 6), 5))
+
+    ax = plt.subplot(111)
+    patterns = ('/', 'x', '\\', '.', 'o', 'O')
+
+    def autolabel(rects):
+        """Attach a text label above each bar in *rects*, displaying its height."""
+        for rect in rects:
+            height = round(rect.get_height(),1)
+            ax.annotate('{}'.format(height),
+                        xy=(rect.get_x() + rect.get_width() / 2, rect.get_height()),
+                        xytext=(0, 3),  # 3 points vertical offset
+                        textcoords="offset points",
+                        ha='center', va='bottom',
+                        fontsize=18)
+
+    # Create TeX-style label
+    def primitive_label(n):
+        e = math.floor(math.log(n + 1, 10))
+        r = math.floor(n/10**e)
+        return (str(r) + '$\cdot $' if r > 1 else '') +  '$10^' + str(e) + '$'
+
+    width = 0.6
+    scale = 1/len(backends)
+    for i in range(0, len(backends)):
+        barplot = ax.bar(np.arange(n_unique) + scale*(i-.5*(len(backends)-1)) * width,
+                         width=scale*width*np.ones(n_unique), height=rates[i, :],
+                         yerr=(errors[i, :] if plot_errors == True else None),
+                         capsize=5, hatch=patterns[i % len(patterns)],
+                         edgecolor='k',
+                         error_kw=dict(ecolor='gray', lw=2, capsize=5, capthick=2),
+                         label=backends[i])
+
+        if plot_numbers:
+            autolabel(barplot)
+
+    ax.legend(loc='upper left', fontsize=20)
+
+    ax.set_xlabel('Number of indexed objects', fontsize=20)
+    plt.xticks(fontsize=18)
+    ax.set_xticks(np.arange(n_unique))
+    ax.set_xticklabels([primitive_label(size) for size in num_unique_primitives])
+    ax.tick_params(axis='x', which='major', bottom='off', top='off')
+    ax.set_xlim([-0.5, n_unique - 0.5])
+
+    ax.set_ylabel('Rate (million queries/second)', fontsize=20)
+    plt.yticks(fontsize=18)
+    ax.yaxis.grid('on')
+    ax.set_ylim([0, 1.1*ax.get_ylim()[1]])
+
+if __name__ == '__main__':
+
+    # Process input
+    options = docopt(__doc__)
+
+    algorithm = options['--algo']
+    backends = options['--backends']
+    geometry = options['--geometry']
+    input_files = options['--input-files']
+    output_file = options['--output-file']
+    plot_numbers = options['--numbers']
+    plot_errors = options['--errors']
+    plot_title = options['--title']
+
+    # Check input
+    if geometry not in allowed_geometries:
+        raise Exception('Unknown geometry: "' + geometry + '". Allowed values are ' + str(allowed_geometries))
+
+    if algorithm not in allowed_algorithms:
+        raise Exception('Unknown algorithm: "' + algorithm + '". Allowed values are ' + str(allowed_algorithms))
+
+    backends_comparison_rate_figure(input_files, algorithm=algorithm, geometry=geometry,
+        backends=backends, plot_numbers=plot_numbers, plot_errors=plot_errors)
+
+    if plot_title != None:
+        plt.title(plot_title, fontsize=18)
+    else:
+        plt.title(algorithm, fontsize=18)
+
+    plt.tight_layout()
+    if output_file:
+        plt.savefig(output_file, bbox_inches='tight', dpi=600)
+    else:
+        plt.show()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+docopt
+matplotlib
+numpy


### PR DESCRIPTION
This is a reduced version of @aprokop's script used for the paper. The intent here is that we can pass any kind of (partial) results produced by `benchmarks/bvh_driver/ArborX_BoundingVolumeHierarchy.exe` and display them graphically. At the moment, we print the mean with some error base indicating a transformed confidence interval for the rate with which points are processed.
Optionally, the actually numbers are also printed. Sample output:
[
![plot_newest_errorbars](https://user-images.githubusercontent.com/2423533/95247289-ae68b380-07e3-11eb-8671-7eb3a3791d5e.png)
](url)

Feel free to comment on how to improve it.