### PR TITLE
Update DBSCAN post-processing to avoid calling sort

### DIFF
--- a/examples/dbscan/ArborX_DBSCAN.hpp
+++ b/examples/dbscan/ArborX_DBSCAN.hpp
@@ -215,9 +215,8 @@ void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
   Kokkos::Profiling::popRegion();
   elapsed["query+cluster"] = timer_seconds(timer);
 
-  // Use new name to clearly demonstrate the meaning of this view from now
-  // on
-  auto clusters = stat;
+  // Use new name to clearly demonstrate the meaning of this view from now on
+  auto const &clusters = stat;
 
   if (verify)
   {
@@ -256,7 +255,7 @@ void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
   //   the offset array
   // We reuse the cluster_sizes array for the second, creating a new alias for
   // it for clarity.
-  auto map_cluster_to_offset_position = cluster_sizes;
+  auto &map_cluster_to_offset_position = cluster_sizes;
   int constexpr IGNORED_CLUSTER = -1;
   int num_clusters;
   reallocWithoutInitializing(cluster_offset, n + 1);

--- a/examples/dbscan/ArborX_DBSCAN.hpp
+++ b/examples/dbscan/ArborX_DBSCAN.hpp
@@ -224,8 +224,8 @@ void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
     timer_start(timer);
     Kokkos::Profiling::pushRegion("ArborX::DBSCAN::verify");
 
-    Kokkos::View<int *, MemorySpace> indices("indices", 0);
-    Kokkos::View<int *, MemorySpace> offset("offset", 0);
+    Kokkos::View<int *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
+    Kokkos::View<int *, MemorySpace> offset("ArborX::DBSCAN::offset", 0);
     ArborX::query(bvh, exec_space, predicates, indices, offset);
 
     auto passed = Details::verifyClusters(exec_space, indices, offset, clusters,

--- a/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
+++ b/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
@@ -123,14 +123,18 @@ bool verifyBoundaryPointsConnectToCorePoints(ExecutionSpace const &exec_space,
 // Check that cluster indices are unique
 template <typename ExecutionSpace, typename IndicesView, typename OffsetView,
           typename ClusterView>
-bool verifyClustersAreUnique(ExecutionSpace const &, IndicesView indices,
-                             OffsetView offset, ClusterView clusters,
-                             int core_min_size)
+bool verifyClustersAreUnique(ExecutionSpace const &exec_space,
+                             IndicesView indices, OffsetView offset,
+                             ClusterView clusters, int core_min_size)
 {
   int n = clusters.size();
 
-  auto clusters_host =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, clusters);
+  decltype(Kokkos::create_mirror_view(Kokkos::HostSpace{},
+                                      std::declval<ClusterView>()))
+      clusters_host(Kokkos::ViewAllocateWithoutInitializing(
+                        "ArborX::DBSCAN::clusters_host"),
+                    clusters.size());
+  Kokkos::deep_copy(exec_space, clusters_host, clusters);
   auto offset_host =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offset);
   auto indices_host =

--- a/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
+++ b/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
@@ -129,6 +129,10 @@ bool verifyClustersAreUnique(ExecutionSpace const &exec_space,
 {
   int n = clusters.size();
 
+  // FIXME we don't want to modify the clusters view in this check. What we
+  // want here is to create a view on the host, and deep_copy into it.
+  // create_mirror_view_and_copy won't work, because it is a no-op if clusters
+  // is already on the host.
   decltype(Kokkos::create_mirror_view(Kokkos::HostSpace{},
                                       std::declval<ClusterView>()))
       clusters_host(Kokkos::ViewAllocateWithoutInitializing(

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -11,7 +11,7 @@
 
 #include <ArborX_DBSCAN.hpp>
 #include <ArborX_DetailsHeap.hpp>
-#include <ArborX_DetailsPriorityQueue.hpp> // Greater
+#include <ArborX_DetailsPriorityQueue.hpp> // Less
 #include <ArborX_Version.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -156,30 +156,26 @@ int main(int argc, char *argv[])
         "Testing::compute_centers",
         Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, num_clusters),
         KOKKOS_LAMBDA(int const i) {
-          // The only reason we use heap here is for reproducibility. Current
-          // DBSCAN algorithm does not guarantee that the indices corresponding
-          // to the same cluster are going to appear in the same order from run
-          // to run. Using heap, we explicitly sort them in ascending order,
-          // thus guaranteeing the same summation order when computing cluster
-          // centers.
-          auto *cluster_start = cluster_indices.data() + cluster_offset(i);
-          int cluster_size = cluster_offset(i + 1) - cluster_offset(i);
+          // The only reason we sort indices here is for reproducibility.
+          // Current DBSCAN algorithm does not guarantee that the indices
+          // corresponding to the same cluster are going to appear in the same
+          // order from run to run. Using sorted indices, we explicitly
+          // guarantee the same summation order when computing cluster centers.
 
-          // Initialize heap
-          for (int j = 0; j < cluster_size; ++j)
-            ArborX::Details::pushHeap(cluster_start, cluster_start + j + 1,
-                                      ArborX::Details::Greater<int>());
+          // Sort cluster indices in ascending order. This uses heap for
+          // sorting, only because there is no other convenient utility that
+          // could sort within a kernel.
+          ArborX::Details::heapSort(cluster_indices.data() + cluster_offset(i),
+                                    cluster_indices.data() +
+                                        cluster_offset(i + 1),
+                                    ArborX::Details::Less<int>());
 
+          // Compute cluster centers
+          auto cluster_size = cluster_offset(i + 1) - cluster_offset(i);
           ArborX::Point cluster_center{0.f, 0.f, 0.f};
-          for (int j = 0; j < cluster_size; ++j)
+          for (int j = cluster_offset(i); j < cluster_offset(i + 1); j++)
           {
-            // Pop heap
-            ArborX::Details::popHeap(cluster_start,
-                                     cluster_start + cluster_size - j,
-                                     ArborX::Details::Greater<int>());
-            auto index = *(cluster_start + cluster_size - 1 - j);
-
-            auto const &cluster_point = primitives(index);
+            auto const &cluster_point = primitives(cluster_indices(j));
             // NOTE The explicit casts below are intended to silent warnings
             // about narrowing conversion from 'int' to 'float'.  The potential
             // issue is that 'float' can represent all integer values in the

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -162,16 +162,18 @@ int main(int argc, char *argv[])
           // order from run to run. Using sorted indices, we explicitly
           // guarantee the same summation order when computing cluster centers.
 
+          auto *cluster_start = cluster_indices.data() + cluster_offset(i);
+          auto cluster_size = cluster_offset(i + 1) - cluster_offset(i);
+
           // Sort cluster indices in ascending order. This uses heap for
           // sorting, only because there is no other convenient utility that
           // could sort within a kernel.
-          ArborX::Details::heapSort(cluster_indices.data() + cluster_offset(i),
-                                    cluster_indices.data() +
-                                        cluster_offset(i + 1),
+          ArborX::Details::makeHeap(cluster_start, cluster_start + cluster_size,
+                                    ArborX::Details::Less<int>());
+          ArborX::Details::sortHeap(cluster_start, cluster_start + cluster_size,
                                     ArborX::Details::Less<int>());
 
           // Compute cluster centers
-          auto cluster_size = cluster_offset(i + 1) - cluster_offset(i);
           ArborX::Point cluster_center{0.f, 0.f, 0.f};
           for (int j = cluster_offset(i); j < cluster_offset(i + 1); j++)
           {

--- a/src/details/ArborX_DetailsHeap.hpp
+++ b/src/details/ArborX_DetailsHeap.hpp
@@ -123,14 +123,6 @@ KOKKOS_INLINE_FUNCTION void sortHeap(RandomIterator first, RandomIterator last,
     popHeap(first, last--, comp);
 }
 
-template <typename RandomIterator, typename Compare>
-KOKKOS_INLINE_FUNCTION void heapSort(RandomIterator first, RandomIterator last,
-                                     Compare comp)
-{
-  makeHeap(first, last, comp);
-  sortHeap(first, last, comp);
-}
-
 } // namespace Details
 } // namespace ArborX
 

--- a/src/details/ArborX_DetailsHeap.hpp
+++ b/src/details/ArborX_DetailsHeap.hpp
@@ -114,6 +114,16 @@ KOKKOS_INLINE_FUNCTION void sortHeap(RandomIterator first, RandomIterator last,
     popHeap(first, last--, comp);
 }
 
+template <typename RandomIterator, typename Compare>
+KOKKOS_INLINE_FUNCTION void heapSort(RandomIterator first, RandomIterator last,
+                                     Compare comp)
+{
+  RandomIterator heap_end = first;
+  while (heap_end != last)
+    pushHeap(first, ++heap_end, comp);
+  sortHeap(first, last, comp);
+}
+
 } // namespace Details
 } // namespace ArborX
 

--- a/src/details/ArborX_DetailsHeap.hpp
+++ b/src/details/ArborX_DetailsHeap.hpp
@@ -107,6 +107,15 @@ KOKKOS_INLINE_FUNCTION void popHeap(RandomIterator first, RandomIterator last,
 }
 
 template <typename RandomIterator, typename Compare>
+KOKKOS_INLINE_FUNCTION void makeHeap(RandomIterator first, RandomIterator last,
+                                     Compare comp)
+{
+  RandomIterator heap_end = first;
+  while (heap_end != last)
+    pushHeap(first, ++heap_end, comp);
+}
+
+template <typename RandomIterator, typename Compare>
 KOKKOS_INLINE_FUNCTION void sortHeap(RandomIterator first, RandomIterator last,
                                      Compare comp)
 {
@@ -118,9 +127,7 @@ template <typename RandomIterator, typename Compare>
 KOKKOS_INLINE_FUNCTION void heapSort(RandomIterator first, RandomIterator last,
                                      Compare comp)
 {
-  RandomIterator heap_end = first;
-  while (heap_end != last)
-    pushHeap(first, ++heap_end, comp);
+  makeHeap(first, last, comp);
   sortHeap(first, last, comp);
 }
 

--- a/test/tstHeapOperations.cpp
+++ b/test/tstHeapOperations.cpp
@@ -160,9 +160,24 @@ BOOST_AUTO_TEST_CASE(min_heap)
   BOOST_TEST(a == ref, tt::per_element());
 }
 
+BOOST_AUTO_TEST_CASE(make_heap)
+{
+  for (auto v : {
+           std::vector<int>{}, std::vector<int>{6}, std::vector<int>{2, 1},
+           std::vector<int>{1, 6, 2, 2, 9, 4, 16},
+           std::vector<int>{8, 6, 7, 2, 0}, std::vector<int>{3, 3, 3, 3, 3, 1},
+           std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9}, // <- already a heap
+       })
+  {
+    makeHeap(v.data(), v.data() + v.size(), Less<int>());
+    BOOST_TEST(std::is_heap(v.begin(), v.end()));
+  }
+}
+
 BOOST_AUTO_TEST_CASE(sort_heap)
 {
-  for (auto heap : {std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9},
+  for (auto heap : {std::vector<int>{}, std::vector<int>{3},
+                    std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9},
                     std::vector<int>{36, 19, 25, 17, 3, 9, 1, 2, 7},
                     std::vector<int>{100, 19, 36, 17, 3, 25, 1, 2, 7},
                     std::vector<int>{15, 5, 11, 3, 4, 8}})
@@ -175,13 +190,13 @@ BOOST_AUTO_TEST_CASE(sort_heap)
 
 BOOST_AUTO_TEST_CASE(heap_sort)
 {
-  for (auto heap :
+  for (auto v :
        {std::vector<int>{}, std::vector<int>{1}, std::vector<int>{2, 1},
         std::vector<int>{1, 6, 2, 2, 9, 4, 16}, std::vector<int>{8, 6, 7, 2, 0},
         std::vector<int>{3, 3, 3, 3, 3, 1}})
   {
-    heapSort(heap.data(), heap.data() + heap.size(), Less<int>());
-    BOOST_TEST(std::is_sorted(heap.begin(), heap.end()));
+    heapSort(v.data(), v.data() + v.size(), Less<int>());
+    BOOST_TEST(std::is_sorted(v.begin(), v.end()));
   }
 }
 

--- a/test/tstHeapOperations.cpp
+++ b/test/tstHeapOperations.cpp
@@ -188,18 +188,6 @@ BOOST_AUTO_TEST_CASE(sort_heap)
   }
 }
 
-BOOST_AUTO_TEST_CASE(heap_sort)
-{
-  for (auto v :
-       {std::vector<int>{}, std::vector<int>{1}, std::vector<int>{2, 1},
-        std::vector<int>{1, 6, 2, 2, 9, 4, 16}, std::vector<int>{8, 6, 7, 2, 0},
-        std::vector<int>{3, 3, 3, 3, 3, 1}})
-  {
-    heapSort(v.data(), v.data() + v.size(), Less<int>());
-    BOOST_TEST(std::is_sorted(v.begin(), v.end()));
-  }
-}
-
 BOOST_AUTO_TEST_CASE(is_heap)
 {
   for (auto heap : {std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9},

--- a/test/tstHeapOperations.cpp
+++ b/test/tstHeapOperations.cpp
@@ -173,6 +173,18 @@ BOOST_AUTO_TEST_CASE(sort_heap)
   }
 }
 
+BOOST_AUTO_TEST_CASE(heap_sort)
+{
+  for (auto heap :
+       {std::vector<int>{}, std::vector<int>{1}, std::vector<int>{2, 1},
+        std::vector<int>{1, 6, 2, 2, 9, 4, 16}, std::vector<int>{8, 6, 7, 2, 0},
+        std::vector<int>{3, 3, 3, 3, 3, 1}})
+  {
+    heapSort(heap.data(), heap.data() + heap.size(), Less<int>());
+    BOOST_TEST(std::is_sorted(heap.begin(), heap.end()));
+  }
+}
+
 BOOST_AUTO_TEST_CASE(is_heap)
 {
   for (auto heap : {std::vector<int>{36, 19, 25, 17, 3, 7, 1, 2, 9},


### PR DESCRIPTION
We know that Kokkos::BinSort struggles on arrays with duplicated
indices, which is certainly the case here, as the sort is called on
cluster indices.

The new approach completely avoids that. And, in fact, seems to be
faster.