### PR TITLE
Query tree unit test (partial) cleanup

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(ArborX_DetailsAlgorithms.exe PRIVATE ${CMAKE_CURRENT_
 add_test(NAME ArborX_DetailsAlgorithms_Test COMMAND ./ArborX_DetailsAlgorithms.exe)
 
 set(ARBORX_TEST_QUERY_TREE_SOURCES)
-foreach(_test Callbacks Degenerate)
+foreach(_test Callbacks Degenerate ManufacturedSolution)
   set(_suffix "_InstantiateAll")
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}${_suffix}.cpp"
     "#include <ArborX_LinearBVH.hpp>\n"
@@ -79,7 +79,6 @@ endforeach()
 add_executable(ArborX_QueryTree.exe
   ${ARBORX_TEST_QUERY_TREE_SOURCES}
   tstQueryTreeComparisonWithBoost.cpp
-  tstQueryTreeManufacturedSolution.cpp
   tstQueryTreeTraversalPolicy.cpp
   tstKokkosToolsAnnotations.cpp
   utf_main.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(ArborX_DetailsAlgorithms.exe PRIVATE ${CMAKE_CURRENT_
 add_test(NAME ArborX_DetailsAlgorithms_Test COMMAND ./ArborX_DetailsAlgorithms.exe)
 
 set(ARBORX_TEST_QUERY_TREE_SOURCES)
-foreach(_test Degenerate)
+foreach(_test Callbacks Degenerate)
   set(_suffix "_InstantiateAll")
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}${_suffix}.cpp"
     "#include <ArborX_LinearBVH.hpp>\n"
@@ -80,7 +80,6 @@ add_executable(ArborX_QueryTree.exe
   ${ARBORX_TEST_QUERY_TREE_SOURCES}
   tstQueryTreeComparisonWithBoost.cpp
   tstQueryTreeManufacturedSolution.cpp
-  tstQueryTreeCallbacks.cpp
   tstQueryTreeTraversalPolicy.cpp
   tstKokkosToolsAnnotations.cpp
   utf_main.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,7 +76,7 @@ foreach(_test Degenerate)
   )
   list(APPEND ARBORX_TEST_QUERY_TREE_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}${_suffix}.cpp")
 endforeach()
-add_executable(ArborX_LinearBVH.exe
+add_executable(ArborX_QueryTree.exe
   ${ARBORX_TEST_QUERY_TREE_SOURCES}
   tstQueryTreeComparisonWithBoost.cpp
   tstQueryTreeManufacturedSolution.cpp
@@ -84,10 +84,10 @@ add_executable(ArborX_LinearBVH.exe
   tstQueryTreeTraversalPolicy.cpp
   tstKokkosToolsAnnotations.cpp
   utf_main.cpp)
-target_link_libraries(ArborX_LinearBVH.exe PRIVATE ArborX Boost::unit_test_framework)
-target_compile_definitions(ArborX_LinearBVH.exe PRIVATE BOOST_TEST_DYN_LINK)
-target_include_directories(ArborX_LinearBVH.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-add_test(NAME ArborX_LinearBVH_Test COMMAND ./ArborX_LinearBVH.exe)
+target_link_libraries(ArborX_QueryTree.exe PRIVATE ArborX Boost::unit_test_framework)
+target_compile_definitions(ArborX_QueryTree.exe PRIVATE BOOST_TEST_DYN_LINK)
+target_include_directories(ArborX_QueryTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME ArborX_QueryTree_Test COMMAND ./ArborX_QueryTree.exe)
 
 add_executable(ArborX_DetailsTreeConstruction.exe tstDetailsTreeConstruction.cpp utf_main.cpp)
 target_link_libraries(ArborX_DetailsTreeConstruction.exe PRIVATE ArborX Boost::unit_test_framework)

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -102,10 +102,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree, TreeTypeTraits, TreeTypeTraitsList)
   auto point_coords_host = Kokkos::create_mirror_view(point_coords);
   Kokkos::View<double *, ExecutionSpace> radii("radii", n_points);
   auto radii_host = Kokkos::create_mirror_view(radii);
-  Kokkos::View<int * [2], ExecutionSpace> within_n_pts("within_n_pts",
-                                                       n_points);
-  Kokkos::View<int * [2], ExecutionSpace> nearest_n_pts("nearest_n_pts",
-                                                        n_points);
   Kokkos::View<int *, ExecutionSpace> k("distribution_k", n_points);
   auto k_host = Kokkos::create_mirror_view(k);
   // use random radius for the search and random number k of for the kNN

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(ComparisonWithBoost)
 
 namespace tt = boost::test_tools;
 
-std::vector<std::array<double, 3>>
+inline std::vector<std::array<double, 3>>
 make_stuctured_cloud(double Lx, double Ly, double Lz, int nx, int ny, int nz)
 {
   std::vector<std::array<double, 3>> cloud(nx * ny * nz);
@@ -47,8 +47,8 @@ make_stuctured_cloud(double Lx, double Ly, double Lz, int nx, int ny, int nz)
   return cloud;
 }
 
-std::vector<std::array<double, 3>> make_random_cloud(double Lx, double Ly,
-                                                     double Lz, int n)
+inline std::vector<std::array<double, 3>>
+make_random_cloud(double Lx, double Ly, double Lz, int n)
 {
   std::vector<std::array<double, 3>> cloud(n);
   std::default_random_engine generator;

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -20,8 +20,6 @@
 #include "ArborXTest_TreeTypeTraits.hpp"
 // clang-format on
 
-#define BOOST_TEST_MODULE LinearBVH
-
 BOOST_AUTO_TEST_SUITE(Degenerate)
 
 namespace tt = boost::test_tools;

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -24,7 +24,8 @@ BOOST_AUTO_TEST_SUITE(Degenerate)
 
 namespace tt = boost::test_tools;
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, TreeTypeTraits, TreeTypeTraitsList)
+BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree_spatial_predicate, TreeTypeTraits,
+                              TreeTypeTraitsList)
 {
   using Tree = typename TreeTypeTraits::type;
   using ExecutionSpace = typename TreeTypeTraits::execution_space;
@@ -57,10 +58,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, TreeTypeTraits, TreeTypeTraitsList)
                            makeIntersectsSphereQueries<DeviceType>({}),
                            make_reference_solution<int>({}, {0}));
 
-    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
-                           makeNearestQueries<DeviceType>({}),
-                           make_reference_solution<int>({}, {0}));
-
     // Now passing a couple queries of various type and checking the
     // results.
     ARBORX_TEST_QUERY_TREE(
@@ -77,7 +74,38 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, TreeTypeTraits, TreeTypeTraitsList)
                                {{{1., 1., 1.}}, 2.},
                            }),
                            make_reference_solution<int>({}, {0, 0, 0}));
+  }
+}
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree_nearest_predicate, TreeTypeTraits,
+                              TreeTypeTraitsList)
+{
+  using Tree = typename TreeTypeTraits::type;
+  using ExecutionSpace = typename TreeTypeTraits::execution_space;
+  using DeviceType = typename TreeTypeTraits::device_type;
+
+  // tree is empty, it has no leaves.
+  for (auto const &tree : {
+           Tree{}, // default constructed
+           make<Tree>(ExecutionSpace{},
+                      {}), // constructed with empty view of boxes
+       })
+  {
+    BOOST_TEST(tree.empty());
+    BOOST_TEST(tree.size() == 0);
+    // Tree::bounds() returns an invalid box when the tree is empty.
+    BOOST_TEST(ArborX::Details::equals(tree.bounds(), {}));
+
+    // Passing a view with no query does seem a bit silly but we still need
+    // to support it. And since the tag dispatching yields different tree
+    // traversals for nearest and spatial predicates, we do have to check
+    // the results for various type of queries.
+    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                           makeNearestQueries<DeviceType>({}),
+                           make_reference_solution<int>({}, {0}));
+
+    // Now passing a couple queries of various type and checking the
+    // results.
     ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                            makeNearestQueries<DeviceType>({
                                {{{0., 0., 0.}}, 1},
@@ -87,8 +115,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, TreeTypeTraits, TreeTypeTraitsList)
   }
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, TreeTypeTraits,
-                              TreeTypeTraitsList)
+BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree_spatial_predicate,
+                              TreeTypeTraits, TreeTypeTraitsList)
 {
   using Tree = typename TreeTypeTraits::type;
   using ExecutionSpace = typename TreeTypeTraits::execution_space;
@@ -114,14 +142,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, TreeTypeTraits,
                          make_reference_solution<int>({}, {0}));
 
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
-                         makeNearestQueries<DeviceType>({}),
-                         make_reference_solution<int>({}, {0}));
-  ARBORX_TEST_QUERY_TREE(
-      ExecutionSpace{}, tree,
-      makeNearestQueries<DeviceType>({{{0., 0., 0.}, 3}, {{4., 5., 1.}, 1}}),
-      make_reference_solution<int>({0, 0}, {0, 1, 2}));
-
-  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                          makeIntersectsBoxQueries<DeviceType>({
                              {{{5., 5., 5.}}, {{5., 5., 5.}}},
                              {{{.5, .5, .5}}, {{.5, .5, .5}}},
@@ -135,6 +155,33 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, TreeTypeTraits,
                              {{{5., 5., 5.}}, 2.},
                          }),
                          make_reference_solution<int>({0, 0}, {0, 1, 2, 2}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree_nearest_predicate,
+                              TreeTypeTraits, TreeTypeTraitsList)
+{
+  using Tree = typename TreeTypeTraits::type;
+  using ExecutionSpace = typename TreeTypeTraits::execution_space;
+  using DeviceType = typename TreeTypeTraits::device_type;
+
+  // tree has a single leaf (unit box)
+  auto const tree =
+      make<Tree>(ExecutionSpace{}, {
+                                       {{{0., 0., 0.}}, {{1., 1., 1.}}},
+                                   });
+
+  BOOST_TEST(!tree.empty());
+  BOOST_TEST(tree.size() == 1);
+  BOOST_TEST(
+      ArborX::Details::equals(tree.bounds(), {{{0., 0., 0.}}, {{1., 1., 1.}}}));
+
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeNearestQueries<DeviceType>({}),
+                         make_reference_solution<int>({}, {0}));
+  ARBORX_TEST_QUERY_TREE(
+      ExecutionSpace{}, tree,
+      makeNearestQueries<DeviceType>({{{0., 0., 0.}, 3}, {{4., 5., 1.}, 1}}),
+      make_reference_solution<int>({0, 0}, {0, 1, 2}));
 
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                          makeNearestQueries<DeviceType>({
@@ -146,8 +193,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_leaf_tree, TreeTypeTraits,
 }
 
 // FIXME Tree with two leaves is not "degenerated".  Find a better place for it.
-BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, TreeTypeTraits,
-                              TreeTypeTraitsList)
+BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree_spatial_predicate,
+                              TreeTypeTraits, TreeTypeTraitsList)
 {
   using Tree = typename TreeTypeTraits::type;
   using ExecutionSpace = typename TreeTypeTraits::execution_space;
@@ -205,6 +252,30 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, TreeTypeTraits,
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                          makeIntersectsBoxQueries<DeviceType>({}),
                          make_reference_solution<int>({}, {0}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree_nearest_predicate,
+                              TreeTypeTraits, TreeTypeTraitsList)
+{
+  using Tree = typename TreeTypeTraits::type;
+  using ExecutionSpace = typename TreeTypeTraits::execution_space;
+  using DeviceType = typename TreeTypeTraits::device_type;
+
+  auto const tree =
+      make<Tree>(ExecutionSpace{}, {
+                                       {{{0., 0., 0.}}, {{0., 0., 0.}}},
+                                       {{{1., 1., 1.}}, {{1., 1., 1.}}},
+                                   });
+
+  BOOST_TEST(!tree.empty());
+  BOOST_TEST(tree.size() == 2);
+  BOOST_TEST(
+      ArborX::Details::equals(tree.bounds(), {{{0., 0., 0.}}, {{1., 1., 1.}}}));
+
+  // no query
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
+                         makeNearestQueries<DeviceType>({}),
+                         make_reference_solution<int>({}, {0}));
 
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
                          makeNearestQueries<DeviceType>({
@@ -214,8 +285,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(couple_leaves_tree, TreeTypeTraits,
                          make_reference_solution<int>({0, 1, 0, 1}, {0, 2, 4}));
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(duplicated_leaves, TreeTypeTraits,
-                              TreeTypeTraitsList)
+BOOST_AUTO_TEST_CASE_TEMPLATE(duplicated_leaves_spatial_predicate,
+                              TreeTypeTraits, TreeTypeTraitsList)
 {
   using Tree = typename TreeTypeTraits::type;
   using ExecutionSpace = typename TreeTypeTraits::execution_space;
@@ -248,8 +319,41 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(Miscellaneous)
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity, TreeTypeTraits,
-                              TreeTypeTraitsList)
+BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_spatial_predicate,
+                              TreeTypeTraits, TreeTypeTraitsList)
+{
+  // FIXME This unit test might make little sense for other trees than BVH
+  // using Tree = typename TreeTypeTraits::type;
+  using ExecutionSpace = typename TreeTypeTraits::execution_space;
+  using DeviceType = typename TreeTypeTraits::device_type;
+
+  std::vector<ArborX::Box> boxes;
+  int const n = 4096; // exceed stack capacity which is 64
+  boxes.reserve(n);
+  for (int i = 0; i < n; ++i)
+  {
+    double const a = i;
+    double const b = i + 1;
+    boxes.push_back({{{a, a, a}}, {{b, b, b}}});
+  }
+  auto const bvh = make<ArborX::BVH<typename DeviceType::memory_space>>(
+      ExecutionSpace{}, boxes);
+
+  Kokkos::View<int *, DeviceType> indices("indices", 0);
+  Kokkos::View<int *, DeviceType> offset("offset", 0);
+  // spatial query that find all indexable in the
+  // tree is fine
+  BOOST_CHECK_NO_THROW(ArborX::query(bvh, ExecutionSpace{},
+                                     makeIntersectsBoxQueries<DeviceType>({
+                                         {},
+                                         {{{0., 0., 0.}}, {{n, n, n}}},
+                                     }),
+                                     indices, offset));
+  BOOST_TEST(ArborX::lastElement(offset) == n);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_nearest_predicate,
+                              TreeTypeTraits, TreeTypeTraitsList)
 {
   // FIXME This unit test might make little sense for other trees than BVH
   // using Tree = typename TreeTypeTraits::type;
@@ -275,16 +379,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity, TreeTypeTraits,
   BOOST_CHECK_NO_THROW(ArborX::query(bvh, ExecutionSpace{},
                                      makeNearestQueries<DeviceType>({
                                          {{{0., 0., 0.}}, n},
-                                     }),
-                                     indices, offset));
-  BOOST_TEST(ArborX::lastElement(offset) == n);
-
-  // spatial query that find all indexable in the
-  // tree is also fine
-  BOOST_CHECK_NO_THROW(ArborX::query(bvh, ExecutionSpace{},
-                                     makeIntersectsBoxQueries<DeviceType>({
-                                         {},
-                                         {{{0., 0., 0.}}, {{n, n, n}}},
                                      }),
                                      indices, offset));
   BOOST_TEST(ArborX::lastElement(offset) == n);

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_spatial_predicate,
   using DeviceType = typename TreeTypeTraits::device_type;
 
   std::vector<ArborX::Box> boxes;
-  int const n = 4096; // exceed stack capacity which is 64
+  int const n = 4096; // exceeds stack capacity which is 64
   boxes.reserve(n);
   for (int i = 0; i < n; ++i)
   {
@@ -341,8 +341,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_spatial_predicate,
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> offset("offset", 0);
-  // spatial query that find all indexable in the
-  // tree is fine
+  // spatial query that is satisfied by all leaves in the tree
   BOOST_CHECK_NO_THROW(ArborX::query(bvh, ExecutionSpace{},
                                      makeIntersectsBoxQueries<DeviceType>({
                                          {},
@@ -374,8 +373,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_nearest_predicate,
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> offset("offset", 0);
-  // query number of nearest neighbors that exceed
-  // capacity of the stack is not a problem
+  // nearest query asking for as many neighbors as they are leaves in the tree
   BOOST_CHECK_NO_THROW(ArborX::query(bvh, ExecutionSpace{},
                                      makeNearestQueries<DeviceType>({
                                          {{{0., 0., 0.}}, n},

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -9,7 +9,6 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
 #include <ArborX_LinearBVH.hpp>
 
 #include <boost/test/unit_test.hpp>
@@ -20,14 +19,20 @@
 #include <tuple>
 
 #include "Search_UnitTestHelpers.hpp"
+// clang-format off
+#include "ArborXTest_TreeTypeTraits.hpp"
+// clang-format on
 
 BOOST_AUTO_TEST_SUITE(ManufacturedSolution)
 
 namespace tt = boost::test_tools;
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
+BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
+                              TreeTypeTraitsList)
 {
-  using ExecutionSpace = typename DeviceType::execution_space;
+  using Tree = typename TreeTypeTraits::type;
+  using ExecutionSpace = typename TreeTypeTraits::execution_space;
+  using DeviceType = typename TreeTypeTraits::device_type;
 
   double Lx = 100.0;
   double Ly = 100.0;
@@ -50,8 +55,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
           }
       });
 
-  ArborX::BVH<typename DeviceType::memory_space> const bvh(ExecutionSpace{},
-                                                           bounding_boxes);
+  Tree const tree(ExecutionSpace{}, bounding_boxes);
 
   // (i) use same objects for the queries than the objects we constructed the
   // BVH
@@ -76,7 +80,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::View<int *, DeviceType> indices("indices", n);
   Kokkos::View<int *, DeviceType> offset("offset", n);
 
-  ArborX::query(bvh, ExecutionSpace{}, queries, indices, offset);
+  ArborX::query(tree, ExecutionSpace{}, queries, indices, offset);
 
   auto indices_host = Kokkos::create_mirror_view(indices);
   Kokkos::deep_copy(indices_host, indices);
@@ -186,7 +190,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
                        KOKKOS_LAMBDA(int i) {
                          queries[i] = ArborX::intersects(bounding_boxes[i]);
                        });
-  ArborX::query(bvh, ExecutionSpace{}, queries, indices, offset);
+  ArborX::query(tree, ExecutionSpace{}, queries, indices, offset);
   indices_host = Kokkos::create_mirror_view(indices);
   Kokkos::deep_copy(indices_host, indices);
   offset_host = Kokkos::create_mirror_view(offset);
@@ -245,7 +249,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, DeviceType, ARBORX_DEVICE_TYPES)
                        KOKKOS_LAMBDA(int i) {
                          queries[i] = ArborX::intersects(bounding_boxes[i]);
                        });
-  ArborX::query(bvh, ExecutionSpace{}, queries, indices, offset);
+  ArborX::query(tree, ExecutionSpace{}, queries, indices, offset);
   indices_host = Kokkos::create_mirror_view(indices);
   Kokkos::deep_copy(indices_host, indices);
   offset_host = Kokkos::create_mirror_view(offset);

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -21,8 +21,6 @@
 
 #include "Search_UnitTestHelpers.hpp"
 
-#define BOOST_TEST_MODULE LinearBVH
-
 BOOST_AUTO_TEST_SUITE(ManufacturedSolution)
 
 namespace tt = boost::test_tools;


### PR DESCRIPTION
Incremental step to cleanup the unit test

* Renamed query tree executable
* Separated out spatial and nearest predicates in unit tests
* Updated more tests to use the tree traits