### PR TITLE
Breakout KokkosExt header and partial cleanup of includes

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -18,7 +18,7 @@
 #include <ArborX_CrsGraphWrapper.hpp>
 #include <ArborX_DetailsBatchedQueries.hpp>
 #include <ArborX_DetailsConcepts.hpp>
-#include <ArborX_DetailsKokkosExt.hpp>
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
 #include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsPermutedData.hpp>
 #include <ArborX_DetailsSortUtils.hpp>

--- a/src/details/ArborX_Box.hpp
+++ b/src/details/ArborX_Box.hpp
@@ -8,10 +8,12 @@
  *                                                                          *
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
+
 #ifndef ARBORX_BOX_HPP
 #define ARBORX_BOX_HPP
 
-#include <ArborX_DetailsKokkosExt.hpp> // ArithmeticTraits
+#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
 #include <ArborX_Point.hpp>
 
 #include <Kokkos_Macros.hpp>

--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -12,7 +12,8 @@
 #define ARBORX_DETAILS_ALGORITHMS_HPP
 
 #include <ArborX_Box.hpp>
-#include <ArborX_DetailsKokkosExt.hpp> // min, max, isFinite
+#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsKokkosExtMathFunctions.hpp> // isFinite
 #include <ArborX_Point.hpp>
 #include <ArborX_Ray.hpp>
 #include <ArborX_Sphere.hpp>

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -14,7 +14,7 @@
 #include <ArborX_Config.hpp>
 
 #include <ArborX_DetailsDistributor.hpp>
-#include <ArborX_DetailsKokkosExt.hpp> // min, max
+#include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsUtils.hpp>
 #include <ArborX_LinearBVH.hpp>

--- a/src/details/ArborX_DetailsKokkosExtAccessibilityTraits.hpp
+++ b/src/details/ArborX_DetailsKokkosExtAccessibilityTraits.hpp
@@ -8,19 +8,19 @@
  *                                                                          *
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
-#ifndef ARBORX_DETAILS_KOKKOS_EXT_HPP
-#define ARBORX_DETAILS_KOKKOS_EXT_HPP
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_ACCESSIBILITY_TRAITS_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_ACCESSIBILITY_TRAITS_HPP
 
 #include <Kokkos_Core.hpp>
 
-#include <cfloat>  // DBL_MAX, DBL_EPSILON
-#include <cmath>   // isfinite, HUGE_VAL
-#include <cstdint> // uint32_t
 #include <type_traits>
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
+
 namespace KokkosExt
 {
+
 template <typename MemorySpace, typename ExecutionSpace, typename = void>
 struct is_accessible_from : std::false_type
 {
@@ -43,88 +43,8 @@ struct is_accessible_from_host
   static_assert(Kokkos::is_view<View>::value, "");
 };
 
-//! Compute the maximum of two values.
-template <typename T>
-KOKKOS_INLINE_FUNCTION constexpr T const &max(T const &a, T const &b)
-{
-  return (a > b) ? a : b;
-}
-
-//! Compute the minimum of two values.
-template <typename T>
-KOKKOS_INLINE_FUNCTION constexpr T const &min(T const &a, T const &b)
-{
-  return (a < b) ? a : b;
-}
-
-/** Determine whether the given floating point argument @param x has finite
- * value.
- *
- * NOTE: Clang issues a warning if the std:: namespace is missing and nvcc
- * complains about calling a __host__ function from a __host__ __device__
- * function when it is present.
- */
-template <typename T>
-KOKKOS_INLINE_FUNCTION bool isFinite(T x)
-{
-#ifdef __CUDA_ARCH__
-  return isfinite(x);
-#else
-  return std::isfinite(x);
-#endif
-}
-
-namespace ArithmeticTraits
-{
-
-template <typename T>
-struct infinity;
-
-template <>
-struct infinity<float>
-{
-  static constexpr float value = HUGE_VALF;
-};
-
-template <>
-struct infinity<double>
-{
-  static constexpr double value = HUGE_VAL;
-};
-
-template <typename T>
-struct max;
-
-template <>
-struct max<float>
-{
-  static constexpr float value = FLT_MAX;
-};
-
-template <>
-struct max<double>
-{
-  static constexpr double value = DBL_MAX;
-};
-
-template <typename T>
-struct epsilon;
-
-template <>
-struct epsilon<float>
-{
-  static constexpr float value = FLT_EPSILON;
-};
-
-template <>
-struct epsilon<double>
-{
-  static constexpr double value = DBL_EPSILON;
-};
-
-} // namespace ArithmeticTraits
-
 } // namespace KokkosExt
+
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 #endif

--- a/src/details/ArborX_DetailsKokkosExtArithmeticTraits.hpp
+++ b/src/details/ArborX_DetailsKokkosExtArithmeticTraits.hpp
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_ARITHMETIC_TRAITS_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_ARITHMETIC_TRAITS_HPP
+
+#include <cfloat> // DBL_MAX, DBL_EPSILON
+#include <cmath>  // HUGE_VAL
+
+namespace KokkosExt
+{
+namespace ArithmeticTraits
+{
+
+template <typename T>
+struct infinity;
+
+template <>
+struct infinity<float>
+{
+  static constexpr float value = HUGE_VALF;
+};
+
+template <>
+struct infinity<double>
+{
+  static constexpr double value = HUGE_VAL;
+};
+
+template <typename T>
+struct max;
+
+template <>
+struct max<float>
+{
+  static constexpr float value = FLT_MAX;
+};
+
+template <>
+struct max<double>
+{
+  static constexpr double value = DBL_MAX;
+};
+
+template <typename T>
+struct epsilon;
+
+template <>
+struct epsilon<float>
+{
+  static constexpr float value = FLT_EPSILON;
+};
+
+template <>
+struct epsilon<double>
+{
+  static constexpr double value = DBL_EPSILON;
+};
+
+} // namespace ArithmeticTraits
+
+} // namespace KokkosExt
+
+#endif

--- a/src/details/ArborX_DetailsKokkosExtMathFunctions.hpp
+++ b/src/details/ArborX_DetailsKokkosExtMathFunctions.hpp
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_MATH_FUNCTIONS_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_MATH_FUNCTIONS_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <cmath> // isfinite
+
+namespace KokkosExt
+{
+
+/** Determine whether the given floating point argument @param x has finite
+ * value.
+ *
+ * NOTE: Clang issues a warning if the std:: namespace is missing and nvcc
+ * complains about calling a __host__ function from a __host__ __device__
+ * function when it is present.
+ */
+template <typename T>
+KOKKOS_INLINE_FUNCTION bool isFinite(T x)
+{
+#ifdef __CUDA_ARCH__
+  return isfinite(x);
+#else
+  return std::isfinite(x);
+#endif
+}
+
+} // namespace KokkosExt
+
+#endif

--- a/src/details/ArborX_DetailsKokkosExtMinMaxOperations.hpp
+++ b/src/details/ArborX_DetailsKokkosExtMinMaxOperations.hpp
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_MIN_MAX_OPERATIONS_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_MIN_MAX_OPERATIONS_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace KokkosExt
+{
+
+//! Compute the maximum of two values.
+template <typename T>
+KOKKOS_INLINE_FUNCTION constexpr T const &max(T const &a, T const &b)
+{
+  return (a > b) ? a : b;
+}
+
+//! Compute the minimum of two values.
+template <typename T>
+KOKKOS_INLINE_FUNCTION constexpr T const &min(T const &a, T const &b)
+{
+  return (a < b) ? a : b;
+}
+
+} // namespace KokkosExt
+
+#endif

--- a/src/details/ArborX_DetailsMortonCode.hpp
+++ b/src/details/ArborX_DetailsMortonCode.hpp
@@ -12,7 +12,7 @@
 #ifndef ARBORX_DETAILS_MORTON_CODE_UTILS_HPP
 #define ARBORX_DETAILS_MORTON_CODE_UTILS_HPP
 
-#include <ArborX_DetailsKokkosExt.hpp> // min. max
+#include <ArborX_DetailsKokkosExtMinMaxOperations.hpp> // min. max
 #include <ArborX_Exception.hpp>
 
 namespace ArborX

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -14,9 +14,11 @@
 
 #include <ArborX_Box.hpp>
 
-#include <Kokkos_Pair.hpp>
+#include <Kokkos_Macros.hpp>
 
 #include <cassert>
+#include <climits> // INT_MIN
+#include <utility> // std::move
 
 namespace ArborX
 {

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -13,6 +13,7 @@
 
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_DetailsAlgorithms.hpp>
+#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
 #include <ArborX_DetailsNode.hpp> // ROPE_SENTINEL
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsStack.hpp>

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -11,6 +11,7 @@
 #ifndef ARBORX_DETAILS_TREE_VISUALIZATION_HPP
 #define ARBORX_DETAILS_TREE_VISUALIZATION_HPP
 
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
 #include <ArborX_DetailsTreeTraversal.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/src/details/ArborX_Ray.hpp
+++ b/src/details/ArborX_Ray.hpp
@@ -12,7 +12,7 @@
 #define ARBORX_RAY_HPP
 
 #include <ArborX_Box.hpp>
-#include <ArborX_DetailsKokkosExt.hpp>
+#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
 #include <ArborX_Point.hpp>
 
 #include <Kokkos_Macros.hpp>

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -17,8 +17,8 @@
 #include "ArborX_BoostGeometryAdapters.hpp"
 #include "ArborX_BoostRangeAdapters.hpp"
 #include <ArborX_Box.hpp>
-#include <ArborX_DetailsKokkosExt.hpp> // is_accessible_from_host
-#include <ArborX_DetailsUtils.hpp>     // exclusivePrefixSum, lastElement
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp> // is_accessible_from_host
+#include <ArborX_DetailsUtils.hpp> // exclusivePrefixSum, lastElement
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
 

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -12,7 +12,7 @@
 #ifndef ARBORX_ENABLE_VIEW_COMPARISON_HPP
 #define ARBORX_ENABLE_VIEW_COMPARISON_HPP
 
-#include <ArborX_DetailsKokkosExt.hpp> // is_accessible_from_host
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp> // is_accessible_from_host
 
 #include <Kokkos_Core.hpp>
 

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -20,7 +20,6 @@
 
 #include "ArborX_BoostRTreeHelpers.hpp"
 #include "ArborX_EnableViewComparison.hpp"
-#include <ArborX_DetailsKokkosExt.hpp> // is_accessible_from
 #ifdef ARBORX_ENABLE_MPI
 #include <ArborX_DistributedTree.hpp>
 #endif


### PR DESCRIPTION
Motivation: While profiling the compilation of some of our executables, I realized `<ArborX_Box.hpp>` was including the whole `<Kokkos_Core.hpp>` which is really silly. This PR is not attempting to fix all the defects, it specifically resolves that issue by breaking out the header `<ArborX_DetailsKokkosExt.hpp>` into
* `ArborX_DetailsKokkosExtAccessibilityTraits.hpp`
* `ArborX_DetailsKokkosExtArithmeticTraits.hpp` (which eventually will be replaced by Kokkos numeric traits)
* `ArborX_DetailsKokkosExtMathFunctions.hpp` (which eventually will be replaced by the math functions in `Kokkos::`)
* `ArborX_DetailsKokkosExtMinMaxOperations.hpp` (replaced by `std:{min,max}` if NVCC quits requiring an experimental flag to enable)