### PR TITLE
Require Boost 1.56.0 for benchmarks

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED COMPONENTS program_options)
+find_package(Boost 1.56.0 REQUIRED COMPONENTS program_options)
 
 add_subdirectory(bvh_driver)
 if (ARBORX_ENABLE_MPI)


### PR DESCRIPTION
Fixes https://github.com/arborx/ArborX/issues/311. This is the first version that works for me.