### PR TITLE
Drop unused type traits

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -8,10 +8,11 @@
  *                                                                          *
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
+
 #ifndef ARBORX_ACCESS_TRAITS_HPP
 #define ARBORX_ACCESS_TRAITS_HPP
 
-#include <ArborX_DetailsConcepts.hpp> // is_complete
+#include <ArborX_DetailsConcepts.hpp>
 #include <ArborX_DetailsTags.hpp>
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -58,15 +58,6 @@ struct is_detected : is_detected_impl<void, Op, Args...>
 template <template <class...> class Op, class... Args>
 using detected_t = typename is_detected<Op, Args...>::type;
 
-// is_complete implementation taken from https://stackoverflow.com/a/44229779
-template <class T, std::size_t = sizeof(T)>
-std::true_type is_complete_impl(T *);
-
-std::false_type is_complete_impl(...);
-
-template <class T>
-using is_complete = decltype(is_complete_impl(std::declval<T *>()));
-
 template <typename T>
 struct first_template_parameter;
 

--- a/src/details/ArborX_DetailsConcepts.hpp
+++ b/src/details/ArborX_DetailsConcepts.hpp
@@ -8,10 +8,9 @@
  *                                                                          *
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
+
 #ifndef ARBORX_DETAILS_CONCEPTS_HPP
 #define ARBORX_DETAILS_CONCEPTS_HPP
-
-#include <ArborX_DetailsAlgorithms.hpp>
 
 #include <type_traits>
 
@@ -58,37 +57,6 @@ struct is_detected : is_detected_impl<void, Op, Args...>
 
 template <template <class...> class Op, class... Args>
 using detected_t = typename is_detected<Op, Args...>::type;
-
-// Checks for existence of a free function that expands an object of type
-// Geometry using an object of type Other
-template <typename Geometry, typename Other, typename = void>
-struct is_expandable : std::false_type
-{
-};
-
-template <typename Geometry, typename Other>
-struct is_expandable<
-    Geometry, Other,
-    std::void_t<decltype(
-        expand(std::declval<Geometry &>(), std::declval<Other const &>()))>>
-    : std::true_type
-{
-};
-
-// Checks for existence of a free function that calculates the centroid of an
-// object of type Geometry
-template <typename Geometry, typename Point, typename = void>
-struct has_centroid : std::false_type
-{
-};
-
-template <typename Geometry, typename Point>
-struct has_centroid<
-    Geometry, Point,
-    std::void_t<decltype(centroid(std::declval<Geometry const &>(),
-                                  std::declval<Point &>()))>> : std::true_type
-{
-};
 
 // is_complete implementation taken from https://stackoverflow.com/a/44229779
 template <class T, std::size_t = sizeof(T)>

--- a/test/tstDetailsConcepts.cpp
+++ b/test/tstDetailsConcepts.cpp
@@ -15,19 +15,6 @@
 
 #include <tuple>
 
-using ArborX::Details::is_complete;
-
-template <typename T, typename Enable = void>
-struct NotSpecializedForIntegralTypes;
-template <typename T>
-struct NotSpecializedForIntegralTypes<
-    T, std::enable_if_t<!std::is_integral<T>::value>>
-{
-};
-
-static_assert(is_complete<NotSpecializedForIntegralTypes<float>>::value, "");
-static_assert(!is_complete<NotSpecializedForIntegralTypes<int>>::value, "");
-
 using ArborX::Details::first_template_parameter_t;
 static_assert(std::is_same<first_template_parameter_t<std::tuple<int, float>>,
                            int>::value,

--- a/test/tstDetailsConcepts.cpp
+++ b/test/tstDetailsConcepts.cpp
@@ -15,32 +15,6 @@
 
 #include <tuple>
 
-using ArborX::Box;
-using ArborX::Point;
-using ArborX::Sphere;
-using ArborX::Details::has_centroid;
-using ArborX::Details::is_expandable;
-
-static_assert(is_expandable<Box, Box>::value, "");
-static_assert(is_expandable<Box, Box const>::value, "");
-static_assert(!is_expandable<Box const, Box>::value, "");
-
-static_assert(is_expandable<Box, Point>::value, "");
-static_assert(is_expandable<Box, Sphere>::value, "");
-
-static_assert(!is_expandable<Point, Point>::value, "");
-static_assert(!is_expandable<Point, Box>::value, "");
-static_assert(!is_expandable<Point, Sphere>::value, "");
-
-// NOTE Possible but not implemented
-static_assert(!is_expandable<Sphere, Point>::value, "");
-static_assert(!is_expandable<Sphere, Box>::value, "");
-static_assert(!is_expandable<Sphere, Sphere>::value, "");
-
-static_assert(has_centroid<Box, Point>::value, "");
-static_assert(has_centroid<Point, Point>::value, "");
-static_assert(has_centroid<Sphere, Point>::value, "");
-
 using ArborX::Details::is_complete;
 
 template <typename T, typename Enable = void>


### PR DESCRIPTION
Rational: The traits have been unused for a long time and I don't anticipate we will change our mind anytime soon.

* Besides not being used, `is_expandable` and `has_centroid` functionality can easily be implemented using the detection idiom.
* `is_complete` had other issues that led to our using another mechanism to detect whether the access traits were specialized. https://github.com/arborx/ArborX/blob/b020ca71f3994d9bc8c0c3b151dceb41114061e3/src/details/ArborX_AccessTraits.hpp#L35