### PR TITLE
Switch SYCL build to Debug to speed it up

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -402,7 +402,7 @@ pipeline {
                             sh '''
                                 cmake \
                                     -D CMAKE_INSTALL_PREFIX=$ARBORX_DIR \
-                                    -D CMAKE_BUILD_TYPE=Release \
+                                    -D CMAKE_BUILD_TYPE=Debug \
                                     -D CMAKE_CXX_COMPILER=clang++ \
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra -Wno-unknown-cuda-version -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice" \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -405,7 +405,7 @@ pipeline {
                                     -D CMAKE_BUILD_TYPE=Debug \
                                     -D CMAKE_CXX_COMPILER=clang++ \
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
-                                    -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra -Wno-unknown-cuda-version -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice" \
+                                    -D CMAKE_CXX_FLAGS="-Wpedantic -DNDEBUG -Wall -Wextra -Wno-unknown-cuda-version -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR;$ONE_DPL_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
                                     -D MPIEXEC_PREFLAGS="--allow-run-as-root" \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -42,7 +42,7 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV SYCL_DIR=/opt/sycl
-RUN SYCL_VERSION=20210311 && \
+RUN SYCL_VERSION=20210621 && \
     SYCL_URL=https://github.com/intel/llvm/archive/sycl-nightly && \
     SYCL_ARCHIVE=${SYCL_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \


### PR DESCRIPTION
SYCL build takes a very long time:
![Screen Shot 2020-12-30 at 9 47 43 AM](https://user-images.githubusercontent.com/7297887/103358645-1990f180-4a84-11eb-8d53-0274fcd5ac52.png)

Looking closely in `.jenkins`, all builds are `Debug` except SYCL, which may explain the reason. The only downside is that we won't have any `Release` builds, but it's fine.