### PR TITLE
[WIP] Externalize buffer in BVH callback benchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
 variables:
-  SCHEDULER_PARAMETERS: "-J ArborX_CI -W 0:30 -nnodes 1 -P CSC333 -alloc_flags smt1"
+  SCHEDULER_PARAMETERS: "-J ArborX_CI -W 1:00 -nnodes 1 -P CSC333 -alloc_flags smt1"
 
 stages:
   - buildDependencies

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -488,7 +488,7 @@ void BM_radius_callback_search(benchmark::State &state, Spec const &spec)
     Kokkos::Profiling::pushRegion("second_pass");
     index.query(queries, callback_second,
                 ArborX::Experimental::TraversalPolicy()
-                    .setPredicateSorting(spec.sort_predicates)
+                    .setPredicateSorting(false)
                     .setBufferSize(spec.buffer_size));
     Kokkos::Profiling::popRegion();
 

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -254,6 +254,13 @@ public:
         BoostRTreeHelpers::performQueries(_tree, predicates);
   }
 
+  template <typename Predicates, typename Callback, typename... TrailingArgs>
+  void query(Predicates const &, Callback const &, TrailingArgs &&...) const
+  {
+    throw std::runtime_error(
+        "Boost RTree does not support callback only query overload.");
+  }
+
 private:
   BoostRTreeHelpers::RTree<Indexable> _tree;
 };


### PR DESCRIPTION
This pull request is meant to explore how much externalizing the buffer logic really costs (somewhat based on #412. Initial tests on my laptop look at least reasonable:
```
----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                  Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------------
BM_radius_search<ArborX::BVH<Serial>>/50000/20000/10/1/0/0/0/manual_time               58428 us        58430 us           11
BM_radius_callback_search<ArborX::BVH<Serial>>/50000/20000/10/1/0/0/0/manual_time      60663 us        60706 us           11
BM_radius_search<ArborX::BVH<OpenMP>>/50000/20000/10/1/0/0/0/manual_time               13582 us        13371 us           42
BM_radius_callback_search<ArborX::BVH<OpenMP>>/50000/20000/10/1/0/0/0/manual_time      14341 us        14196 us           49
```
