### PR TITLE
Stop using BVH<DeviceType> and DistributedTree<DeviceType> internally

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -540,12 +540,9 @@ int main(int argc, char *argv[])
   {
 #ifdef KOKKOS_ENABLE_SERIAL
     if (spec.backends == "all" || spec.backends == "serial")
-    {
-      using DeviceType = Kokkos::Serial::device_type;
-      register_benchmark<typename DeviceType::execution_space,
-                         ArborX::BVH<typename DeviceType::memory_space>>(
+      register_benchmark<Kokkos::Serial,
+                         ArborX::BVH<typename Kokkos::Serial::memory_space>>(
           "ArborX::BVH<Serial>", spec);
-    }
 #else
     if (spec.backends == "serial")
       throw std::runtime_error("Serial backend not available!");
@@ -553,12 +550,9 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_OPENMP
     if (spec.backends == "all" || spec.backends == "openmp")
-    {
-      using DeviceType = Kokkos::OpenMP::device_type;
-      register_benchmark<typename DeviceType::execution_space,
-                         ArborX::BVH<typename DeviceType::memory_space>>(
+      register_benchmark<Kokkos::OpenMP,
+                         ArborX::BVH<typename Kokkos::OpenMP::memory_space>>(
           "ArborX::BVH<OpenMP>", spec);
-    }
 #else
     if (spec.backends == "openmp")
       throw std::runtime_error("OpenMP backend not available!");
@@ -566,12 +560,9 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_THREADS
     if (spec.backends == "all" || spec.backends == "threads")
-    {
-      using DeviceType = Kokkos::Threads::device_type;
-      register_benchmark<typename DeviceType::execution_space,
-                         ArborX::BVH<typename DeviceType::memory_space>>(
+      register_benchmark<Kokkos::Threads,
+                         ArborX::BVH<typename Kokkos::Threads::memory_space>>(
           "ArborX::BVH<Threads>", spec);
-    }
 #else
     if (spec.backends == "threads")
       throw std::runtime_error("Threads backend not available!");
@@ -579,12 +570,9 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_CUDA
     if (spec.backends == "all" || spec.backends == "cuda")
-    {
-      using DeviceType = Kokkos::Cuda::device_type;
-      register_benchmark<typename DeviceType::execution_space,
-                         ArborX::BVH<typename DeviceType::memory_space>>(
+      register_benchmark<Kokkos::Cuda,
+                         ArborX::BVH<typename Kokkos::Cuda::memory_space>>(
           "ArborX::BVH<Cuda>", spec);
-    }
 #else
     if (spec.backends == "cuda")
       throw std::runtime_error("CUDA backend not available!");
@@ -592,12 +580,10 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_HIP
     if (spec.backends == "all" || spec.backends == "hip")
-    {
-      using DeviceType = Kokkos::Experimental::HIP::device_type;
-      register_benchmark<typename DeviceType::execution_space,
-                         ArborX::BVH<typename DeviceType::memory_space>>(
+      register_benchmark<
+          Kokkos::Experimental::HIP,
+          ArborX::BVH<typename Kokkos::Experimental::HIP::memory_space>>(
           "ArborX::BVH<HIP>", spec);
-    }
 #else
     if (spec.backends == "hip")
       throw std::runtime_error("HIP backend not available!");
@@ -605,12 +591,11 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     if (spec.backends == "all" || spec.backends == "openmptarget")
-    {
-      using DeviceType = Kokkos::Experimental::OpenMPTarget::device_type;
-      register_benchmark<typename DeviceType::execution_space,
-                         ArborX::BVH<typename DeviceType::memory_space>>(
+      register_benchmark<
+          Kokkos::Experimental::OpenMPTarget,
+          ArborX::BVH<
+              typename Kokkos::Experimental::OpenMPTarget::memory_space>>(
           "ArborX::BVH<OpenMPTarget>", spec);
-    }
 #else
     if (spec.backends == "openmptarget")
       throw std::runtime_error("OpenMPTarget backend not available!");
@@ -618,12 +603,10 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_
     if (spec.backends == "all" || spec.backends == "sycl")
-    {
-      using DeviceType = Kokkos::Experimental::SYCL::device_type;
-      register_benchmark<typename DeviceType::execution_space,
-                         ArborX::BVH<typename DeviceType::memory_space>>(
+      register_benchmark<
+          Kokkos::Experimental::SYCL,
+          ArborX::BVH<typename Kokkos::Experimental::SYCL::memory_space>>(
           "ArborX::BVH<SYCL>", spec);
-    }
 #else
     if (spec.backends == "sycl")
       throw std::runtime_error("SYCL backend not available!");
@@ -631,8 +614,8 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_SERIAL
     if (spec.backends == "all" || spec.backends == "rtree")
-      register_benchmark<typename Kokkos::Serial::execution_space,
-                         BoostExt::RTree<ArborX::Point>>("BoostRTree", spec);
+      register_benchmark<Kokkos::Serial, BoostExt::RTree<ArborX::Point>>(
+          "BoostRTree", spec);
 #endif
   }
 

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -188,29 +188,33 @@ struct ArborX::AccessTraits<QueriesWithIndex<Queries>, ArborX::PredicatesTag>
   }
 };
 
-template <class TreeType>
+template <typename ExecutionSpace, class TreeType>
 void BM_construction(benchmark::State &state, Spec const &spec)
 {
-  using DeviceType = typename TreeType::device_type;
+  using DeviceType =
+      Kokkos::Device<ExecutionSpace, typename TreeType::memory_space>;
+
   auto const points =
       constructPoints<DeviceType>(spec.n_values, spec.source_point_cloud_type);
 
   for (auto _ : state)
   {
     auto const start = std::chrono::high_resolution_clock::now();
-    TreeType index(points);
+    TreeType index(ExecutionSpace{}, points);
     auto const end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
   }
 }
 
-template <class TreeType>
+template <typename ExecutionSpace, class TreeType>
 void BM_knn_search(benchmark::State &state, Spec const &spec)
 {
-  using DeviceType = typename TreeType::device_type;
+  using DeviceType =
+      Kokkos::Device<ExecutionSpace, typename TreeType::memory_space>;
 
   TreeType index(
+      ExecutionSpace{},
       constructPoints<DeviceType>(spec.n_values, spec.source_point_cloud_type));
   auto const queries = makeNearestQueries<DeviceType>(
       spec.n_values, spec.n_queries, spec.n_neighbors,
@@ -221,7 +225,7 @@ void BM_knn_search(benchmark::State &state, Spec const &spec)
     Kokkos::View<int *, DeviceType> offset("offset", 0);
     Kokkos::View<int *, DeviceType> indices("indices", 0);
     auto const start = std::chrono::high_resolution_clock::now();
-    index.query(queries, indices, offset,
+    index.query(ExecutionSpace{}, queries, indices, offset,
                 ArborX::Experimental::TraversalPolicy().setPredicateSorting(
                     spec.sort_predicates));
     auto const end = std::chrono::high_resolution_clock::now();
@@ -243,12 +247,14 @@ struct NearestCallback
   }
 };
 
-template <class TreeType>
+template <typename ExecutionSpace, class TreeType>
 void BM_knn_callback_search(benchmark::State &state, Spec const &spec)
 {
-  using DeviceType = typename TreeType::device_type;
+  using DeviceType =
+      Kokkos::Device<ExecutionSpace, typename TreeType::memory_space>;
 
   TreeType index(
+      ExecutionSpace{},
       constructPoints<DeviceType>(spec.n_values, spec.source_point_cloud_type));
   auto const queries_no_index = makeNearestQueries<DeviceType>(
       spec.n_values, spec.n_queries, spec.n_neighbors,
@@ -262,7 +268,7 @@ void BM_knn_callback_search(benchmark::State &state, Spec const &spec)
     NearestCallback<DeviceType> callback{num_neigh};
 
     auto const start = std::chrono::high_resolution_clock::now();
-    index.query(queries, callback,
+    index.query(ExecutionSpace{}, queries, callback,
                 ArborX::Experimental::TraversalPolicy().setPredicateSorting(
                     spec.sort_predicates));
     auto const end = std::chrono::high_resolution_clock::now();
@@ -271,12 +277,14 @@ void BM_knn_callback_search(benchmark::State &state, Spec const &spec)
   }
 }
 
-template <class TreeType>
+template <typename ExecutionSpace, class TreeType>
 void BM_radius_search(benchmark::State &state, Spec const &spec)
 {
-  using DeviceType = typename TreeType::device_type;
+  using DeviceType =
+      Kokkos::Device<ExecutionSpace, typename TreeType::memory_space>;
 
   TreeType index(
+      ExecutionSpace{},
       constructPoints<DeviceType>(spec.n_values, spec.source_point_cloud_type));
   auto const queries = makeSpatialQueries<DeviceType>(
       spec.n_values, spec.n_queries, spec.n_neighbors,
@@ -287,7 +295,7 @@ void BM_radius_search(benchmark::State &state, Spec const &spec)
     Kokkos::View<int *, DeviceType> offset("offset", 0);
     Kokkos::View<int *, DeviceType> indices("indices", 0);
     auto const start = std::chrono::high_resolution_clock::now();
-    index.query(queries, indices, offset,
+    index.query(ExecutionSpace{}, queries, indices, offset,
                 ArborX::Experimental::TraversalPolicy()
                     .setPredicateSorting(spec.sort_predicates)
                     .setBufferSize(spec.buffer_size));
@@ -310,12 +318,14 @@ struct SpatialCallback
   }
 };
 
-template <class TreeType>
+template <typename ExecutionSpace, class TreeType>
 void BM_radius_callback_search(benchmark::State &state, Spec const &spec)
 {
-  using DeviceType = typename TreeType::device_type;
+  using DeviceType =
+      Kokkos::Device<ExecutionSpace, typename TreeType::memory_space>;
 
   TreeType index(
+      ExecutionSpace{},
       constructPoints<DeviceType>(spec.n_values, spec.source_point_cloud_type));
   auto const queries_no_index = makeSpatialQueries<DeviceType>(
       spec.n_values, spec.n_queries, spec.n_neighbors,
@@ -329,7 +339,7 @@ void BM_radius_callback_search(benchmark::State &state, Spec const &spec)
     SpatialCallback<DeviceType> callback{num_neigh};
 
     auto const start = std::chrono::high_resolution_clock::now();
-    index.query(queries, callback,
+    index.query(ExecutionSpace{}, queries, callback,
                 ArborX::Experimental::TraversalPolicy()
                     .setPredicateSorting(spec.sort_predicates)
                     .setBufferSize(spec.buffer_size));
@@ -346,17 +356,21 @@ public:
   ~KokkosScopeGuard() { Kokkos::finalize(); }
 };
 
-template <typename TreeType>
+template <typename ExecutionSpace, typename TreeType>
 void register_benchmark(std::string const &description, Spec const &spec)
 {
   benchmark::RegisterBenchmark(
       spec.create_label_construction(description).c_str(),
-      [=](benchmark::State &state) { BM_construction<TreeType>(state, spec); })
+      [=](benchmark::State &state) {
+        BM_construction<ExecutionSpace, TreeType>(state, spec);
+      })
       ->UseManualTime()
       ->Unit(benchmark::kMicrosecond);
   benchmark::RegisterBenchmark(
       spec.create_label_knn_search(description).c_str(),
-      [=](benchmark::State &state) { BM_knn_search<TreeType>(state, spec); })
+      [=](benchmark::State &state) {
+        BM_knn_search<ExecutionSpace, TreeType>(state, spec);
+      })
       ->UseManualTime()
       ->Unit(benchmark::kMicrosecond);
   if (description != "BoostRTree")
@@ -364,14 +378,16 @@ void register_benchmark(std::string const &description, Spec const &spec)
     benchmark::RegisterBenchmark(
         spec.create_label_knn_search(description, "callback").c_str(),
         [=](benchmark::State &state) {
-          BM_knn_callback_search<TreeType>(state, spec);
+          BM_knn_callback_search<ExecutionSpace, TreeType>(state, spec);
         })
         ->UseManualTime()
         ->Unit(benchmark::kMicrosecond);
   }
   benchmark::RegisterBenchmark(
       spec.create_label_radius_search(description).c_str(),
-      [=](benchmark::State &state) { BM_radius_search<TreeType>(state, spec); })
+      [=](benchmark::State &state) {
+        BM_radius_search<ExecutionSpace, TreeType>(state, spec);
+      })
       ->UseManualTime()
       ->Unit(benchmark::kMicrosecond);
   if (description != "BoostRTree")
@@ -379,7 +395,7 @@ void register_benchmark(std::string const &description, Spec const &spec)
     benchmark::RegisterBenchmark(
         spec.create_label_radius_search(description, "callback").c_str(),
         [=](benchmark::State &state) {
-          BM_radius_callback_search<TreeType>(state, spec);
+          BM_radius_callback_search<ExecutionSpace, TreeType>(state, spec);
         })
         ->UseManualTime()
         ->Unit(benchmark::kMicrosecond);
@@ -524,8 +540,12 @@ int main(int argc, char *argv[])
   {
 #ifdef KOKKOS_ENABLE_SERIAL
     if (spec.backends == "all" || spec.backends == "serial")
-      register_benchmark<ArborX::BVH<Kokkos::Serial::device_type>>(
+    {
+      using DeviceType = Kokkos::Serial::device_type;
+      register_benchmark<typename DeviceType::execution_space,
+                         ArborX::BVH<typename DeviceType::memory_space>>(
           "ArborX::BVH<Serial>", spec);
+    }
 #else
     if (spec.backends == "serial")
       throw std::runtime_error("Serial backend not available!");
@@ -533,8 +553,12 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_OPENMP
     if (spec.backends == "all" || spec.backends == "openmp")
-      register_benchmark<ArborX::BVH<Kokkos::OpenMP::device_type>>(
+    {
+      using DeviceType = Kokkos::OpenMP::device_type;
+      register_benchmark<typename DeviceType::execution_space,
+                         ArborX::BVH<typename DeviceType::memory_space>>(
           "ArborX::BVH<OpenMP>", spec);
+    }
 #else
     if (spec.backends == "openmp")
       throw std::runtime_error("OpenMP backend not available!");
@@ -542,8 +566,12 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_THREADS
     if (spec.backends == "all" || spec.backends == "threads")
-      register_benchmark<ArborX::BVH<Kokkos::Threads::device_type>>(
+    {
+      using DeviceType = Kokkos::Threads::device_type;
+      register_benchmark<typename DeviceType::execution_space,
+                         ArborX::BVH<typename DeviceType::memory_space>>(
           "ArborX::BVH<Threads>", spec);
+    }
 #else
     if (spec.backends == "threads")
       throw std::runtime_error("Threads backend not available!");
@@ -551,8 +579,12 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_CUDA
     if (spec.backends == "all" || spec.backends == "cuda")
-      register_benchmark<ArborX::BVH<Kokkos::Cuda::device_type>>(
+    {
+      using DeviceType = Kokkos::Cuda::device_type;
+      register_benchmark<typename DeviceType::execution_space,
+                         ArborX::BVH<typename DeviceType::memory_space>>(
           "ArborX::BVH<Cuda>", spec);
+    }
 #else
     if (spec.backends == "cuda")
       throw std::runtime_error("CUDA backend not available!");
@@ -560,8 +592,12 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_HIP
     if (spec.backends == "all" || spec.backends == "hip")
-      register_benchmark<ArborX::BVH<Kokkos::Experimental::HIP::device_type>>(
+    {
+      using DeviceType = Kokkos::Experimental::HIP::device_type;
+      register_benchmark<typename DeviceType::execution_space,
+                         ArborX::BVH<typename DeviceType::memory_space>>(
           "ArborX::BVH<HIP>", spec);
+    }
 #else
     if (spec.backends == "hip")
       throw std::runtime_error("HIP backend not available!");
@@ -569,9 +605,12 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     if (spec.backends == "all" || spec.backends == "openmptarget")
-      register_benchmark<
-          ArborX::BVH<Kokkos::Experimental::OpenMPTarget::device_type>>(
+    {
+      using DeviceType = Kokkos::Experimental::OpenMPTarget::device_type;
+      register_benchmark<typename DeviceType::execution_space,
+                         ArborX::BVH<typename DeviceType::memory_space>>(
           "ArborX::BVH<OpenMPTarget>", spec);
+    }
 #else
     if (spec.backends == "openmptarget")
       throw std::runtime_error("OpenMPTarget backend not available!");
@@ -579,16 +618,20 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_
     if (spec.backends == "all" || spec.backends == "sycl")
-      register_benchmark<ArborX::BVH<Kokkos::Experimental::SYCL::device_type>>(
+    {
+      using DeviceType = Kokkos::Experimental::SYCL::device_type;
+      register_benchmark<typename DeviceType::execution_space,
+                         ArborX::BVH<typename DeviceType::memory_space>>(
           "ArborX::BVH<SYCL>", spec);
+    }
 #else
     if (spec.backends == "sycl")
       throw std::runtime_error("SYCL backend not available!");
 #endif
 
 #ifdef KOKKOS_ENABLE_SERIAL
-    if (spec.backends == "all" || spec.backends == "rtree")
-      register_benchmark<BoostExt::RTree<ArborX::Point>>("BoostRTree", spec);
+    // if (spec.backends == "all" || spec.backends == "rtree")
+    // register_benchmark<BoostExt::RTree<ArborX::Point>>("BoostRTree", spec);
 #endif
   }
 

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -630,8 +630,9 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef KOKKOS_ENABLE_SERIAL
-    // if (spec.backends == "all" || spec.backends == "rtree")
-    // register_benchmark<BoostExt::RTree<ArborX::Point>>("BoostRTree", spec);
+    if (spec.backends == "all" || spec.backends == "rtree")
+      register_benchmark<typename Kokkos::Serial::execution_space,
+                         BoostExt::RTree<ArborX::Point>>("BoostRTree", spec);
 #endif
   }
 

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -225,6 +225,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
 
   using DeviceType = typename NO::device_type;
   using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
 
   int n_values;
   int n_queries;
@@ -413,7 +414,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   auto construction = time_monitor.getNewTimer("construction");
   MPI_Barrier(comm);
   construction->start();
-  ArborX::DistributedTree<DeviceType> distributed_tree(comm, bounding_boxes);
+  ArborX::DistributedTree<MemorySpace> distributed_tree(comm, ExecutionSpace{},
+                                                        bounding_boxes);
   construction->stop();
 
   std::ostream &os = std::cout;
@@ -431,6 +433,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     MPI_Barrier(comm);
     knn->start();
     distributed_tree.query(
+        ExecutionSpace{},
         NearestNeighborsSearches<DeviceType>{random_queries, n_neighbors},
         values, offsets);
     knn->stop();
@@ -474,7 +477,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     auto radius = time_monitor.getNewTimer("radius");
     MPI_Barrier(comm);
     radius->start();
-    distributed_tree.query(RadiusSearches<DeviceType>{random_queries, r},
+    distributed_tree.query(ExecutionSpace{},
+                           RadiusSearches<DeviceType>{random_queries, r},
                            values, offsets);
     radius->stop();
 

--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -192,12 +192,17 @@ class DistributedTree<DeviceType,
 {
 public:
   using device_type = DeviceType;
+
+  // clang-format off
   template <typename Primitives>
+  [[deprecated("ArborX::DistributedTree templated on a device type is "
+               "deprecated, use it templated on a memory space instead.")]]
   DistributedTree(MPI_Comm comm, Primitives const &primitives)
       : DistributedTree<typename DeviceType::memory_space>(
             comm, typename DeviceType::execution_space{}, primitives)
   {
   }
+  // clang-format on
   template <typename... Args>
   void query(Args &&... args) const
   {
@@ -212,7 +217,7 @@ template <typename MemorySpace, typename Enable = void>
 using DistributedSearchTree [[deprecated("Use DistributedTree instead.")]] =
     DistributedTree<MemorySpace, Enable>;
 
-// clang-format-on   
+// clang-format-on
 
 } // namespace ArborX
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -143,13 +143,20 @@ class BoundingVolumeHierarchy<
 {
 public:
   using device_type = DeviceType;
+
+  // clang-format off
+  [[deprecated("ArborX::BoundingVolumeHierarchy templated on a device type "
+               "is deprecated, use it templated on a memory space instead.")]]
   BoundingVolumeHierarchy() = default;
   template <typename Primitives>
+  [[deprecated("ArborX::BoundingVolumeHierarchy templated on a device type "
+               "is deprecated, use it templated on a memory space instead.")]]
   BoundingVolumeHierarchy(Primitives const &primitives)
       : BoundingVolumeHierarchy<typename DeviceType::memory_space>(
             typename DeviceType::execution_space{}, primitives)
   {
   }
+  // clang-format on
   template <typename... Args>
   void query(Args &&... args) const
   {

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -179,6 +179,7 @@ static std::tuple<OutputView, OutputView>
 performQueries(RTree<Indexable> const &rtree, InputView const &queries)
 {
   static_assert(KokkosExt::is_accessible_from_host<InputView>::value, "");
+
   using Value = typename RTree<Indexable>::value_type;
   auto const n_queries = queries.extent_int(0);
   OutputView offset("offset", n_queries + 1);
@@ -238,42 +239,35 @@ class RTree
 {
 public:
   using DeviceType = Kokkos::DefaultHostExecutionSpace::device_type;
-  using device_type = DeviceType;
   using memory_space = typename DeviceType::memory_space;
-
-  RTree(Kokkos::View<Indexable *, DeviceType> const &values)
-  {
-    _tree = BoostRTreeHelpers::makeRTree(values);
-  }
 
   template <typename ExecutionSpace>
   RTree(ExecutionSpace, Kokkos::View<Indexable *, DeviceType> const &values)
-      : RTree(values)
   {
+    static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+
+    _tree = BoostRTreeHelpers::makeRTree(values);
   }
 
   // WARNING trailing pack will match anything :/
-  template <typename Predicates, typename InputView, typename... TrailingArgs>
-  std::enable_if_t<!Kokkos::is_execution_space<Predicates>::value>
-  query(Predicates const &predicates, InputView &indices, InputView &offset,
-        TrailingArgs &&...) const
+  template <typename ExecutionSpace, typename Predicates, typename InputView,
+            typename... TrailingArgs>
+  void query(ExecutionSpace const &, Predicates const &predicates,
+             InputView &indices, InputView &offset, TrailingArgs &&...) const
   {
+    static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+
     std::tie(offset, indices) =
         BoostRTreeHelpers::performQueries(_tree, predicates);
   }
 
-  template <typename ExecutionSpace, typename Predicates, typename InputView,
+  template <typename ExecutionSpace, typename Predicates, typename Callback,
             typename... TrailingArgs>
-  std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>
-  query(ExecutionSpace, Predicates const &predicates, InputView &indices,
-        InputView &offset, TrailingArgs &&...) const
+  void query(ExecutionSpace const &, Predicates const &, Callback const &,
+             TrailingArgs &&...) const
   {
-    query(predicates, indices, offset);
-  }
+    static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
 
-  template <typename Predicates, typename Callback, typename... TrailingArgs>
-  void query(Predicates const &, Callback const &, TrailingArgs &&...) const
-  {
     throw std::runtime_error(
         "Boost RTree does not support callback only query overload.");
   }
@@ -288,20 +282,25 @@ class ParallelRTree
 {
 public:
   using DeviceType = Kokkos::DefaultHostExecutionSpace::device_type;
-  using device_type = DeviceType;
+  using memory_space = typename DeviceType::memory_space;
 
-  ParallelRTree(MPI_Comm comm,
+  template <typename ExecutionSpace>
+  ParallelRTree(MPI_Comm comm, ExecutionSpace const &,
                 Kokkos::View<Indexable *, DeviceType> const &values)
   {
+    static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+
     _tree = BoostRTreeHelpers::makeRTree(comm, values);
   }
 
   // WARNING trailing pack will match anything :/
-  template <typename Predicates, typename InputView1, typename InputView2,
-            typename... TrailingArgs>
-  void query(Predicates const &predicates, InputView1 &indices,
-             InputView2 &offset, TrailingArgs &&...) const
+  template <typename ExecutionSpace, typename Predicates, typename InputView1,
+            typename InputView2, typename... TrailingArgs>
+  void query(ExecutionSpace const &, Predicates const &predicates,
+             InputView1 &indices, InputView2 &offset, TrailingArgs &&...) const
   {
+    static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+
     std::tie(offset, indices) =
         BoostRTreeHelpers::performQueries(_tree, predicates);
   }

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -107,22 +107,6 @@ auto query(ExecutionSpace const &exec_space, Tree const &tree,
   BOOST_TEST(query(exec_space, tree, queries) == (reference),                  \
              boost::test_tools::per_element());
 
-template <typename Tree, typename Queries>
-auto query_with_distance(Tree const &tree, Queries const &queries,
-                         std::enable_if_t<!is_distributed<Tree>{}> * = nullptr)
-{
-  using device_type = typename Tree::device_type;
-  Kokkos::View<Kokkos::pair<int, float> *, device_type> values(
-      "Testing::values", 0);
-  Kokkos::View<int *, device_type> offsets("Testing::offsets", 0);
-  tree.query(queries,
-             ArborX::Details::CallbackDefaultNearestPredicateWithDistance{},
-             values, offsets);
-  return make_compressed_storage(
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, values));
-}
-
 template <typename ExecutionSpace, typename Tree, typename Queries>
 auto query_with_distance(ExecutionSpace const &exec_space, Tree const &tree,
                          Queries const &queries,

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -191,20 +191,18 @@ auto query_with_distance(ExecutionSpace const &exec_space, Tree const &tree,
   BOOST_TEST(query_with_distance(exec_space, tree, queries) == (reference),    \
              boost::test_tools::per_element());
 
-template <typename DeviceType>
-ArborX::BVH<typename DeviceType::memory_space>
-makeTree(std::vector<ArborX::Box> const &b)
+template <typename ExecutionSpace, typename Tree>
+auto makeTree(ExecutionSpace const &exec_space,
+              std::vector<ArborX::Box> const &b)
 {
-  using ExecutionSpace = typename DeviceType::execution_space;
-
   int const n = b.size();
-  Kokkos::View<ArborX::Box *, DeviceType> boxes("Testing::boxes", n);
+  Kokkos::View<ArborX::Box *, typename Tree::memory_space> boxes(
+      "Testing::boxes", n);
   auto boxes_host = Kokkos::create_mirror_view(boxes);
   for (int i = 0; i < n; ++i)
     boxes_host(i) = b[i];
   Kokkos::deep_copy(boxes, boxes_host);
-  return ArborX::BVH<typename DeviceType::memory_space>(ExecutionSpace{},
-                                                        boxes);
+  return Tree(exec_space, boxes);
 }
 
 #ifdef ARBORX_ENABLE_MPI

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -175,9 +175,8 @@ auto query_with_distance(ExecutionSpace const &exec_space, Tree const &tree,
   BOOST_TEST(query_with_distance(exec_space, tree, queries) == (reference),    \
              boost::test_tools::per_element());
 
-template <typename ExecutionSpace, typename Tree>
-auto makeTree(ExecutionSpace const &exec_space,
-              std::vector<ArborX::Box> const &b)
+template <typename Tree, typename ExecutionSpace>
+auto make(ExecutionSpace const &exec_space, std::vector<ArborX::Box> const &b)
 {
   int const n = b.size();
   Kokkos::View<ArborX::Box *, typename Tree::memory_space> boxes(

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -102,8 +102,23 @@ auto query(Tree const &tree, Queries const &queries)
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, values));
 }
 
-#define ARBORX_TEST_QUERY_TREE(tree, queries, reference)                       \
-  BOOST_TEST(query(tree, queries) == (reference),                              \
+template <typename ExecutionSpace, typename Tree, typename Queries>
+auto query(ExecutionSpace const &exec_space, Tree const &tree,
+           Queries const &queries)
+{
+  using memory_space = typename Tree::memory_space;
+  using value_type =
+      std::conditional_t<is_distributed<Tree>{}, Kokkos::pair<int, int>, int>;
+  Kokkos::View<value_type *, memory_space> values("Testing::values", 0);
+  Kokkos::View<int *, memory_space> offsets("Testing::offsets", 0);
+  tree.query(exec_space, queries, values, offsets);
+  return make_compressed_storage(
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, values));
+}
+
+#define ARBORX_TEST_QUERY_TREE(exec_space, tree, queries, reference)           \
+  BOOST_TEST(query(exec_space, tree, queries) == (reference),                  \
              boost::test_tools::per_element());
 
 template <typename Tree, typename Queries>
@@ -115,6 +130,23 @@ auto query_with_distance(Tree const &tree, Queries const &queries,
       "Testing::values", 0);
   Kokkos::View<int *, device_type> offsets("Testing::offsets", 0);
   tree.query(queries,
+             ArborX::Details::CallbackDefaultNearestPredicateWithDistance{},
+             values, offsets);
+  return make_compressed_storage(
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, values));
+}
+
+template <typename ExecutionSpace, typename Tree, typename Queries>
+auto query_with_distance(ExecutionSpace const &exec_space, Tree const &tree,
+                         Queries const &queries,
+                         std::enable_if_t<!is_distributed<Tree>{}> * = nullptr)
+{
+  using memory_space = typename Tree::memory_space;
+  Kokkos::View<Kokkos::pair<int, float> *, memory_space> values(
+      "Testing::values", 0);
+  Kokkos::View<int *, memory_space> offsets("Testing::offsets", 0);
+  tree.query(exec_space, queries,
              ArborX::Details::CallbackDefaultNearestPredicateWithDistance{},
              values, offsets);
   return make_compressed_storage(
@@ -144,22 +176,23 @@ zip(ExecutionSpace const &space, Kokkos::View<int *, DeviceType> indices,
 }
 
 #ifdef ARBORX_ENABLE_MPI
-template <typename Tree, typename Queries>
-auto query_with_distance(Tree const &tree, Queries const &queries,
+template <typename ExecutionSpace, typename Tree, typename Queries>
+auto query_with_distance(ExecutionSpace const &exec_space, Tree const &tree,
+                         Queries const &queries,
                          std::enable_if_t<is_distributed<Tree>{}> * = nullptr)
 {
-  using device_type = typename Tree::device_type;
-  Kokkos::View<int *, device_type> offsets("Testing::offsets", 0);
-  Kokkos::View<int *, device_type> indices("Testing::indices", 0);
-  Kokkos::View<int *, device_type> ranks("Testing::ranks", 0);
-  Kokkos::View<float *, device_type> distances("Testing::distances", 0);
-  using ExecutionSpace = typename device_type::execution_space;
-  ExecutionSpace space;
-  ArborX::Details::DistributedTreeImpl<device_type>::queryDispatchImpl(
-      ArborX::Details::NearestPredicateTag{}, tree, space, queries, indices,
-      offsets, ranks, &distances);
+  using MemorySpace = typename Tree::memory_space;
+  using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
-  auto values = zip(space, indices, ranks, distances);
+  Kokkos::View<int *, MemorySpace> offsets("Testing::offsets", 0);
+  Kokkos::View<int *, MemorySpace> indices("Testing::indices", 0);
+  Kokkos::View<int *, MemorySpace> ranks("Testing::ranks", 0);
+  Kokkos::View<float *, MemorySpace> distances("Testing::distances", 0);
+  ArborX::Details::DistributedTreeImpl<DeviceType>::queryDispatchImpl(
+      ArborX::Details::NearestPredicateTag{}, tree, exec_space, queries,
+      indices, offsets, ranks, &distances);
+
+  auto values = zip(exec_space, indices, ranks, distances);
 
   return make_compressed_storage(
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
@@ -167,35 +200,43 @@ auto query_with_distance(Tree const &tree, Queries const &queries,
 }
 #endif
 
-#define ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(tree, queries, reference)         \
-  BOOST_TEST(query_with_distance(tree, queries) == (reference),                \
+#define ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(exec_space, tree, queries,        \
+                                             reference)                        \
+  BOOST_TEST(query_with_distance(exec_space, tree, queries) == (reference),    \
              boost::test_tools::per_element());
 
-template <typename Tree>
-auto make(std::vector<ArborX::Box> const &b)
-{
-  int const n = b.size();
-  Kokkos::View<ArborX::Box *, typename Tree::device_type> boxes(
-      "Testing::boxes", n);
-  auto boxes_host = Kokkos::create_mirror_view(boxes);
-  for (int i = 0; i < n; ++i)
-    boxes_host(i) = b[i];
-  Kokkos::deep_copy(boxes, boxes_host);
-  return Tree(boxes);
-}
-
-#ifdef ARBORX_ENABLE_MPI
 template <typename DeviceType>
-ArborX::DistributedTree<DeviceType>
-makeDistributedTree(MPI_Comm comm, std::vector<ArborX::Box> const &b)
+ArborX::BVH<typename DeviceType::memory_space>
+makeTree(std::vector<ArborX::Box> const &b)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   int const n = b.size();
   Kokkos::View<ArborX::Box *, DeviceType> boxes("Testing::boxes", n);
   auto boxes_host = Kokkos::create_mirror_view(boxes);
   for (int i = 0; i < n; ++i)
     boxes_host(i) = b[i];
   Kokkos::deep_copy(boxes, boxes_host);
-  return ArborX::DistributedTree<DeviceType>(comm, boxes);
+  return ArborX::BVH<typename DeviceType::memory_space>(ExecutionSpace{},
+                                                        boxes);
+}
+
+#ifdef ARBORX_ENABLE_MPI
+template <typename DeviceType>
+ArborX::DistributedTree<typename DeviceType::memory_space>
+makeDistributedTree(MPI_Comm comm, std::vector<ArborX::Box> const &b)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+
+  int const n = b.size();
+  Kokkos::View<ArborX::Box *, DeviceType> boxes("Testing::boxes", n);
+  auto boxes_host = Kokkos::create_mirror_view(boxes);
+  for (int i = 0; i < n; ++i)
+    boxes_host(i) = b[i];
+  Kokkos::deep_copy(boxes, boxes_host);
+
+  return ArborX::DistributedTree<typename DeviceType::memory_space>(
+      comm, ExecutionSpace{}, boxes);
 }
 #endif
 

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -88,20 +88,6 @@ auto make_reference_solution(std::vector<T> const &values,
   return make_compressed_storage(offsets, values);
 }
 
-template <typename Tree, typename Queries>
-auto query(Tree const &tree, Queries const &queries)
-{
-  using device_type = typename Tree::device_type;
-  using value_type =
-      std::conditional_t<is_distributed<Tree>{}, Kokkos::pair<int, int>, int>;
-  Kokkos::View<value_type *, device_type> values("Testing::values", 0);
-  Kokkos::View<int *, device_type> offsets("Testing::offsets", 0);
-  tree.query(queries, values, offsets);
-  return make_compressed_storage(
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, values));
-}
-
 template <typename ExecutionSpace, typename Tree, typename Queries>
 auto query(ExecutionSpace const &exec_space, Tree const &tree,
            Queries const &queries)

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -32,6 +32,9 @@ using TupleIndexRankDistance = Kokkos::pair<Kokkos::pair<int, int>, float>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using Tree = ArborX::DistributedTree<typename DeviceType::memory_space>;
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   MPI_Comm comm = MPI_COMM_WORLD;
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -47,13 +50,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   //                 0   1   2   3   ^   ^   ^   ^
   //                                 0   1   2   3   ^   ^   ^   ^
   //                                                 0   1   2   3
-  using ExecutionSpace = typename DeviceType::execution_space;
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        KOKKOS_LAMBDA(int i) {
                          points(i) = {{(double)i / n + comm_rank, 0., 0.}};
                        });
 
-  ArborX::DistributedTree<DeviceType> tree(comm, points);
+  Tree tree(comm, ExecutionSpace{}, points);
 
   // 0---0---0---0---1---1---1---1---2---2---2---2---3---3---3---3---
   // |               |               |               |               |
@@ -98,19 +100,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   if (comm_rank > 0)
   {
     values.emplace_back(0, comm_size - comm_rank);
-    ARBORX_TEST_QUERY_TREE(tree, queries,
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, queries,
                            make_reference_solution(values, {0, n + 1}));
   }
   else
   {
-    ARBORX_TEST_QUERY_TREE(tree, queries,
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, queries,
                            make_reference_solution(values, {0, n}));
   }
 
   BOOST_TEST(n > 2);
   if (comm_rank < comm_size - 1)
   {
-    ARBORX_TEST_QUERY_TREE(tree, nearest_queries,
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, nearest_queries,
                            make_reference_solution<PairIndexRank>(
                                {{0, comm_size - 1 - comm_rank},
                                 {n - 1, comm_size - 2 - comm_rank},
@@ -120,7 +122,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   else
   {
     ARBORX_TEST_QUERY_TREE(
-        tree, nearest_queries,
+        ExecutionSpace{}, tree, nearest_queries,
         make_reference_solution<PairIndexRank>(
             {{0, comm_size - 1 - comm_rank}, {1, comm_size - 1 - comm_rank}},
             {0, 2}));
@@ -129,6 +131,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   MPI_Comm comm = MPI_COMM_WORLD;
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -142,42 +146,47 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
 
   BOOST_TEST(ArborX::Details::equals(tree.bounds(), {}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeIntersectsBoxQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeIntersectsBoxQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeIntersectsSphereQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeIntersectsSphereQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeNearestQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeNearestQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
   ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(
-      tree, makeNearestQueries<DeviceType>({}),
+      ExecutionSpace{}, tree, makeNearestQueries<DeviceType>({}),
       make_reference_solution<TupleIndexRankDistance>({}, {0}));
 
   // Only rank 0 has a couple spatial queries with a spatial predicate
   if (comm_rank == 0)
   {
     ARBORX_TEST_QUERY_TREE(
-        tree, makeIntersectsBoxQueries<DeviceType>({{}, {}}),
+        ExecutionSpace{}, tree, makeIntersectsBoxQueries<DeviceType>({{}, {}}),
         make_reference_solution<PairIndexRank>({}, {0, 0, 0}));
   }
   else
   {
-    ARBORX_TEST_QUERY_TREE(tree, makeIntersectsBoxQueries<DeviceType>({}),
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                           makeIntersectsBoxQueries<DeviceType>({}),
                            make_reference_solution<PairIndexRank>({}, {0}));
   }
 
   // All ranks but rank 0 have a single query with a spatial predicate
   if (comm_rank == 0)
   {
-    ARBORX_TEST_QUERY_TREE(tree, makeIntersectsSphereQueries<DeviceType>({}),
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                           makeIntersectsSphereQueries<DeviceType>({}),
                            make_reference_solution<PairIndexRank>({}, {0}));
   }
   else
   {
     ARBORX_TEST_QUERY_TREE(
-        tree,
+        ExecutionSpace{}, tree,
         makeIntersectsSphereQueries<DeviceType>({
             {{{(double)comm_rank, 0., 0.}}, (double)comm_size},
         }),
@@ -187,12 +196,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
   // All ranks but rank 0 have a single query with a nearest predicate
   if (comm_rank == 0)
   {
-    ARBORX_TEST_QUERY_TREE(tree, makeNearestQueries<DeviceType>({}),
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                           makeNearestQueries<DeviceType>({}),
                            make_reference_solution<PairIndexRank>({}, {0}));
   }
   else
   {
-    ARBORX_TEST_QUERY_TREE(tree,
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                            makeNearestQueries<DeviceType>({
                                {{{0., 0., 0.}}, comm_rank},
                            }),
@@ -202,7 +212,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
   // All ranks have a single query with a nearest predicate (this version
   // returns distances as well)
   ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(
-      tree,
+      ExecutionSpace{}, tree,
       makeNearestQueries<DeviceType>({
           {{{0., 0., 0.}}, comm_size},
       }),
@@ -212,6 +222,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
 BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   MPI_Comm comm = MPI_COMM_WORLD;
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -233,22 +245,25 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
   BOOST_TEST(
       ArborX::Details::equals(tree.bounds(), {{{0., 0., 0.}}, {{1., 1., 1.}}}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeIntersectsBoxQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeIntersectsBoxQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeIntersectsSphereQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeIntersectsSphereQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeNearestQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeNearestQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
   ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(
-      tree, makeNearestQueries<DeviceType>({}),
+      ExecutionSpace{}, tree, makeNearestQueries<DeviceType>({}),
       make_reference_solution<TupleIndexRankDistance>({}, {0}));
 
   // Querying for more neighbors than there are leaves in the tree
   ARBORX_TEST_QUERY_TREE(
-      tree,
+      ExecutionSpace{}, tree,
       makeNearestQueries<DeviceType>({
           {{{(double)comm_rank, (double)comm_rank, (double)comm_rank}},
            comm_size},
@@ -259,6 +274,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
 BOOST_AUTO_TEST_CASE_TEMPLATE(one_leaf_per_rank, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   MPI_Comm comm = MPI_COMM_WORLD;
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -279,7 +296,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(one_leaf_per_rank, DeviceType,
       tree.bounds(), {{{0., 0., 0.}}, {{(double)comm_size, 1., 1.}}}));
 
   ARBORX_TEST_QUERY_TREE(
-      tree,
+      ExecutionSpace{}, tree,
       makeIntersectsBoxQueries<DeviceType>({
           {{{(double)comm_size - (double)comm_rank - .5, .5, .5}},
            {{(double)comm_size - (double)comm_rank - .5, .5, .5}}},
@@ -289,15 +306,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(one_leaf_per_rank, DeviceType,
       make_reference_solution<PairIndexRank>(
           {{0, comm_size - 1 - comm_rank}, {0, comm_rank}}, {0, 1, 2}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeNearestQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeNearestQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
-  ARBORX_TEST_QUERY_TREE(tree, makeIntersectsBoxQueries<DeviceType>({}),
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeIntersectsBoxQueries<DeviceType>({}),
                          make_reference_solution<PairIndexRank>({}, {0}));
 
   if (comm_rank > 0)
   {
-    ARBORX_TEST_QUERY_TREE(tree,
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                            makeNearestQueries<DeviceType>({
                                {{{0., 0., 0.}}, comm_rank * comm_size},
                            }),
@@ -313,7 +332,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(one_leaf_per_rank, DeviceType,
   }
   else
   {
-    ARBORX_TEST_QUERY_TREE(tree,
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                            makeNearestQueries<DeviceType>({
                                {{{0., 0., 0.}}, comm_rank * comm_size},
                            }),
@@ -324,6 +343,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(one_leaf_per_rank, DeviceType,
 BOOST_AUTO_TEST_CASE_TEMPLATE(do_not_exceed_capacity, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   // This unit tests exposes bug that essentially assumed the number of
   // neighbors queried for would not exceed the maximum size of the default
   // underlying container for a priority queue which was 256.
@@ -340,18 +361,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(do_not_exceed_capacity, DeviceType,
                        KOKKOS_LAMBDA(int i) {
                          points(i) = {{(float)i, (float)i, (float)i}};
                        });
-  ArborX::DistributedTree<DeviceType> tree{comm, points};
+
+  ArborX::DistributedTree<typename DeviceType::memory_space> tree{
+      comm, ExecutionSpace{}, points};
   Kokkos::View<decltype(nearest(Point{})) *, DeviceType> queries(
       "Testing::queries", 1);
   Kokkos::deep_copy(queries, nearest(Point{0, 0, 0}, 512));
   Kokkos::View<PairIndexRank *, DeviceType> values("Testing::values", 0);
   Kokkos::View<int *, DeviceType> offset("Testing::offset", 0);
-  BOOST_CHECK_NO_THROW(tree.query(queries, values, offset));
+  BOOST_CHECK_NO_THROW(tree.query(ExecutionSpace{}, queries, values, offset));
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_nearest_neighbors, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   MPI_Comm comm = MPI_COMM_WORLD;
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -389,7 +414,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_nearest_neighbors, DeviceType,
   if (comm_rank > 0)
   {
     ARBORX_TEST_QUERY_TREE(
-        tree,
+        ExecutionSpace{}, tree,
         makeNearestQueries<DeviceType>({
             {{{(double)(comm_size - 1 - comm_rank) + .75, 0., 0.}}, 1},
         }),
@@ -399,7 +424,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_nearest_neighbors, DeviceType,
   else
   {
     ARBORX_TEST_QUERY_TREE(
-        tree,
+        ExecutionSpace{}, tree,
         makeNearestQueries<DeviceType>({
             {{{(double)(comm_size - 1 - comm_rank) + .75, 0., 0.}}, 1},
         }),
@@ -456,6 +481,8 @@ struct CustomPostCallbackAttachmentSpatialPredicate
 BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   MPI_Comm comm = MPI_COMM_WORLD;
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -517,6 +544,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
     Kokkos::View<float *, DeviceType> custom("Testing::custom", 0);
     Kokkos::View<int *, DeviceType> offset("Testing::offset", 0);
     tree.query(
+        ExecutionSpace{},
         makeIntersectsBoxWithAttachmentQueries<DeviceType, int>(
             {{points_host(0), points_host(0)}}, {comm_rank}),
         CustomInlineCallbackAttachmentSpatialPredicate<DeviceType>{points},
@@ -535,7 +563,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
   {
     Kokkos::View<float *, DeviceType> custom("Testing::custom", 0);
     Kokkos::View<int *, DeviceType> offset("Testing::offset", 0);
-    tree.query(makeIntersectsBoxWithAttachmentQueries<DeviceType, int>(
+    tree.query(ExecutionSpace{},
+               makeIntersectsBoxWithAttachmentQueries<DeviceType, int>(
                    {{points_host(0), points_host(0)}}, {comm_rank}),
                CustomPostCallbackAttachmentSpatialPredicate<DeviceType>{points},
                custom, offset);
@@ -573,6 +602,8 @@ make_random_cloud(double const Lx, double const Ly, double const Lz,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   MPI_Comm comm = MPI_COMM_WORLD;
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
@@ -608,10 +639,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::deep_copy(bounding_boxes, bounding_boxes_host);
 
   // Initialize the distributed search tree
-  ArborX::DistributedTree<DeviceType> distributed_tree(comm, bounding_boxes);
+  ArborX::DistributedTree<typename DeviceType::memory_space> distributed_tree(
+      comm, ExecutionSpace{}, bounding_boxes);
 
   // make queries
-  using ExecutionSpace = typename DeviceType::execution_space;
   Kokkos::View<double * [3], ExecutionSpace> point_coords(
       "Testing::point_coords", local_n);
   auto point_coords_host = Kokkos::create_mirror_view(point_coords);
@@ -657,6 +688,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
 
   BoostExt::ParallelRTree<ArborX::Box> rtree(comm, bounding_boxes_host);
 
-  ARBORX_TEST_QUERY_TREE(distributed_tree, within_queries,
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, distributed_tree, within_queries,
                          query(rtree, within_queries_host));
 }

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -686,8 +686,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_comparison, DeviceType, ARBORX_DEVICE_TYPES)
   auto within_queries_host = Kokkos::create_mirror_view(within_queries);
   Kokkos::deep_copy(within_queries_host, within_queries);
 
-  BoostExt::ParallelRTree<ArborX::Box> rtree(comm, bounding_boxes_host);
+  BoostExt::ParallelRTree<ArborX::Box> rtree(comm, ExecutionSpace{},
+                                             bounding_boxes_host);
 
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, distributed_tree, within_queries,
-                         query(rtree, within_queries_host));
+                         query(ExecutionSpace{}, rtree, within_queries_host));
 }

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -40,6 +40,9 @@ BOOST_AUTO_TEST_CASE(is_prefixed_with)
 BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  using Tree = ArborX::BVH<typename DeviceType::memory_space>;
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, const char *label,
          void const * /*ptr*/, uint64_t /*size*/) {
@@ -55,24 +58,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
       });
 
   { // default constructed
-    ArborX::BVH<typename DeviceType::memory_space> tree;
+    Tree tree;
   }
 
   { // empty
-    auto tree = makeTree<DeviceType>({});
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{}, {});
   }
 
   { // one leaf
-    auto tree = makeTree<DeviceType>({
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-    });
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                               {
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               });
   }
 
   { // two leaves
-    auto tree = makeTree<DeviceType>({
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-    });
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                               {
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               });
   }
 
   Kokkos::Tools::Experimental::set_allocate_data_callback(nullptr);
@@ -83,10 +88,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_query_allocations_prefixed, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto tree = makeTree<DeviceType>({
-      {{{0, 0, 0}}, {{1, 1, 1}}},
-      {{{0, 0, 0}}, {{1, 1, 1}}},
-  });
+  auto tree =
+      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
+          ExecutionSpace{}, {
+                                {{{0, 0, 0}}, {{1, 1, 1}}},
+                                {{{0, 0, 0}}, {{1, 1, 1}}},
+                            });
 
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, const char *label,
@@ -121,6 +128,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_query_allocations_prefixed, DeviceType,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using Tree = ArborX::BVH<typename DeviceType::memory_space>;
   using ExecutionSpace = typename DeviceType::execution_space;
 
   auto const callback = [](char const *label, uint32_t, uint64_t *) {
@@ -135,32 +143,35 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   // BVH::BVH
 
   { // default constructed
-    ArborX::BVH<typename DeviceType::memory_space> tree;
+    Tree tree;
   }
 
   { // empty
-    auto tree = makeTree<DeviceType>({});
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{}, {});
   }
 
   { // one leaf
-    auto tree = makeTree<DeviceType>({
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-    });
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                               {
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               });
   }
 
   { // two leaves
-    auto tree = makeTree<DeviceType>({
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-    });
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                               {
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               });
   }
 
   // BVH::query
 
-  auto tree = makeTree<DeviceType>({
-      {{{0, 0, 0}}, {{1, 1, 1}}},
-      {{{0, 0, 0}}, {{1, 1, 1}}},
-  });
+  auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                             {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
 
   // spatial predicates
   query(ExecutionSpace{}, tree,
@@ -183,6 +194,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using Tree = ArborX::BVH<typename DeviceType::memory_space>;
   using ExecutionSpace = typename DeviceType::execution_space;
 
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
@@ -194,32 +206,35 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   // BVH::BVH
 
   { // default constructed
-    ArborX::BVH<typename DeviceType::memory_space> tree;
+    Tree tree;
   }
 
   { // empty
-    auto tree = makeTree<DeviceType>({});
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{}, {});
   }
 
   { // one leaf
-    auto tree = makeTree<DeviceType>({
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-    });
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                               {
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               });
   }
 
   { // two leaves
-    auto tree = makeTree<DeviceType>({
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-        {{{0, 0, 0}}, {{1, 1, 1}}},
-    });
+    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                               {
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               });
   }
 
   // BVH::query
 
-  auto tree = makeTree<DeviceType>({
-      {{{0, 0, 0}}, {{1, 1, 1}}},
-      {{{0, 0, 0}}, {{1, 1, 1}}},
-  });
+  auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
+                                             {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
 
   // spatial predicates
   query(ExecutionSpace{}, tree,

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -62,22 +62,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
   }
 
   { // empty
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{}, {});
+    auto tree = make<Tree>(ExecutionSpace{}, {});
   }
 
   { // one leaf
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                               {
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                               });
+    auto tree = make<Tree>(ExecutionSpace{}, {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
   }
 
   { // two leaves
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                               {
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                               });
+    auto tree = make<Tree>(ExecutionSpace{}, {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
   }
 
   Kokkos::Tools::Experimental::set_allocate_data_callback(nullptr);
@@ -88,12 +86,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_query_allocations_prefixed, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto tree =
-      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
-          ExecutionSpace{}, {
-                                {{{0, 0, 0}}, {{1, 1, 1}}},
-                                {{{0, 0, 0}}, {{1, 1, 1}}},
-                            });
+  auto tree = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, {
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                            {{{0, 0, 0}}, {{1, 1, 1}}},
+                        });
 
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, const char *label,
@@ -147,31 +144,28 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   }
 
   { // empty
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{}, {});
+    auto tree = make<Tree>(ExecutionSpace{}, {});
   }
 
   { // one leaf
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                               {
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                               });
+    auto tree = make<Tree>(ExecutionSpace{}, {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
   }
 
   { // two leaves
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                               {
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                               });
+    auto tree = make<Tree>(ExecutionSpace{}, {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
   }
 
   // BVH::query
 
-  auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                             {
-                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
-                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
-                                             });
+  auto tree = make<Tree>(ExecutionSpace{}, {
+                                               {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               {{{0, 0, 0}}, {{1, 1, 1}}},
+                                           });
 
   // spatial predicates
   query(ExecutionSpace{}, tree,
@@ -210,31 +204,28 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   }
 
   { // empty
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{}, {});
+    auto tree = make<Tree>(ExecutionSpace{}, {});
   }
 
   { // one leaf
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                               {
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                               });
+    auto tree = make<Tree>(ExecutionSpace{}, {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
   }
 
   { // two leaves
-    auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                               {
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
-                                               });
+    auto tree = make<Tree>(ExecutionSpace{}, {
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
+                                             });
   }
 
   // BVH::query
 
-  auto tree = makeTree<ExecutionSpace, Tree>(ExecutionSpace{},
-                                             {
-                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
-                                                 {{{0, 0, 0}}, {{1, 1, 1}}},
-                                             });
+  auto tree = make<Tree>(ExecutionSpace{}, {
+                                               {{{0, 0, 0}}, {{1, 1, 1}}},
+                                               {{{0, 0, 0}}, {{1, 1, 1}}},
+                                           });
 
   // spatial predicates
   query(ExecutionSpace{}, tree,

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -71,6 +71,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     distributed_search_tree_query_allocations_prefixed, DeviceType,
     ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   auto tree = makeDistributedTree<DeviceType>(MPI_COMM_WORLD,
                                               {
                                                   {{{0, 0, 0}}, {{1, 1, 1}}},
@@ -93,22 +95,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
       });
 
   // spatial predicates
-  query(tree, makeIntersectsBoxQueries<DeviceType>({
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-              }));
+  query(ExecutionSpace{}, tree,
+        makeIntersectsBoxQueries<DeviceType>({
+            {{{0, 0, 0}}, {{1, 1, 1}}},
+            {{{0, 0, 0}}, {{1, 1, 1}}},
+        }));
 
   // nearest predicates
-  query(tree, makeNearestQueries<DeviceType>({
-                  {{{0, 0, 0}}, 1},
-                  {{{0, 0, 0}}, 2},
-              }));
+  query(ExecutionSpace{}, tree,
+        makeNearestQueries<DeviceType>({
+            {{{0, 0, 0}}, 1},
+            {{{0, 0, 0}}, 2},
+        }));
 
   Kokkos::Tools::Experimental::set_allocate_data_callback(nullptr);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   auto const callback = [](char const *label, uint32_t, uint64_t *) {
     std::cout << label << '\n';
     BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
@@ -127,16 +133,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
                                               });
 
   // spatial predicates
-  query(tree, makeIntersectsBoxQueries<DeviceType>({
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-              }));
+  query(ExecutionSpace{}, tree,
+        makeIntersectsBoxQueries<DeviceType>({
+            {{{0, 0, 0}}, {{1, 1, 1}}},
+            {{{0, 0, 0}}, {{1, 1, 1}}},
+        }));
 
   // nearest predicates
-  query(tree, makeNearestQueries<DeviceType>({
-                  {{{0, 0, 0}}, 1},
-                  {{{0, 0, 0}}, 2},
-              }));
+  query(ExecutionSpace{}, tree,
+        makeNearestQueries<DeviceType>({
+            {{{0, 0, 0}}, 1},
+            {{{0, 0, 0}}, 2},
+        }));
 
   Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
   Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
@@ -145,6 +153,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  using ExecutionSpace = typename DeviceType::execution_space;
+
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
     std::cout << label << '\n';
     BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
@@ -166,16 +176,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
                                               });
 
   // spatial predicates
-  query(tree, makeIntersectsBoxQueries<DeviceType>({
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-                  {{{0, 0, 0}}, {{1, 1, 1}}},
-              }));
+  query(ExecutionSpace{}, tree,
+        makeIntersectsBoxQueries<DeviceType>({
+            {{{0, 0, 0}}, {{1, 1, 1}}},
+            {{{0, 0, 0}}, {{1, 1, 1}}},
+        }));
 
   // nearest predicates
-  query(tree, makeNearestQueries<DeviceType>({
-                  {{{0, 0, 0}}, 1},
-                  {{{0, 0, 0}}, 2},
-              }));
+  query(ExecutionSpace{}, tree,
+        makeNearestQueries<DeviceType>({
+            {{{0, 0, 0}}, 1},
+            {{{0, 0, 0}}, 2},
+        }));
 
   Kokkos::Tools::Experimental::set_push_region_callback(nullptr);
 }

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -1162,13 +1162,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, DeviceType, ARBORX_DEVICE_TYPES)
   ArborX::BVH<typename DeviceType::memory_space> bvh(ExecutionSpace{},
                                                      bounding_boxes);
 
-  BoostExt::RTree<ArborX::Box> rtree(bounding_boxes_host);
+  BoostExt::RTree<ArborX::Box> rtree(ExecutionSpace{}, bounding_boxes_host);
 
   // FIXME check currently sporadically fails when using the HIP backend
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, bvh, nearest_queries,
-                         query(rtree, nearest_queries_host));
+                         query(ExecutionSpace{}, rtree, nearest_queries_host));
 
   // FIXME ditto
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, bvh, within_queries,
-                         query(rtree, within_queries_host));
+                         query(ExecutionSpace{}, rtree, within_queries_host));
 }

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -33,8 +33,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
 
   // tree is empty, it has no leaves.
   for (auto const &tree : {
-           Tree{},                   // default constructed
-           makeTree<DeviceType>({}), // constructed with empty view of boxes
+           Tree{}, // default constructed
+           makeTree<ExecutionSpace, Tree>(
+               ExecutionSpace{}, {}), // constructed with empty view of boxes
        })
   {
     BOOST_TEST(tree.empty());
@@ -105,10 +106,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   // tree has a single leaf (unit box)
-  auto const tree = makeTree<DeviceType>({
-
-      {{{0., 0., 0.}}, {{1., 1., 1.}}},
-  });
+  auto const tree =
+      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
+          ExecutionSpace{}, {
+                                {{{0., 0., 0.}}, {{1., 1., 1.}}},
+                            });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST(tree.size() == 1);
@@ -178,10 +180,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto const tree = makeTree<DeviceType>({
-      {{{0., 0., 0.}}, {{0., 0., 0.}}},
-      {{{1., 1., 1.}}, {{1., 1., 1.}}},
-  });
+  auto const tree =
+      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
+          ExecutionSpace{}, {
+                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                            });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST(tree.size() == 2);
@@ -253,12 +257,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(duplicated_leaves, DeviceType,
   // when building trees over ~10M indexable values.  The hierarchy generated
   // at construction had leaves with no parent which yielded a segfault later
   // when computing bounding boxes and walking the hierarchy toward the root.
-  auto const bvh = makeTree<DeviceType>({
-      {{{0., 0., 0.}}, {{0., 0., 0.}}},
-      {{{1., 1., 1.}}, {{1., 1., 1.}}},
-      {{{1., 1., 1.}}, {{1., 1., 1.}}},
-      {{{1., 1., 1.}}, {{1., 1., 1.}}},
-  });
+  auto const bvh =
+      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
+          ExecutionSpace{}, {
+                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                            });
 
   ARBORX_TEST_QUERY_TREE(
       ExecutionSpace{}, bvh,
@@ -275,12 +281,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(buffer_optimization, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto const bvh = makeTree<DeviceType>({
-      {{{0., 0., 0.}}, {{0., 0., 0.}}},
-      {{{1., 0., 0.}}, {{1., 0., 0.}}},
-      {{{2., 0., 0.}}, {{2., 0., 0.}}},
-      {{{3., 0., 0.}}, {{3., 0., 0.}}},
-  });
+  auto const bvh =
+      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
+          ExecutionSpace{}, {
+                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                                {{{1., 0., 0.}}, {{1., 0., 0.}}},
+                                {{{2., 0., 0.}}, {{2., 0., 0.}}},
+                                {{{3., 0., 0.}}, {{3., 0., 0.}}},
+                            });
 
   auto const queries = makeIntersectsBoxQueries<DeviceType>({
       {},
@@ -356,12 +364,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unsorted_predicates, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto const bvh = makeTree<DeviceType>({
-      {{{0., 0., 0.}}, {{0., 0., 0.}}},
-      {{{1., 1., 1.}}, {{1., 1., 1.}}},
-      {{{2., 2., 2.}}, {{2., 2., 2.}}},
-      {{{3., 3., 3.}}, {{3., 3., 3.}}},
-  });
+  auto const bvh =
+      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
+          ExecutionSpace{}, {
+                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                                {{{2., 2., 2.}}, {{2., 2., 2.}}},
+                                {{{3., 3., 3.}}, {{3., 3., 3.}}},
+                            });
 
   using ViewType = Kokkos::View<int *, DeviceType>;
   ViewType indices("indices", 0);
@@ -430,7 +440,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity, DeviceType,
     double const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
-  auto const bvh = makeTree<DeviceType>(boxes);
+  auto const bvh =
+      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
+          ExecutionSpace{}, boxes);
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> offset("offset", 0);

--- a/test/tstLinearBVH.cpp
+++ b/test/tstLinearBVH.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
   // tree is empty, it has no leaves.
   for (auto const &tree : {
            Tree{}, // default constructed
-           makeTree<ExecutionSpace, Tree>(
-               ExecutionSpace{}, {}), // constructed with empty view of boxes
+           make<Tree>(ExecutionSpace{},
+                      {}), // constructed with empty view of boxes
        })
   {
     BOOST_TEST(tree.empty());
@@ -106,11 +106,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   // tree has a single leaf (unit box)
-  auto const tree =
-      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
-          ExecutionSpace{}, {
-                                {{{0., 0., 0.}}, {{1., 1., 1.}}},
-                            });
+  auto const tree = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, {
+                            {{{0., 0., 0.}}, {{1., 1., 1.}}},
+                        });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST(tree.size() == 1);
@@ -180,12 +179,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto const tree =
-      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
-          ExecutionSpace{}, {
-                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
-                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
-                            });
+  auto const tree = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, {
+                            {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                            {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                        });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST(tree.size() == 2);
@@ -257,14 +255,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(duplicated_leaves, DeviceType,
   // when building trees over ~10M indexable values.  The hierarchy generated
   // at construction had leaves with no parent which yielded a segfault later
   // when computing bounding boxes and walking the hierarchy toward the root.
-  auto const bvh =
-      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
-          ExecutionSpace{}, {
-                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
-                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
-                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
-                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
-                            });
+  auto const bvh = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, {
+                            {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                            {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                            {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                            {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                        });
 
   ARBORX_TEST_QUERY_TREE(
       ExecutionSpace{}, bvh,
@@ -281,14 +278,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(buffer_optimization, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto const bvh =
-      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
-          ExecutionSpace{}, {
-                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
-                                {{{1., 0., 0.}}, {{1., 0., 0.}}},
-                                {{{2., 0., 0.}}, {{2., 0., 0.}}},
-                                {{{3., 0., 0.}}, {{3., 0., 0.}}},
-                            });
+  auto const bvh = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, {
+                            {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                            {{{1., 0., 0.}}, {{1., 0., 0.}}},
+                            {{{2., 0., 0.}}, {{2., 0., 0.}}},
+                            {{{3., 0., 0.}}, {{3., 0., 0.}}},
+                        });
 
   auto const queries = makeIntersectsBoxQueries<DeviceType>({
       {},
@@ -364,14 +360,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unsorted_predicates, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
 
-  auto const bvh =
-      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
-          ExecutionSpace{}, {
-                                {{{0., 0., 0.}}, {{0., 0., 0.}}},
-                                {{{1., 1., 1.}}, {{1., 1., 1.}}},
-                                {{{2., 2., 2.}}, {{2., 2., 2.}}},
-                                {{{3., 3., 3.}}, {{3., 3., 3.}}},
-                            });
+  auto const bvh = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, {
+                            {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                            {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                            {{{2., 2., 2.}}, {{2., 2., 2.}}},
+                            {{{3., 3., 3.}}, {{3., 3., 3.}}},
+                        });
 
   using ViewType = Kokkos::View<int *, DeviceType>;
   ViewType indices("indices", 0);
@@ -440,9 +435,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity, DeviceType,
     double const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
-  auto const bvh =
-      makeTree<ExecutionSpace, ArborX::BVH<typename DeviceType::memory_space>>(
-          ExecutionSpace{}, boxes);
+  auto const bvh = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, boxes);
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> offset("offset", 0);


### PR DESCRIPTION
The only thing that's left is to somehow deprecate both. My first attempt of deprecation was unsuccessful. But removing them works.