### PR TITLE
Enable all experimental backends

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -567,6 +567,25 @@ int main(int argc, char *argv[])
       throw std::runtime_error("HIP backend not available!");
 #endif
 
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+    if (spec.backends == "all" || spec.backends == "openmptarget")
+      register_benchmark<
+          ArborX::BVH<Kokkos::Experimental::OpenMPTarget::device_type>>(
+          "ArborX::BVH<OpenMPTarget>", spec);
+#else
+    if (spec.backends == "openmptarget")
+      throw std::runtime_error("OpenMPTarget backend not available!");
+#endif
+
+#ifdef KOKKOS_ENABLE_
+    if (spec.backends == "all" || spec.backends == "sycl")
+      register_benchmark<ArborX::BVH<Kokkos::Experimental::SYCL::device_type>>(
+          "ArborX::BVH<SYCL>", spec);
+#else
+    if (spec.backends == "sycl")
+      throw std::runtime_error("SYCL backend not available!");
+#endif
+
 #ifdef KOKKOS_ENABLE_SERIAL
     if (spec.backends == "all" || spec.backends == "rtree")
       register_benchmark<BoostExt::RTree<ArborX::Point>>("BoostRTree", spec);

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -65,14 +65,18 @@ struct PrintfCallback
   KOKKOS_FUNCTION void operator()(Predicate, int primitive,
                                   OutputFunctor const &out) const
   {
+#ifndef KOKKOS_ENABLE_SYCL
     printf("Found %d from functor\n", primitive);
+#endif
     out(primitive);
   }
   template <typename Predicate, typename OutputFunctor>
   KOKKOS_FUNCTION void operator()(Predicate, int primitive, float distance,
                                   OutputFunctor const &out) const
   {
+#ifndef KOKKOS_ENABLE_SYCL
     printf("Found %d with distance %.3f from functor\n", primitive, distance);
+#endif
     out({primitive, distance});
   }
 };
@@ -107,7 +111,9 @@ int main(int argc, char *argv[])
     bvh.query(ExecutionSpace{}, FirstOctant{},
               KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                             auto /*output_functor*/) {
+#ifndef KOKKOS_ENABLE_SYCL
                 printf("Found %d from generic lambda\n", primitive);
+#endif
               },
               values, offsets);
 #endif
@@ -123,8 +129,10 @@ int main(int argc, char *argv[])
     bvh.query(ExecutionSpace{}, NearestToOrigin{k},
               KOKKOS_LAMBDA(auto /*predicate*/, int primitive, float distance,
                             auto /*output_functor*/) {
+#ifndef KOKKOS_ENABLE_SYCL
                 printf("Found %d with distance %.3f from generic lambda\n",
                        primitive, distance);
+#endif
               },
               values, offsets);
 #endif
@@ -138,7 +146,9 @@ int main(int argc, char *argv[])
 #ifndef __NVCC__
     bvh.query(ExecutionSpace{}, FirstOctant{},
               KOKKOS_LAMBDA(auto /*predicate*/, int j) {
+#ifndef KOKKOS_ENABLE_SYCL
                 printf("%d %d %d\n", ++c(), -1, j);
+#endif
               });
 #endif
   }

--- a/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
+++ b/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
@@ -52,9 +52,11 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
 
             if (neigh_is_core_point && clusters(i) != clusters(j))
             {
+#ifndef KOKKOS_ENABLE_SYCL
               printf("Connected cores do not belong to the same cluster: "
                      "%d [%d] -> %d [%d]\n",
                      i, clusters(i), j, clusters(j));
+#endif
               update++;
             }
           }
@@ -105,9 +107,11 @@ bool verifyBoundaryPointsConnectToCorePoints(ExecutionSpace const &exec_space,
 
           if (is_boundary && !have_shared_core)
           {
+#ifndef KOKKOS_ENABLE_SYCL
             printf("Boundary point does not belong to a cluster: "
                    "%d [%d]\n",
                    i, clusters(i));
+#endif
             update++;
           }
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,11 +15,17 @@ endif()
 if(Kokkos_ENABLE_HIP)
   list(APPEND ARBORX_DEVICE_TYPES Kokkos::Experimental::HIPSpace::device_type)
 endif()
+if(Kokkos_ENABLE_OPENMPTARGET)
+  list(APPEND ARBORX_DEVICE_TYPES Kokkos::Experimental::OpenMPTarget::device_type)
+endif()
+if(Kokkos_ENABLE_SYCL)
+  list(APPEND ARBORX_DEVICE_TYPES Kokkos::Experimental::SYCL::device_type)
+endif()
 
 string(REPLACE ";" "," ARBORX_DEVICE_TYPES "${ARBORX_DEVICE_TYPES}")
 
 if(NOT ARBORX_DEVICE_TYPES)
-  message(SEND_ERROR "Kokkos_DEVICES must include at least one of 'SERIAL', 'OPENMP', 'CUDA', 'HIP', or 'PTHREAD'!")
+  message(SEND_ERROR "Kokkos_DEVICES must include at least one of 'SERIAL', 'OPENMP', 'CUDA', 'HIP', 'OPENMPTARGET', 'SYCL' or 'PTHREAD'!")
 endif()
 
 configure_file(ArborX_EnableDeviceTypes.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/ArborX_EnableDeviceTypes.hpp @ONLY)


### PR DESCRIPTION
These are changes that are needed to check whether ArborX can build with the Kokkos experimental backends OpenMPTarget and SYCL.  I have had to make these changes manually several times and I am sure other have too.  I think it is time to merge it in.

I do not believe that having this in will confuse users and expect that we will get it working soon enough.