### PR TITLE
Use new Kokkos occupancy feature for Cuda traversal

### DIFF
--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -67,10 +67,20 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
               std::is_same<typename Node::Tag, NodeWithLeftChildAndRopeTag>{},
           "Unrecognized node tag");
 
-      Kokkos::parallel_for("ArborX::TreeTraversal::spatial",
-                           Kokkos::RangePolicy<ExecutionSpace>(
-                               space, 0, Access::size(predicates)),
-                           *this);
+#if defined(KOKKOS_ENABLE_CUDA) && KOKKOS_VERSION >= 30300
+      if (std::is_same<ExecutionSpace, Kokkos::Cuda>{})
+        Kokkos::parallel_for("ArborX::TreeTraversal::spatial",
+                             Kokkos::Experimental::prefer(
+                                 Kokkos::RangePolicy<ExecutionSpace>(
+                                     space, 0, Access::size(predicates)),
+                                 Kokkos::Experimental::DesiredOccupancy{75}),
+                             *this);
+      else
+#endif
+        Kokkos::parallel_for("ArborX::TreeTraversal::spatial",
+                             Kokkos::RangePolicy<ExecutionSpace>(
+                                 space, 0, Access::size(predicates)),
+                             *this);
     }
   }
 
@@ -258,10 +268,20 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
 
       allocateBuffer(space);
 
-      Kokkos::parallel_for("ArborX::TreeTraversal::nearest",
-                           Kokkos::RangePolicy<ExecutionSpace>(
-                               space, 0, Access::size(predicates)),
-                           *this);
+#if defined(KOKKOS_ENABLE_CUDA) && KOKKOS_VERSION >= 30300
+      if (std::is_same<ExecutionSpace, Kokkos::Cuda>{})
+        Kokkos::parallel_for("ArborX::TreeTraversal::nearest",
+                             Kokkos::Experimental::prefer(
+                                 Kokkos::RangePolicy<ExecutionSpace>(
+                                     space, 0, Access::size(predicates)),
+                                 Kokkos::Experimental::DesiredOccupancy{75}),
+                             *this);
+      else
+#endif
+        Kokkos::parallel_for("ArborX::TreeTraversal::nearest",
+                             Kokkos::RangePolicy<ExecutionSpace>(
+                                 space, 0, Access::size(predicates)),
+                             *this);
     }
   }
 

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -68,6 +68,10 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
           "Unrecognized node tag");
 
 #if defined(KOKKOS_ENABLE_CUDA) && KOKKOS_VERSION >= 30300
+      // While DesiredOccupancy option is only implemented for Cuda and is
+      // no-op for other backends, we don't want a surprise in the future once
+      // it's implemented for HIP. It is also unclear at this point what HIP
+      // value is going to be.
       if (std::is_same<ExecutionSpace, Kokkos::Cuda>{})
         Kokkos::parallel_for("ArborX::TreeTraversal::spatial",
                              Kokkos::Experimental::prefer(
@@ -269,6 +273,10 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
       allocateBuffer(space);
 
 #if defined(KOKKOS_ENABLE_CUDA) && KOKKOS_VERSION >= 30300
+      // While DesiredOccupancy option is only implemented for Cuda and is
+      // no-op for other backends, we don't want a surprise in the future once
+      // it's implemented for HIP. It is also unclear at this point what HIP
+      // value is going to be.
       if (std::is_same<ExecutionSpace, Kokkos::Cuda>{})
         Kokkos::parallel_for("ArborX::TreeTraversal::nearest",
                              Kokkos::Experimental::prefer(


### PR DESCRIPTION
Couple things about the implementation.

First, we could start requiring Kokkos 3.3 after creating a 3.2 tag. I would be OK with it, but I would also be OK allowing older versions of Kokkos. Thus, at this point I protected it by the `KOKKOS_VERSION`, which first appeared in 3.1.00 which we require.

Second, I decided to only enable it for Cuda. I know that it's a no-op for others, but I don't want a surprise in the future once it's implemented for HIP. I also don't know what HIP parameters would need to be.

Last, I'm running some performance benchmarks with 25, 50 and 75 occupancy for Cuda on V100. I will post the results to figure out what is the best choice.