### PR TITLE
Avoid unnecessary rebuilds for generated unit test source files

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,20 +69,28 @@ add_test(NAME ArborX_DetailsAlgorithms_Test COMMAND ./ArborX_DetailsAlgorithms.e
 
 set(ARBORX_TEST_QUERY_TREE_SOURCES)
 foreach(_test Callbacks Degenerate ManufacturedSolution ComparisonWithBoost)
-  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp"
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp.tmp"
     "#include <ArborX_LinearBVH.hpp>\n"
     "#define ARBORX_TEST_TREE_TYPES Tuple<ArborX::BVH>\n"
     "#define ARBORX_TEST_DEVICE_TYPES std::tuple<${ARBORX_DEVICE_TYPES}>\n"
     "#include <tstQueryTree${_test}.cpp>\n"
   )
+  configure_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp.tmp"
+    "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp" COPYONLY
+  )
   list(APPEND ARBORX_TEST_QUERY_TREE_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp")
-  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BF.cpp"
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BF.cpp.tmp"
     "#include <ArborX_BruteForce.hpp>\n"
     "#define ARBORX_TEST_TREE_TYPES Tuple<ArborX::BruteForce>\n"
     "#define ARBORX_TEST_DEVICE_TYPES std::tuple<${ARBORX_DEVICE_TYPES}>\n"
     "#define ARBORX_TEST_DISABLE_NEAREST_QUERY\n"
     "#define ARBORX_TEST_DISABLE_CALLBACK_EARLY_EXIT\n"
     "#include <tstQueryTree${_test}.cpp>\n"
+  )
+  configure_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BF.cpp.tmp"
+    "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BF.cpp" COPYONLY
   )
   list(APPEND ARBORX_TEST_QUERY_TREE_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BF.cpp")
 endforeach()


### PR DESCRIPTION
Note that CMake 3.18 introduces
```cmake
file(CONFIGURE OUTPUT <output-file> CONTENT <content> [...])
```