### PR TITLE
Move comparison function objects out of priority queue header

### DIFF
--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -11,7 +11,7 @@
 
 #include <ArborX_DBSCAN.hpp>
 #include <ArborX_DetailsHeap.hpp>
-#include <ArborX_DetailsPriorityQueue.hpp> // Less
+#include <ArborX_DetailsOperatorFunctionObjects.hpp> // Less
 #include <ArborX_Version.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/src/details/ArborX_DetailsOperatorFunctionObjects.hpp
+++ b/src/details/ArborX_DetailsOperatorFunctionObjects.hpp
@@ -23,7 +23,7 @@ template <typename T>
 struct Less
 {
 public:
-  KOKKOS_INLINE_FUNCTION bool operator()(T const &lhs, T const &rhs) const
+  KOKKOS_FUNCTION constexpr bool operator()(T const &lhs, T const &rhs) const
   {
     return lhs < rhs;
   }
@@ -33,7 +33,7 @@ template <typename T>
 struct Greater
 {
 public:
-  KOKKOS_INLINE_FUNCTION bool operator()(T const &lhs, T const &rhs) const
+  KOKKOS_FUNCTION constexpr bool operator()(T const &lhs, T const &rhs) const
   {
     return lhs > rhs;
   }

--- a/src/details/ArborX_DetailsOperatorFunctionObjects.hpp
+++ b/src/details/ArborX_DetailsOperatorFunctionObjects.hpp
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_OPERATOR_FUNCTION_OBJECTS_HPP
+#define ARBORX_DETAILS_OPERATOR_FUNCTION_OBJECTS_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace ArborX
+{
+namespace Details
+{
+
+template <typename T>
+struct Less
+{
+public:
+  KOKKOS_INLINE_FUNCTION bool operator()(T const &lhs, T const &rhs) const
+  {
+    return lhs < rhs;
+  }
+};
+
+template <typename T>
+struct Greater
+{
+public:
+  KOKKOS_INLINE_FUNCTION bool operator()(T const &lhs, T const &rhs) const
+  {
+    return lhs > rhs;
+  }
+};
+
+} // namespace Details
+} // namespace ArborX
+
+#endif

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -13,6 +13,7 @@
 
 #include <ArborX_DetailsContainers.hpp>
 #include <ArborX_DetailsHeap.hpp>
+#include <ArborX_DetailsOperatorFunctionObjects.hpp> // Less
 
 #include <Kokkos_Macros.hpp>
 
@@ -24,26 +25,6 @@ namespace ArborX
 {
 namespace Details
 {
-
-template <typename T>
-struct Less
-{
-public:
-  KOKKOS_INLINE_FUNCTION bool operator()(T const &lhs, T const &rhs) const
-  {
-    return lhs < rhs;
-  }
-};
-
-template <typename T>
-struct Greater
-{
-public:
-  KOKKOS_INLINE_FUNCTION bool operator()(T const &lhs, T const &rhs) const
-  {
-    return lhs > rhs;
-  }
-};
 
 template <typename T, typename Compare = Less<T>,
           typename Container = StaticVector<T, 256>>


### PR DESCRIPTION
Rational: It somehow bothered me when we had to include `<ArborX_DetailsPriorityQueue.hpp>` to use `Less` in #453 

Note that I made the operators `constexpr` to be consistent with the function objects in `<functional>`