### PR TITLE
Use Kokkos built-in reducer in bounding scene calculation

### DIFF
--- a/src/details/ArborX_Box.hpp
+++ b/src/details/ArborX_Box.hpp
@@ -65,6 +65,53 @@ struct Box
   Point _max_corner = {{-KokkosExt::ArithmeticTraits::max<float>::value,
                         -KokkosExt::ArithmeticTraits::max<float>::value,
                         -KokkosExt::ArithmeticTraits::max<float>::value}};
+
+  KOKKOS_FUNCTION Box &operator+=(Box const &other)
+  {
+    using KokkosExt::max;
+    using KokkosExt::min;
+
+    for (int d = 0; d < 3; ++d)
+    {
+      minCorner()[d] = min(minCorner()[d], other.minCorner()[d]);
+      maxCorner()[d] = max(maxCorner()[d], other.maxCorner()[d]);
+    }
+    return *this;
+  }
+
+  KOKKOS_FUNCTION void operator+=(Box const volatile &other) volatile
+  {
+    using KokkosExt::max;
+    using KokkosExt::min;
+
+    for (int d = 0; d < 3; ++d)
+    {
+      minCorner()[d] = min(minCorner()[d], other.minCorner()[d]);
+      maxCorner()[d] = max(maxCorner()[d], other.maxCorner()[d]);
+    }
+  }
+
+  KOKKOS_FUNCTION Box &operator+=(Point const &point)
+  {
+    using KokkosExt::max;
+    using KokkosExt::min;
+
+    for (int d = 0; d < 3; ++d)
+    {
+      minCorner()[d] = min(minCorner()[d], point[d]);
+      maxCorner()[d] = max(maxCorner()[d], point[d]);
+    }
+    return *this;
+  }
+
+// FIXME Temporary workaround until we clarify requirements on the Kokkos side.
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+private:
+  friend KOKKOS_FUNCTION Box operator+(Box box, Box const &other)
+  {
+    return box += other;
+  }
+#endif
 };
 } // namespace ArborX
 

--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -108,16 +108,7 @@ float distance(Point const &point, Sphere const &sphere)
 
 // expand an axis-aligned bounding box to include a point
 KOKKOS_INLINE_FUNCTION
-void expand(Box &box, Point const &point)
-{
-  using KokkosExt::max;
-  using KokkosExt::min;
-  for (int d = 0; d < 3; ++d)
-  {
-    box.minCorner()[d] = min(box.minCorner()[d], point[d]);
-    box.maxCorner()[d] = max(box.maxCorner()[d], point[d]);
-  }
-}
+void expand(Box &box, Point const &point) { box += point; }
 
 // expand an axis-aligned bounding box to include another box
 // NOTE: Box type is templated here to be able to use expand(box, box) in a
@@ -128,13 +119,7 @@ template <typename BOX,
               typename std::remove_volatile<BOX>::type, Box>::value>::type>
 KOKKOS_INLINE_FUNCTION void expand(BOX &box, BOX const &other)
 {
-  using KokkosExt::max;
-  using KokkosExt::min;
-  for (int d = 0; d < 3; ++d)
-  {
-    box.minCorner()[d] = min(box.minCorner()[d], other.minCorner()[d]);
-    box.maxCorner()[d] = max(box.maxCorner()[d], other.maxCorner()[d]);
-  }
+  box += other;
 }
 
 // expand an axis-aligned bounding box to include a sphere


### PR DESCRIPTION
Prefer built-in reducer with user-defined scalar type to custom reducer because it is not currently supported with the Kokkos OpenMPTarget backend.

I was able to pass all examples, benchmarks, and tests with these changes (modulo minor change to tools annotation check because one allocation was not prefixed properly in Kokkos).  I did not enable MPI.

This is only a draft because I wanted to clarify requirements on the scalar type to work with build-in reducers.