### PR TITLE
Replace assert by ARBORX_ASSERT

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -55,13 +55,13 @@ public:
     }
     void start()
     {
-      assert(!_started);
+      ARBORX_ASSERT(!_started);
       _tick = std::chrono::high_resolution_clock::now();
       _started = true;
     }
     void stop()
     {
-      assert(_started);
+      ARBORX_ASSERT(_started);
       std::chrono::duration<double> duration =
           std::chrono::high_resolution_clock::now() - _tick;
       // NOTE I have put much thought into whether we should use the

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -108,20 +108,20 @@ private:
 
   Kokkos::View<node_type *, MemorySpace> getInternalNodes()
   {
-    assert(!empty());
+    ARBORX_ASSERT(!empty());
     return Kokkos::subview(_internal_and_leaf_nodes,
                            std::make_pair(size_type{0}, size() - 1));
   }
 
   Kokkos::View<node_type *, MemorySpace> getLeafNodes()
   {
-    assert(!empty());
+    ARBORX_ASSERT(!empty());
     return Kokkos::subview(_internal_and_leaf_nodes,
                            std::make_pair(size() - 1, 2 * size() - 1));
   }
   Kokkos::View<node_type const *, MemorySpace> getLeafNodes() const
   {
-    assert(!empty());
+    ARBORX_ASSERT(!empty());
     return Kokkos::subview(_internal_and_leaf_nodes,
                            std::make_pair(size() - 1, 2 * size() - 1));
   }

--- a/src/details/ArborX_DetailsContainers.hpp
+++ b/src/details/ArborX_DetailsContainers.hpp
@@ -11,6 +11,8 @@
 #ifndef ARBORX_DETAILS_CONTAINERS_HPP
 #define ARBORX_DETAILS_CONTAINERS_HPP
 
+#include <details/ArborX_Exception.hpp>
+
 #include <Kokkos_Macros.hpp>
 
 #include <cassert> // assert
@@ -40,17 +42,17 @@ class StaticVector
     KOKKOS_INLINE_FUNCTION size_type size() const { return _size; }
     KOKKOS_INLINE_FUNCTION constexpr size_type maxSize() const { return N; }
     KOKKOS_INLINE_FUNCTION constexpr size_type capacity() const { return N; }
-    KOKKOS_INLINE_FUNCTION reference operator[]( size_type pos ) { assert(pos < size()); return _data[pos]; }
-    KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { assert(pos < size()); return _data[pos]; }
-    KOKKOS_INLINE_FUNCTION reference back() { assert(size() > 0 ); return _data[_size - 1]; }
-    KOKKOS_INLINE_FUNCTION const_reference back() const { assert(size() > 0); return _data[_size - 1]; }
-    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { assert(size() < maxSize()); _data[_size++] = value; }
-    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { assert(size() < maxSize()); _data[_size++] = std::move(value); }
+    KOKKOS_INLINE_FUNCTION reference operator[]( size_type pos ) { ARBORX_ASSERT(pos < size()); return _data[pos]; }
+    KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { ARBORX_ASSERT(pos < size()); return _data[pos]; }
+    KOKKOS_INLINE_FUNCTION reference back() { ARBORX_ASSERT(size() > 0 ); return _data[_size - 1]; }
+    KOKKOS_INLINE_FUNCTION const_reference back() const { ARBORX_ASSERT(size() > 0); return _data[_size - 1]; }
+    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { ARBORX_ASSERT(size() < maxSize()); _data[_size++] = value; }
+    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { ARBORX_ASSERT(size() < maxSize()); _data[_size++] = std::move(value); }
     template<class... Args>
-    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_data + _size++)) T(std::forward<Args>(args)...); }
-    KOKKOS_INLINE_FUNCTION void popBack() { assert(size() > 0); _size--; }
-    KOKKOS_INLINE_FUNCTION reference front() { assert(size() > 0); return _data[0]; }
-    KOKKOS_INLINE_FUNCTION const_reference front() const { assert(size() > 0); return _data[0]; }
+    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { ARBORX_ASSERT(size() < maxSize()); ::new (static_cast<void*>(_data + _size++)) T(std::forward<Args>(args)...); }
+    KOKKOS_INLINE_FUNCTION void popBack() { ARBORX_ASSERT(size() > 0); _size--; }
+    KOKKOS_INLINE_FUNCTION reference front() { ARBORX_ASSERT(size() > 0); return _data[0]; }
+    KOKKOS_INLINE_FUNCTION const_reference front() const { ARBORX_ASSERT(size() > 0); return _data[0]; }
     KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }
     KOKKOS_INLINE_FUNCTION pointer data() { return _data; }
     KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const { return _data; }
@@ -73,22 +75,22 @@ class UnmanagedStaticVector
     using const_reference = value_type const &;
     using pointer = value_type *;
     using const_pointer = value_type const *;
-    KOKKOS_FUNCTION UnmanagedStaticVector( pointer ptr, size_type max_size ) : _ptr(ptr) , _max_size(max_size) { assert(ptr != nullptr); }
+    KOKKOS_FUNCTION UnmanagedStaticVector( pointer ptr, size_type max_size ) : _ptr(ptr) , _max_size(max_size) { ARBORX_ASSERT(ptr != nullptr); }
     KOKKOS_INLINE_FUNCTION bool empty() const { return _size == 0; }
     KOKKOS_INLINE_FUNCTION size_type size() const { return _size; }
     KOKKOS_INLINE_FUNCTION constexpr size_type maxSize() const { return _max_size; }
     KOKKOS_INLINE_FUNCTION constexpr size_type capacity() const { return _max_size; }
-    KOKKOS_INLINE_FUNCTION reference operator[]( size_type pos ) { assert(pos < size()); return *(_ptr + pos); }
-    KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { assert(pos < size()); return *(_ptr + pos); }
-    KOKKOS_INLINE_FUNCTION reference back() { assert(size() > 0); return *(_ptr + _size - 1); }
-    KOKKOS_INLINE_FUNCTION const_reference back() const { assert(size() > 0); return *(_ptr + _size - 1); }
-    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { assert(size() < maxSize()); *(_ptr + _size++) = value; }
-    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { assert(size() < maxSize()); *(_ptr + _size++) = std::move(value); }
+    KOKKOS_INLINE_FUNCTION reference operator[]( size_type pos ) { ARBORX_ASSERT(pos < size()); return *(_ptr + pos); }
+    KOKKOS_INLINE_FUNCTION const_reference operator[]( size_type pos ) const { ARBORX_ASSERT(pos < size()); return *(_ptr + pos); }
+    KOKKOS_INLINE_FUNCTION reference back() { ARBORX_ASSERT(size() > 0); return *(_ptr + _size - 1); }
+    KOKKOS_INLINE_FUNCTION const_reference back() const { ARBORX_ASSERT(size() > 0); return *(_ptr + _size - 1); }
+    KOKKOS_INLINE_FUNCTION void pushBack(T const &value) { ARBORX_ASSERT(size() < maxSize()); *(_ptr + _size++) = value; }
+    KOKKOS_INLINE_FUNCTION void pushBack(T &&value) { ARBORX_ASSERT(size() < maxSize()); *(_ptr + _size++) = std::move(value); }
     template<class... Args>
-    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { assert(size() < maxSize()); ::new (static_cast<void*>(_ptr + _size++)) T(std::forward<Args>(args)...); }
-    KOKKOS_INLINE_FUNCTION void popBack() { assert(size() > 0); _size--; }
-    KOKKOS_INLINE_FUNCTION reference front() { assert(size() > 0); return *(_ptr + 0); }
-    KOKKOS_INLINE_FUNCTION const_reference front() const { assert(size() > 0); return *(_ptr + 0); }
+    KOKKOS_INLINE_FUNCTION void emplaceBack(Args&&... args) { ARBORX_ASSERT(size() < maxSize()); ::new (static_cast<void*>(_ptr + _size++)) T(std::forward<Args>(args)...); }
+    KOKKOS_INLINE_FUNCTION void popBack() { ARBORX_ASSERT(size() > 0); _size--; }
+    KOKKOS_INLINE_FUNCTION reference front() { ARBORX_ASSERT(size() > 0); return *(_ptr + 0); }
+    KOKKOS_INLINE_FUNCTION const_reference front() const { ARBORX_ASSERT(size() > 0); return *(_ptr + 0); }
     KOKKOS_INLINE_FUNCTION void clear() { _size = 0; }
     KOKKOS_INLINE_FUNCTION pointer data() { return _ptr; }
     KOKKOS_INLINE_FUNCTION const_pointer data() const { return _ptr; }

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -13,6 +13,7 @@
 #define ARBORX_NODE_HPP
 
 #include <ArborX_Box.hpp>
+#include <details/ArborX_Exception.hpp>
 
 #include <Kokkos_Pair.hpp>
 
@@ -45,7 +46,7 @@ struct NodeWithTwoChildren
   KOKKOS_INLINE_FUNCTION constexpr std::size_t getLeafPermutationIndex() const
       noexcept
   {
-    assert(isLeaf());
+    ARBORX_ASSERT(isLeaf());
     return right_child;
   }
 
@@ -82,7 +83,7 @@ struct NodeWithLeftChildAndRope
   KOKKOS_INLINE_FUNCTION constexpr std::size_t getLeafPermutationIndex() const
       noexcept
   {
-    assert(isLeaf());
+    ARBORX_ASSERT(isLeaf());
     return -left_child;
   }
 

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -13,6 +13,7 @@
 
 #include <ArborX_DetailsContainers.hpp>
 #include <ArborX_DetailsHeap.hpp>
+#include <details/ArborX_Exception.hpp>
 
 #include <Kokkos_Macros.hpp>
 
@@ -66,7 +67,8 @@ public:
   KOKKOS_FUNCTION PriorityQueue(Container const &c)
       : _c(c)
   {
-    assert(_c.empty() || isHeap(_c.data(), _c.data() + _c.size(), _compare));
+    ARBORX_ASSERT(_c.empty() ||
+                  isHeap(_c.data(), _c.data() + _c.size(), _compare));
   }
 
   // Capacity
@@ -105,7 +107,7 @@ public:
   template <typename... Args>
   KOKKOS_INLINE_FUNCTION void popPush(Args &&... args)
   {
-    assert(!_c.empty());
+    ARBORX_ASSERT(!_c.empty());
     bubbleDown(_c.data(), std::ptrdiff_t(0), std::ptrdiff_t(_c.size()),
                T{std::forward<Args>(args)...}, _compare);
   }

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -218,7 +218,7 @@ public:
   KOKKOS_FUNCTION std::enable_if_t<std::is_same<Tag, NodeWithTwoChildrenTag>{}>
   setRightChild(Node *node, int child_right) const
   {
-    assert(!node->isLeaf());
+    ARBORX_ASSERT(!node->isLeaf());
     node->right_child = child_right;
   }
 
@@ -227,7 +227,7 @@ public:
       std::enable_if_t<std::is_same<Tag, NodeWithLeftChildAndRopeTag>{}>
       setRightChild(Node *node, int) const
   {
-    assert(!node->isLeaf());
+    ARBORX_ASSERT(!node->isLeaf());
     (void)node;
   }
 

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -285,7 +285,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
       std::enable_if_t<std::is_same<Tag, NodeWithTwoChildrenTag>{}, int>
       getRightChild(Node const *node) const
   {
-    assert(!node->isLeaf());
+    ARBORX_ASSERT(!node->isLeaf());
     return node->right_child;
   }
 
@@ -294,7 +294,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
       std::enable_if_t<std::is_same<Tag, NodeWithLeftChildAndRopeTag>{}, int>
       getRightChild(Node const *node) const
   {
-    assert(!node->isLeaf());
+    ARBORX_ASSERT(!node->isLeaf());
     return _bvh.getNodePtr(node->left_child)->rope;
   }
 
@@ -335,7 +335,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     // preserve the heap structure internally at all time.  There is no
     // memory allocation, elements are stored in the buffer passed as an
     // argument. The farthest leaf node is on top.
-    assert(k == (int)buffer.size());
+    ARBORX_ASSERT(k == (int)buffer.size());
     PriorityQueue<PairIndexDistance, CompareDistance,
                   UnmanagedStaticVector<PairIndexDistance>>
         heap(UnmanagedStaticVector<PairIndexDistance>(buffer.data(),

--- a/src/details/ArborX_Exception.hpp
+++ b/src/details/ArborX_Exception.hpp
@@ -11,6 +11,8 @@
 #ifndef ARBORX_SEARCH_EXCEPTION_HPP
 #define ARBORX_SEARCH_EXCEPTION_HPP
 
+#include <impl/Kokkos_Error.hpp>
+
 #include <stdexcept>
 #include <string>
 
@@ -34,7 +36,6 @@ public:
 // Once moved out, possibly make it conditional
 #define ARBORX_ASSERT(c)                                                       \
   if (!(c))                                                                    \
-  throw ArborX::SearchException(#c ", failed at " __FILE__                     \
-                                   ":" ARBORX_STRINGIZE(__LINE__) ".")
+  Kokkos::abort(#c ", failed at " __FILE__ ":" ARBORX_STRINGIZE(__LINE__) ".")
 
 #endif

--- a/src/details/ArborX_Ray.hpp
+++ b/src/details/ArborX_Ray.hpp
@@ -14,6 +14,7 @@
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsKokkosExt.hpp>
 #include <ArborX_Point.hpp>
+#include <details/ArborX_Exception.hpp>
 
 #include <Kokkos_Macros.hpp>
 
@@ -51,7 +52,7 @@ struct Ray
   KOKKOS_FUNCTION static void normalize(Vector &v)
   {
     auto const magv = norm(v);
-    assert(magv > 0);
+    ARBORX_ASSERT(magv > 0);
     for (int d = 0; d < 3; ++d)
       v[d] /= magv;
   }


### PR DESCRIPTION
We have problems with calling `assert` in kernel code.
Use ARBORX_ASSERT instead and let it use `Kokkos::abort` underneath. We can, of course, thinking about disabling when `NDEBUG` is defined.