### PR TITLE
Add rocPrim dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_dependencies(ArborX record_hash)
 include(CMakeDependentOption)
 cmake_dependent_option(ARBORX_ENABLE_ROCTHRUST "Enable rocThrust support" ON "Kokkos_ENABLE_HIP" OFF)
 if(Kokkos_ENABLE_HIP AND ARBORX_ENABLE_ROCTHRUST)
+  find_package(rocprim REQUIRED CONFIG)     # On ROCm rocThrust requires rocPRIM
   find_package(rocthrust REQUIRED CONFIG)
   target_link_libraries(ArborX INTERFACE roc::rocthrust)
 endif()

--- a/cmake/ArborXConfig.cmake.in
+++ b/cmake/ArborXConfig.cmake.in
@@ -13,6 +13,7 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArborXSettings.cmake")
 if(Kokkos_ENABLE_HIP AND ARBORX_ENABLE_ROCTHRUST)
+  find_dependency(rocprim)
   find_dependency(rocthrust)
 endif()
 if(ARBORX_ENABLE_MPI)


### PR DESCRIPTION
According to rocThrust's [README](https://github.com/ROCmSoftwarePlatform/rocThrust/blob/master/README.md#using-rocthrust-in-a-project), one needs to also add `rocPrim` dependency.

I opened this PR just to test. So far, I'm not sure about what is the right way to fix it, or which versions of rocthrust are affected.

Some references: ROCmSoftwarePlatform/rocThrust#61, ROCmSoftwarePlatform/rocThrust#107
