### PR TITLE
Add testing of new query overload to the perf benchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
 variables:
-  SCHEDULER_PARAMETERS: "-J ArborX_CI -W 0:30 -nnodes 1 -P CSC333 -alloc_flags smt1"
+  SCHEDULER_PARAMETERS: "-J ArborX_CI -W 1:00 -nnodes 1 -P CSC333 -alloc_flags smt1"
 
 stages:
   - buildDependencies

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -254,6 +254,13 @@ public:
         BoostRTreeHelpers::performQueries(_tree, predicates);
   }
 
+  template <typename Predicates, typename Callback, typename... TrailingArgs>
+  void query(Predicates const &, Callback const &, TrailingArgs &&...) const
+  {
+    throw std::runtime_error(
+        "Boost RTree does not support callback only query overload.");
+  }
+
 private:
   BoostRTreeHelpers::RTree<Indexable> _tree;
 };


### PR DESCRIPTION
The callbacks simply count the number of found neighbors.

The PR should be pretty straightforward. One thing that we need to decide on is whether we want to test both types of queries on the same number of points for performance testing. Testing both on everything essentially doubles testing time.

If decide to not test the same way, the answer will depend on what we think is more important.
I think my current position would be to test all numbers for pure callbacks, and not more than 3 for the old callbacks (with indices and offsets).