### PR TITLE
Restore expected failures decorators for HIP

### DIFF
--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -66,6 +66,10 @@ make_random_cloud(double Lx, double Ly, double Lz, int n)
   return cloud;
 }
 
+// FIXME temporary workaround bug in HIP-Clang (register spill)
+#ifdef KOKKOS_ENABLE_HIP
+BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(1))
+#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
                               TreeTypeTraitsList)
 {
@@ -123,6 +127,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
 }
 
 #ifndef ARBORX_TEST_DISABLE_NEAREST_QUERY
+// FIXME temporary workaround bug in HIP-Clang (register spill)
+#ifdef KOKKOS_ENABLE_HIP
+BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(1))
+#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate, TreeTypeTraits,
                               TreeTypeTraitsList)
 {

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -29,7 +29,7 @@ namespace tt = boost::test_tools;
 
 // FIXME temporary workaround bug in HIP-Clang (register spill)
 #if defined(KOKKOS_ENABLE_HIP)
-BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(5))
+BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(4))
 #endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
                               TreeTypeTraitsList)
@@ -96,8 +96,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
   std::vector<int> offset_ref(n + 1);
   std::iota(indices_ref.begin(), indices_ref.end(), 0);
   std::iota(offset_ref.begin(), offset_ref.end(), 0);
-  BOOST_TEST(indices_host == indices_ref, tt::per_element());
-  BOOST_TEST(offset_host == offset_ref, tt::per_element());
+  BOOST_TEST(make_compressed_storage(offset_host, indices_host) ==
+                 make_compressed_storage(offset_ref, indices_ref),
+             tt::per_element());
 
   // (ii) use bounding boxes that intersects with first neighbors
   //

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -27,6 +27,10 @@ BOOST_AUTO_TEST_SUITE(ManufacturedSolution)
 
 namespace tt = boost::test_tools;
 
+// FIXME temporary workaround bug in HIP-Clang (register spill)
+#if defined(KOKKOS_ENABLE_HIP)
+BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(5))
+#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
                               TreeTypeTraitsList)
 {


### PR DESCRIPTION
The comparison with Boost was removed in bfa54105cd4b8c84566c2adaa9f5f4cb4097e142 and never restored. The rest were part of #442 that were never merged.