### PR TITLE
Avoid giving impression that it is legal to add stuff to ArborX::

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -184,37 +184,38 @@ struct RadiusSearches
   double radius;
 };
 
-namespace ArborX
-{
 template <typename DeviceType>
-struct AccessTraits<RadiusSearches<DeviceType>, PredicatesTag>
+struct ArborX::AccessTraits<RadiusSearches<DeviceType>, ArborX::PredicatesTag>
 {
   using memory_space = typename DeviceType::memory_space;
-  static std::size_t size(RadiusSearches<DeviceType> const &pred)
+  static KOKKOS_FUNCTION std::size_t
+  size(RadiusSearches<DeviceType> const &pred)
   {
     return pred.points.extent(0);
   }
   static KOKKOS_FUNCTION auto get(RadiusSearches<DeviceType> const &pred,
                                   std::size_t i)
   {
-    return intersects(Sphere{pred.points(i), pred.radius});
+    return ArborX::intersects(ArborX::Sphere{pred.points(i), pred.radius});
   }
 };
+
 template <typename DeviceType>
-struct AccessTraits<NearestNeighborsSearches<DeviceType>, PredicatesTag>
+struct ArborX::AccessTraits<NearestNeighborsSearches<DeviceType>,
+                            ArborX::PredicatesTag>
 {
   using memory_space = typename DeviceType::memory_space;
-  static std::size_t size(NearestNeighborsSearches<DeviceType> const &pred)
+  static KOKKOS_FUNCTION std::size_t
+  size(NearestNeighborsSearches<DeviceType> const &pred)
   {
     return pred.points.extent(0);
   }
   static KOKKOS_FUNCTION auto
   get(NearestNeighborsSearches<DeviceType> const &pred, std::size_t i)
   {
-    return nearest(pred.points(i), pred.k);
+    return ArborX::nearest(pred.points(i), pred.k);
   }
 };
-} // namespace ArborX
 
 namespace bpo = boost::program_options;
 

--- a/examples/access_traits/example_cuda_access_traits.cpp
+++ b/examples/access_traits/example_cuda_access_traits.cpp
@@ -34,13 +34,15 @@ struct Spheres
   int N;
 };
 
-namespace ArborX
-{
 template <>
-struct AccessTraits<PointCloud, PrimitivesTag>
+struct ArborX::AccessTraits<PointCloud, ArborX::PrimitivesTag>
 {
-  static std::size_t size(PointCloud const &cloud) { return cloud.N; }
-  KOKKOS_FUNCTION static Point get(PointCloud const &cloud, std::size_t i)
+  static KOKKOS_FUNCTION std::size_t size(PointCloud const &cloud)
+  {
+    return cloud.N;
+  }
+  static KOKKOS_FUNCTION ArborX::Point get(PointCloud const &cloud,
+                                           std::size_t i)
   {
     return {{cloud.d_x[i], cloud.d_y[i], cloud.d_z[i]}};
   }
@@ -48,16 +50,16 @@ struct AccessTraits<PointCloud, PrimitivesTag>
 };
 
 template <>
-struct AccessTraits<Spheres, PredicatesTag>
+struct ArborX::AccessTraits<Spheres, ArborX::PredicatesTag>
 {
-  static std::size_t size(Spheres const &d) { return d.N; }
-  KOKKOS_FUNCTION static auto get(Spheres const &d, std::size_t i)
+  static KOKKOS_FUNCTION std::size_t size(Spheres const &d) { return d.N; }
+  static KOKKOS_FUNCTION auto get(Spheres const &d, std::size_t i)
   {
-    return intersects(Sphere{{{d.d_x[i], d.d_y[i], d.d_z[i]}}, d.d_r[i]});
+    return ArborX::intersects(
+        ArborX::Sphere{{{d.d_x[i], d.d_y[i], d.d_z[i]}}, d.d_r[i]});
   }
   using memory_space = Kokkos::CudaSpace;
 };
-} // namespace ArborX
 
 int main(int argc, char *argv[])
 {

--- a/examples/access_traits/example_host_access_traits.cpp
+++ b/examples/access_traits/example_host_access_traits.cpp
@@ -17,19 +17,13 @@
 #include <random>
 #include <vector>
 
-namespace ArborX
-{
 template <typename T, typename Tag>
-struct AccessTraits<std::vector<T>, Tag>
+struct ArborX::AccessTraits<std::vector<T>, Tag>
 {
   static std::size_t size(std::vector<T> const &v) { return v.size(); }
-  KOKKOS_FUNCTION static T const &get(std::vector<T> const &v, std::size_t i)
-  {
-    return v[i];
-  }
+  static T const &get(std::vector<T> const &v, std::size_t i) { return v[i]; }
   using memory_space = Kokkos::HostSpace;
 };
-} // namespace ArborX
 
 int main(int argc, char *argv[])
 {

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -29,29 +29,27 @@ struct NearestToOrigin
   int k;
 };
 
-namespace ArborX
-{
 template <>
-struct AccessTraits<FirstOctant, PredicatesTag>
+struct ArborX::AccessTraits<FirstOctant, ArborX::PredicatesTag>
 {
-  KOKKOS_FUNCTION static std::size_t size(FirstOctant) { return 1; }
-  KOKKOS_FUNCTION static auto get(FirstOctant, std::size_t)
+  static KOKKOS_FUNCTION std::size_t size(FirstOctant) { return 1; }
+  static KOKKOS_FUNCTION auto get(FirstOctant, std::size_t)
   {
-    return intersects(Box{{{0, 0, 0}}, {{1, 1, 1}}});
+    return ArborX::intersects(ArborX::Box{{{0, 0, 0}}, {{1, 1, 1}}});
   }
   using memory_space = MemorySpace;
 };
+
 template <>
-struct AccessTraits<NearestToOrigin, PredicatesTag>
+struct ArborX::AccessTraits<NearestToOrigin, ArborX::PredicatesTag>
 {
-  KOKKOS_FUNCTION static std::size_t size(NearestToOrigin) { return 1; }
-  KOKKOS_FUNCTION static auto get(NearestToOrigin d, std::size_t)
+  static KOKKOS_FUNCTION std::size_t size(NearestToOrigin) { return 1; }
+  static KOKKOS_FUNCTION auto get(NearestToOrigin d, std::size_t)
   {
-    return nearest(Point{0, 0, 0}, d.k);
+    return ArborX::nearest(ArborX::Point{0, 0, 0}, d.k);
   }
   using memory_space = MemorySpace;
 };
-} // namespace ArborX
 
 struct PrintfCallback
 {

--- a/test/tstAccessTraits.cpp
+++ b/test/tstAccessTraits.cpp
@@ -17,54 +17,50 @@ using ArborX::PredicatesTag;
 using ArborX::PrimitivesTag;
 using ArborX::Details::check_valid_access_traits;
 
+// NOTE Let's not bother with __host__ __device__ annotations here
+
 struct NoAccessTraitsSpecialization
 {
 };
+
 struct EmptySpecialization
 {
 };
+template <typename Tag>
+struct ArborX::AccessTraits<EmptySpecialization, Tag>
+{
+};
+
 struct InvalidMemorySpace
 {
 };
-struct SizeMemberFunctionNotStatic
-{
-};
-namespace ArborX
-{
 template <typename Tag>
-struct AccessTraits<EmptySpecialization, Tag>
-{
-};
-template <typename Tag>
-struct AccessTraits<InvalidMemorySpace, Tag>
+struct ArborX::AccessTraits<InvalidMemorySpace, Tag>
 {
   using memory_space = void;
 };
+
+struct SizeMemberFunctionNotStatic
+{
+};
 template <typename Tag>
-struct AccessTraits<SizeMemberFunctionNotStatic, Tag>
+struct ArborX::AccessTraits<SizeMemberFunctionNotStatic, Tag>
 {
   using memory_space = Kokkos::HostSpace;
   int size(SizeMemberFunctionNotStatic) { return 255; }
 };
-} // namespace ArborX
 
 // Ensure legacy access traits are still valid
 struct LegacyAccessTraits
 {
 };
-namespace ArborX
-{
-namespace Traits
-{
 template <typename Tag>
-struct Access<LegacyAccessTraits, Tag>
+struct ArborX::Traits::Access<LegacyAccessTraits, Tag>
 {
   using memory_space = Kokkos::HostSpace;
-  KOKKOS_FUNCTION static int size(LegacyAccessTraits) { return 0; }
-  KOKKOS_FUNCTION static Point get(LegacyAccessTraits, int) { return {}; }
+  static int size(LegacyAccessTraits) { return 0; }
+  static Point get(LegacyAccessTraits, int) { return {}; }
 };
-} // namespace Traits
-} // namespace ArborX
 
 int main()
 {

--- a/test/tstCallbacks.cpp
+++ b/test/tstCallbacks.cpp
@@ -13,25 +13,24 @@
 #include <ArborX_Callbacks.hpp>
 #include <ArborX_Predicates.hpp>
 
+// NOTE Let's not bother with __host__ __device__ annotations here
+
 struct NearestPredicates
 {
 };
-
-struct SpatialPredicates
-{
-};
-
-namespace ArborX
-{
 template <>
-struct AccessTraits<NearestPredicates, PredicatesTag>
+struct ArborX::AccessTraits<NearestPredicates, ArborX::PredicatesTag>
 {
   using memory_space = Kokkos::HostSpace;
   static int size(NearestPredicates const &) { return 1; }
   static auto get(NearestPredicates const &, int) { return nearest(Point{}); }
 };
+
+struct SpatialPredicates
+{
+};
 template <>
-struct AccessTraits<SpatialPredicates, PredicatesTag>
+struct ArborX::AccessTraits<SpatialPredicates, ArborX::PredicatesTag>
 {
   using memory_space = Kokkos::HostSpace;
   static int size(SpatialPredicates const &) { return 1; }
@@ -40,7 +39,6 @@ struct AccessTraits<SpatialPredicates, PredicatesTag>
     return intersects(Point{});
   }
 };
-} // namespace ArborX
 
 // Custom callbacks
 struct CallbackMissingTag


### PR DESCRIPTION
cc @wjge 

NOTE order between `static` and the function annotation does not actually matter.  I picked the one I liked better (today at least)

NOTE qualification `ArborX::` is not strictly necessary in the body of the access traits.  I added it for clarity.