### PR TITLE
Fix ambiguities arising from using initializer lists without specifying a type

### DIFF
--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -47,6 +47,12 @@ constexpr bool equals(Sphere const &l, Sphere const &r)
 }
 
 KOKKOS_INLINE_FUNCTION
+constexpr bool equals(Ray const &l, Ray const &r)
+{
+  return equals(l.origin(), r.origin()) && equals(l.direction(), r.direction());
+}
+
+KOKKOS_INLINE_FUNCTION
 bool isValid(Point const &p)
 {
   using KokkosExt::isFinite;

--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -14,6 +14,7 @@
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsKokkosExt.hpp> // min, max, isFinite
 #include <ArborX_Point.hpp>
+#include <ArborX_Ray.hpp>
 #include <ArborX_Sphere.hpp>
 
 #include <Kokkos_Macros.hpp>
@@ -207,6 +208,9 @@ Point returnCentroid(Box const &box)
 
 KOKKOS_INLINE_FUNCTION
 Point returnCentroid(Sphere const &sphere) { return sphere.centroid(); }
+
+KOKKOS_INLINE_FUNCTION
+Point returnCentroid(Ray const &ray) { return ray.origin(); }
 
 // transformation that maps the unit cube into a new axis-aligned box
 // NOTE safe to perform in-place

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -56,8 +56,8 @@ BOOST_AUTO_TEST_CASE(intersects)
   // uninitialized box does not even intersect with itself
   STATIC_ASSERT(!intersects(Box{}, Box{}));
   // box with zero extent does
-  STATIC_ASSERT(intersects({{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}},
-                           {{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}}));
+  STATIC_ASSERT(intersects(Box{{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}},
+                           Box{{{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}}));
 
   // point
   constexpr Point point{{1.0, 1.0, 1.0}};
@@ -97,12 +97,12 @@ BOOST_AUTO_TEST_CASE(equals)
 {
   using ArborX::Details::equals;
   // points
-  STATIC_ASSERT(equals({{0., 0., 0.}}, {{0., 0., 0.}}));
-  STATIC_ASSERT(!equals({{0., 0., 0.}}, {{1., 1., 1.}}));
+  STATIC_ASSERT(equals(Point{{0., 0., 0.}}, {{0., 0., 0.}}));
+  STATIC_ASSERT(!equals(Point{{0., 0., 0.}}, {{1., 1., 1.}}));
   // boxes
-  STATIC_ASSERT(equals({{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}},
+  STATIC_ASSERT(equals(Box{{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}},
                        {{{0.0, 0.0, 0.0}}, {{1.0, 1.0, 1.0}}}));
-  STATIC_ASSERT(!equals({{{0.0, 0.0, 0.0}}, {{1.0, 0.0, 1.0}}},
+  STATIC_ASSERT(!equals(Box{{{0.0, 0.0, 0.0}}, {{1.0, 0.0, 1.0}}},
                         {{{-1.0, -1.0, -1.0}}, {{1.0, 1.0, 1.0}}}));
   // spheres
   STATIC_ASSERT(equals({{{0., 0., 0.}}, 1.}, {{{0., 0., 0.}}, 1.}));


### PR DESCRIPTION
This is pr to make make ArborX::Ray working as a predicate for batched queries.
I ran into and then resolved an issue #435.

Fix #435