### PR TITLE
Fence ArborX calls in the benchmark and (optionally) DBSCAN

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -355,9 +355,8 @@ void BM_radius_callback_search(benchmark::State &state, Spec const &spec)
     auto const start = std::chrono::high_resolution_clock::now();
 
     index.query(exec_space, queries, callback,
-                ArborX::Experimental::TraversalPolicy()
-                    .setPredicateSorting(spec.sort_predicates)
-                    .setBufferSize(spec.buffer_size));
+                ArborX::Experimental::TraversalPolicy().setPredicateSorting(
+                    spec.sort_predicates));
 
     exec_space.fence();
     auto const end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
It may happen that the last kernel in ArborX is a Kokkos::parallel_for.
As ArborX does have a guaranteed fence() at the end, what could happen
is that that kernel is launched, and ArborX returns. Thus, when the
ending timer is called, the kernel has not been completed yet. Thus, the
measured time would be wrong in this case.