### PR TITLE
Print out rates in the benchmark

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -213,6 +213,12 @@ void BM_construction(benchmark::State &state, Spec const &spec)
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
   }
+  // In Benchmark 1.5.0, it could be rewritten as
+  //   state.counters["rate"] = benchmark::Counter(
+  //     spec.n_values, benchmark::Counter::kIsIterationInvariantRate);
+  // Benchmark 1.4 does not support kIsIterationInvariantRate, however.
+  state.counters["rate"] = benchmark::Counter(
+      spec.n_values * state.iterations(), benchmark::Counter::kIsRate);
 }
 
 template <typename ExecutionSpace, class TreeType>
@@ -246,6 +252,8 @@ void BM_knn_search(benchmark::State &state, Spec const &spec)
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
   }
+  state.counters["rate"] = benchmark::Counter(
+      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
 }
 
 template <typename DeviceType>
@@ -294,6 +302,8 @@ void BM_knn_callback_search(benchmark::State &state, Spec const &spec)
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
   }
+  state.counters["rate"] = benchmark::Counter(
+      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
 }
 
 template <typename ExecutionSpace, class TreeType>
@@ -328,6 +338,8 @@ void BM_radius_search(benchmark::State &state, Spec const &spec)
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
   }
+  state.counters["rate"] = benchmark::Counter(
+      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
 }
 
 template <typename ExecutionSpace, class TreeType>
@@ -364,6 +376,8 @@ void BM_radius_callback_search(benchmark::State &state, Spec const &spec)
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
   }
+  state.counters["rate"] = benchmark::Counter(
+      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
 }
 
 class KokkosScopeGuard


### PR DESCRIPTION
It is useful on its own. It is also a good way to resolve #410 blocking issue, as Google Benchmark itself will compute the statistics on the rate.

The output looks like this:
```
./ArborX_BoundingVolumeHierarchy.exe --benchmark_filter=construction.*Serial --benchmark_repetitions=2
rk_out_format=json                                                                                                                                 
ArborX version: 0.9 (dev)                                                                                                                          
ArborX hash   : bc6ac790                                                                                                                         
2021-01-09 13:21:38                           
Running ./ArborX_BoundingVolumeHierarchy.exe
Run on (32 X 3000 MHz CPU s)      
CPU Caches:
  L1 Data 32K (x16)
  L1 Instruction 32K (x16)
  L2 Unified 256K (x16)
  L3 Unified 20480K (x2)
Load Average: 0.31, 0.25, 0.18
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
---------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------------------------------------------------
BM_construction<ArborX::BVH<Serial>>/50000/0/manual_time                                      31582 us        31584 us           21 rate=1.58317M/s
BM_construction<ArborX::BVH<Serial>>/50000/0/manual_time                                      31499 us        31500 us           21 rate=1.58736M/s
BM_construction<ArborX::BVH<Serial>>/50000/0/manual_time_mean                                 31541 us        31542 us            2 rate=1.58526M/s
BM_construction<ArborX::BVH<Serial>>/50000/0/manual_time_median                               31541 us        31542 us            2 rate=1.58526M/s
BM_construction<ArborX::BVH<Serial>>/50000/0/manual_time_stddev                                59.0 us         59.1 us            2 rate=2.96407k/s
```
I also checked that if one runs with dumping into JSON file (running with `--benchmark_out=file.json --benchmark_out_format=json`), the rate is present there
```
    {                                                                                                                                                         
      "name": "BM_construction<ArborX::BVH<Serial>>/50000/0/manual_time_median",                                                                              
      "run_name": "BM_construction<ArborX::BVH<Serial>>/50000/0/manual_time",                                                                                 
      "run_type": "aggregate",                                                                                                                                
      "repetitions": 0,                                                                                                                                       
      "threads": 1,                                                                                                                                           
      "aggregate_name": "median",                                                                                                                             
      "iterations": 2,                                                                                                                                        
      "real_time": 3.1540527071428569e+04,                                                                                                                    
      "cpu_time": 3.1541904785714287e+04,                                                                                                                     
      "time_unit": "us",                                                                                                                                      
      "rate": 1.5852648019218259e+06                                                                                                                          
    },   
```
The behavior of `compare_bench.py` is not affected, and it produces only the time differences.