### PR TITLE
Clarify bounding volume and predicate geometry type requirements

### DIFF
--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -62,8 +62,8 @@ public:
         "ArborX::BatchedQueries::assign_morton_codes_to_queries",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
         KOKKOS_LAMBDA(int i) {
-          Point xyz =
-              Details::returnCentroid(getGeometry(Access::get(predicates, i)));
+          using Details::returnCentroid;
+          Point xyz = returnCentroid(getGeometry(Access::get(predicates, i)));
           translateAndScale(xyz, xyz, scene_bounding_box);
           morton_codes(i) = morton3D(xyz[0], xyz[1], xyz[2]);
         });

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -305,7 +305,8 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     auto const k = getK(predicate);
     auto const distance = [geometry = getGeometry(predicate),
                            bvh = _bvh](Node const *node) {
-      return Details::distance(geometry, bvh.getBoundingVolume(node));
+      using Details::distance;
+      return distance(geometry, bvh.getBoundingVolume(node));
     };
     auto const buffer = _buffer(queryIndex);
 

--- a/src/details/ArborX_Predicates.hpp
+++ b/src/details/ArborX_Predicates.hpp
@@ -59,7 +59,8 @@ struct Intersects
   template <typename Other>
   KOKKOS_INLINE_FUNCTION bool operator()(Other const &other) const
   {
-    return Details::intersects(_geometry, other);
+    using Details::intersects;
+    return intersects(_geometry, other);
   }
 
   Geometry _geometry;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,9 @@ target_link_libraries(ArborX_Callbacks.exe PRIVATE ArborX)
 add_executable(ArborX_DetailsConcepts.exe tstDetailsConcepts.cpp)
 target_link_libraries(ArborX_DetailsConcepts.exe PRIVATE ArborX)
 
+add_executable(ArborX_TypeRequirements.exe tstDetailsTypeRequirements.cpp)
+target_link_libraries(ArborX_TypeRequirements.exe PRIVATE ArborX)
+
 add_executable(ArborX_DetailsUtils.exe tstDetailsUtils.cpp utf_main.cpp)
 # TODO link Boost::dynamic_linking interface target to enable dynamic linking
 # (adds BOOST_ALL_DYN_LINK)

--- a/test/tstDetailsTypeRequirements.cpp
+++ b/test/tstDetailsTypeRequirements.cpp
@@ -16,18 +16,18 @@
 namespace Test
 {
 // NOTE only supporting Point and Box
-using FakePrimitive = ArborX::Point;
-// using FakePrimitive = ArborX::Box;
+using PrimitivePointOrBox = ArborX::Point;
+// using PrimitivePointOrBox = ArborX::Box;
 
 // clang-format off
 struct FakeBoundingVolume
 {
-  KOKKOS_FUNCTION FakeBoundingVolume &operator+=(FakePrimitive) { return *this; }
-  KOKKOS_FUNCTION void operator+=(FakePrimitive) volatile {}
+  KOKKOS_FUNCTION FakeBoundingVolume &operator+=(PrimitivePointOrBox) { return *this; }
+  KOKKOS_FUNCTION void operator+=(PrimitivePointOrBox) volatile {}
   KOKKOS_FUNCTION operator ArborX::Box() const { return {}; }
 };
 KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakeBoundingVolume) {}
-KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakePrimitive) {}
+KOKKOS_FUNCTION void expand(FakeBoundingVolume, PrimitivePointOrBox) {}
 
 struct FakePredicateGeometry {};
 KOKKOS_FUNCTION ArborX::Point returnCentroid(FakePredicateGeometry) { return {}; }
@@ -44,7 +44,8 @@ void check_bounding_volume_and_predicate_geometry_type_requirements()
   using Tree = ArborX::BasicBoundingVolumeHierarchy<MemorySpace,
                                                     Test::FakeBoundingVolume>;
 
-  Kokkos::View<Test::FakePrimitive *, MemorySpace> primitives("primitives", 0);
+  Kokkos::View<Test::PrimitivePointOrBox *, MemorySpace> primitives(
+      "primitives", 0);
   Tree tree(ExecutionSpace{}, primitives);
 
   using SpatialPredicate =

--- a/test/tstDetailsTypeRequirements.cpp
+++ b/test/tstDetailsTypeRequirements.cpp
@@ -32,6 +32,7 @@ KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakePrimitive) {}
 struct FakePredicateGeometry {};
 KOKKOS_FUNCTION ArborX::Point returnCentroid(FakePredicateGeometry) { return {}; }
 KOKKOS_FUNCTION bool intersects(FakePredicateGeometry, FakeBoundingVolume) { return true; }
+KOKKOS_FUNCTION float distance(FakePredicateGeometry, FakeBoundingVolume) { return 0.f; }
 // clang-format on
 } // namespace Test
 
@@ -46,10 +47,19 @@ void check_bounding_volume_and_predicate_geometry_type_requirements()
   Kokkos::View<Test::FakePrimitive *, MemorySpace> primitives("primitives", 0);
   Tree tree(ExecutionSpace{}, primitives);
 
-  Kokkos::View<decltype(ArborX::intersects(Test::FakePredicateGeometry{})) *,
-               MemorySpace>
-      predicates("predicates", 0);
-  tree.query(ExecutionSpace{}, predicates, [](auto, int) {});
+  using SpatialPredicate =
+      decltype(ArborX::intersects(Test::FakePredicateGeometry{}));
+  Kokkos::View<SpatialPredicate *, MemorySpace> spatial_predicates(
+      "spatial_predicates", 0);
+  tree.query(ExecutionSpace{}, spatial_predicates,
+             KOKKOS_LAMBDA(SpatialPredicate, int){});
+
+  using NearestPredicate =
+      decltype(ArborX::nearest(Test::FakePredicateGeometry{}));
+  Kokkos::View<NearestPredicate *, MemorySpace> nearest_predicates(
+      "nearest_predicates", 0);
+  tree.query(ExecutionSpace{}, nearest_predicates,
+             KOKKOS_LAMBDA(NearestPredicate, int){});
 }
 
 int main() { return 0; }

--- a/test/tstDetailsTypeRequirements.cpp
+++ b/test/tstDetailsTypeRequirements.cpp
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <ArborX_LinearBVH.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace Test
+{
+// NOTE only supporting Point and Box
+using FakePrimitive = ArborX::Point;
+// using FakePrimitive = ArborX::Box;
+
+// clang-format off
+struct FakeBoundingVolume
+{
+  KOKKOS_FUNCTION FakeBoundingVolume &operator+=(FakePrimitive) { return *this; }
+  KOKKOS_FUNCTION void operator+=(FakePrimitive) volatile {}
+  KOKKOS_FUNCTION operator ArborX::Box() const { return {}; }
+};
+KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakeBoundingVolume) {}
+KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakePrimitive) {}
+
+struct FakePredicateGeometry {};
+KOKKOS_FUNCTION ArborX::Point returnCentroid(FakePredicateGeometry) { return {}; }
+KOKKOS_FUNCTION bool intersects(FakePredicateGeometry, FakeBoundingVolume) { return true; }
+// clang-format on
+} // namespace Test
+
+// Compile-only
+void check_bounding_volume_and_predicate_geometry_type_requirements()
+{
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using MemorySpace = ExecutionSpace::memory_space;
+  using Tree = ArborX::BasicBoundingVolumeHierarchy<MemorySpace,
+                                                    Test::FakeBoundingVolume>;
+
+  Kokkos::View<Test::FakePrimitive *, MemorySpace> primitives("primitives", 0);
+  Tree tree(ExecutionSpace{}, primitives);
+
+  Kokkos::View<decltype(ArborX::intersects(Test::FakePredicateGeometry{})) *,
+               MemorySpace>
+      predicates("predicates", 0);
+  tree.query(ExecutionSpace{}, predicates, [](auto, int) {});
+}
+
+int main() { return 0; }


### PR DESCRIPTION
Rational:  These changes enable defining `kDOP` from #386 in an `Experimental::` namespace if we chose to do so.  Similarly they enable predicates such as `Ray` to be defined in user code.

You'll notice some oddities such as our requiring both `BoundingVolume::operator+=(Primitive)` and `expand(BoundingVolume, Primitive)` but the goal of this PR is only clarify the requirements and enable the use of types not defined within `ArborX::` (in particular remove the need to inject code in `ArborX::Details::`)