### PR TITLE
Fixup builtin reducer type requirements for SYCL backend 

### DIFF
--- a/src/details/ArborX_Box.hpp
+++ b/src/details/ArborX_Box.hpp
@@ -105,7 +105,7 @@ struct Box
   }
 
 // FIXME Temporary workaround until we clarify requirements on the Kokkos side.
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_SYCL)
 private:
   friend KOKKOS_FUNCTION Box operator+(Box box, Box const &other)
   {


### PR DESCRIPTION
Amend to #439 because new SYCL build introduced in #423 did not run.

SYCL backend reduction displays similar type requirements than the OpenMPTarget.
The code should still been see as a workaround.  We reported the issue and will address on the Kokkos side.