### PR TITLE
Be more conservative allowing default access traits implementation for Kokkos::View

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -41,7 +41,12 @@ using AccessTraitsNotSpecializedArchetypeAlias =
 
 template <typename View, typename Tag>
 struct AccessTraits<
-    View, Tag, std::enable_if_t<Kokkos::is_view<View>{} && View::rank == 1>>
+    View, Tag,
+    std::enable_if_t<
+        Kokkos::is_view<View>{} && View::rank == 1 &&
+        (std::is_same<Tag, PredicatesTag>{} ||
+         std::is_same<typename View::non_const_value_type, Point>{} ||
+         std::is_same<typename View::non_const_value_type, Box>{})>>
 {
   // Returns a const reference
   KOKKOS_FUNCTION static typename View::const_value_type &get(View const &v,
@@ -57,7 +62,11 @@ struct AccessTraits<
 
 template <typename View, typename Tag>
 struct AccessTraits<
-    View, Tag, std::enable_if_t<Kokkos::is_view<View>{} && View::rank == 2>>
+    View, Tag,
+    std::enable_if_t<
+        Kokkos::is_view<View>{} && View::rank == 2 &&
+        std::is_same<Tag, PrimitivesTag>{} &&
+        std::is_floating_point<typename View::non_const_value_type>{}>>
 {
   // Returns by value
   KOKKOS_FUNCTION static Point get(View const &v, int i)

--- a/test/tstAccessTraits.cpp
+++ b/test/tstAccessTraits.cpp
@@ -64,10 +64,10 @@ struct ArborX::Traits::Access<LegacyAccessTraits, Tag>
 
 int main()
 {
-  Kokkos::View<ArborX::Point *> p;
-  Kokkos::View<float **> v;
-  check_valid_access_traits(PrimitivesTag{}, p);
-  check_valid_access_traits(PrimitivesTag{}, v);
+  check_valid_access_traits(PrimitivesTag{}, Kokkos::View<ArborX::Point *>{});
+  check_valid_access_traits(PrimitivesTag{},
+                            Kokkos::View<ArborX::Box const *>{});
+  check_valid_access_traits(PrimitivesTag{}, Kokkos::View<float **>{});
 
   using NearestPredicate = decltype(ArborX::nearest(ArborX::Point{}));
   Kokkos::View<NearestPredicate *> q;
@@ -76,6 +76,15 @@ int main()
   check_valid_access_traits(PrimitivesTag{}, LegacyAccessTraits{});
 
   // Uncomment to see error messages
+
+  // check_valid_access_traits(PrimitivesTag{},
+  // Kokkos::View<ArborX::Sphere*>{});
+
+  // check_valid_access_traits(PrimitivesTag{}, Kokkos::View<float *>{});
+
+  // check_valid_access_traits(PrimitivesTag{}, Kokkos::View<float ***>{});
+
+  // check_valid_access_traits(PrimitivesTag{}, Kokkos::View<int **>{});
 
   // check_valid_access_traits(PrimitivesTag{}, NoAccessTraitsSpecialization{});
 

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -223,6 +223,18 @@ KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakeBoundingVolume) {}
 KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakePrimitive) {}
 } // namespace Test
 
+template <typename... ViewProperties>
+struct ArborX::AccessTraits<
+    Kokkos::View<Test::FakePrimitive *, ViewProperties...>,
+    ArborX::PrimitivesTag>
+{
+  using Primitives = Kokkos::View<Test::FakePrimitive *, ViewProperties...>;
+  KOKKOS_FUNCTION
+  static size_t size(Primitives) { return 0; }
+  KOKKOS_FUNCTION
+  static Test::FakeBoundingVolume get(Primitives, int) { return {}; }
+};
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {


### PR DESCRIPTION
If it is a primitives specialization, only allow
- `Kokkos::View<Point*, ...>`
- `Kokkos::View<Box*, ...>`
- `Kokkos::View<float**, ...>`

Right now, user can provide `Kokkos::View<Sphere*, ...>` resulting in an unhelpful message:
```
  ambiguous template instantiation for ‘struct
  ArborX::AccessTraits<Kokkos::View<ArborX::Sphere*, Kokkos::HostSpace>,
  ArborX::PrimitivesTag, void>’
```
if user himself defines the appropriate access traits.