### PR TITLE
Fix performance regression introduced in #366

### DIFF
--- a/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
+++ b/src/details/ArborX_DetailsBoundingVolumeHierarchyImpl.hpp
@@ -161,9 +161,6 @@ queryDispatch(Tag, BVH const &bvh, ExecutionSpace const &space,
 
   Kokkos::Profiling::pushRegion(profiling_prefix);
 
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-  auto const n_queries = Access::size(predicates);
-
   Kokkos::Profiling::pushRegion(profiling_prefix + "::init_and_alloc");
 
   allocateAndInititalizeStorage(Tag{}, space, predicates, offset, out,


### PR DESCRIPTION
See regression [here](https://github.com/arborx/ArborX/pull/366#issuecomment-749245689).

Comparing with 6224c97:

## Cuda

```
BM_construction<ArborX::BVH<Cuda>>/10000/0/manual_time_median                                       +0.0036         +0.0029          1405          1410          1420          1424
BM_construction<ArborX::BVH<Cuda>>/100000/0/manual_time_median                                      +0.0021         +0.0024          2149          2154          2540          2546
BM_construction<ArborX::BVH<Cuda>>/1000000/0/manual_time_median                                     +0.0215         +0.0015          6896          7044          7385          7397
BM_construction<ArborX::BVH<Cuda>>/10000/1/manual_time_median                                       +0.0030         +0.0027          1404          1408          1419          1423
BM_construction<ArborX::BVH<Cuda>>/100000/1/manual_time_median                                      +0.0024         +0.0021          2148          2154          2541          2546
BM_construction<ArborX::BVH<Cuda>>/1000000/1/manual_time_median                                     -0.0094         +0.0009          7144          7077          7388          7394
BM_knn_search<ArborX::BVH<Cuda>>/10000/10000/10/1/0/2/manual_time_median                            -0.0252         -0.0239          1573          1533          1665          1625
BM_knn_search<ArborX::BVH<Cuda>>/100000/100000/10/1/0/2/manual_time_median                          +0.0017         +0.0016          6463          6475          6931          6942
BM_knn_search<ArborX::BVH<Cuda>>/1000000/1000000/10/1/0/2/manual_time_median                        -0.0067         -0.0027         26891         26712         27654         27578
BM_knn_search<ArborX::BVH<Cuda>>/10000/10000/10/1/1/3/manual_time_median                            -0.0101         -0.0095          1621          1605          1712          1696
BM_knn_search<ArborX::BVH<Cuda>>/100000/100000/10/1/1/3/manual_time_median                          +0.0024         +0.0029          7233          7250          7692          7715
BM_knn_search<ArborX::BVH<Cuda>>/1000000/1000000/10/1/1/3/manual_time_median                        +0.0014         -0.0025         43712         43771         44554         44443
BM_knn_search<ArborX::BVH<Cuda>>/10000/10000/10/0/0/2/manual_time_median                            -0.0286         -0.0267          1201          1167          1293          1258
BM_knn_search<ArborX::BVH<Cuda>>/100000/100000/10/0/0/2/manual_time_median                          -0.0017         +0.0044          4703          4695          5121          5143
BM_knn_search<ArborX::BVH<Cuda>>/1000000/1000000/10/0/0/2/manual_time_median                        -0.0282         -0.0140         57813         56181         57891         57080
BM_knn_search<ArborX::BVH<Cuda>>/10000/10000/10/0/1/3/manual_time_median                            -0.0231         -0.0214          1256          1227          1346          1317
BM_knn_search<ArborX::BVH<Cuda>>/100000/100000/10/0/1/3/manual_time_median                          +0.0372         +0.0319          6778          7030          7237          7468
BM_knn_search<ArborX::BVH<Cuda>>/1000000/1000000/10/0/1/3/manual_time_median                        +0.0021         +0.0021         99864        100069        100758        100966
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/1/0/0/2/manual_time_median                       -0.0183         -0.0164           978           960          1069          1051
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/1/0/0/2/manual_time_median                     -0.0120         -0.0025          3207          3169          3653          3644
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/1/0/0/2/manual_time_median                   -0.0024         -0.0021         16926         16885         17817         17780
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/1/0/1/3/manual_time_median                       -0.0152         -0.0136           909           895          1001           987
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/1/0/1/3/manual_time_median                     -0.0049         -0.0037          2468          2456          2931          2920
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/1/0/1/3/manual_time_median                   -0.0043         -0.0031          7755          7722          8581          8554
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/1/10/0/2/manual_time_median                      -0.0026         -0.0021          1096          1093          1188          1185
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/1/10/0/2/manual_time_median                    +0.0024         +0.0014          4210          4220          4684          4690
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/1/10/0/2/manual_time_median                  -0.0048         -0.0010         24483         24366         25272         25247
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/1/10/1/3/manual_time_median                      +0.0059         +0.0055          1019          1025          1111          1117
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/1/10/1/3/manual_time_median                    -0.0080         +0.0025          3728          3698          4150          4160
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/1/10/1/3/manual_time_median                  +0.0066         +0.0010          9888          9953         10729         10740
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/0/0/0/2/manual_time_median                       -0.0439         -0.0396           693           663           785           754
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/0/0/0/2/manual_time_median                     -0.0027         -0.0072          2065          2059          2538          2520
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/0/0/0/2/manual_time_median                   -0.0094         -0.0093         64732         64122         65634         65026
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/0/0/1/3/manual_time_median                       -0.0356         -0.0316           599           577           691           669
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/0/0/1/3/manual_time_median                     -0.0115         -0.0105          1322          1307          1788          1769
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/0/0/1/3/manual_time_median                   -0.0084         -0.0060          4972          4930          5812          5777
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/0/10/0/2/manual_time_median                      -0.0046         -0.0040           752           748           842           839
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/0/10/0/2/manual_time_median                    +0.0015         +0.0013          3145          3149          3618          3623
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/0/10/0/2/manual_time_median                  -0.0121         -0.0122         73682         72794         74493         73581
BM_radius_search<ArborX::BVH<Cuda>>/10000/10000/10/0/10/1/3/manual_time_median                      -0.0075         -0.0068           716           711           808           803
BM_radius_search<ArborX::BVH<Cuda>>/100000/100000/10/0/10/1/3/manual_time_median                    +0.0000         +0.0007          2389          2389          2852          2854
BM_radius_search<ArborX::BVH<Cuda>>/1000000/1000000/10/0/10/1/3/manual_time_median                  -0.0229         +0.0003          7175          7011          7798          7800
```

It is still unclear to me why that #366 introduced performance improvements in OpenMP. There's still a bit of a struggle to figure out why construction time differ in Serial/OpenMP between runs.