### PR TITLE
Merge all compile-only unit tests into a single executable

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,17 +41,14 @@ if(Kokkos_ENABLE_CUDA AND Boost_VERSION_MINOR GREATER_EQUAL 69)
 endif()
 
 # Compile only, nothing to run
-add_executable(ArborX_AccessTraits.exe tstAccessTraits.cpp)
-target_link_libraries(ArborX_AccessTraits.exe PRIVATE ArborX)
-
-add_executable(ArborX_Callbacks.exe tstCallbacks.cpp)
-target_link_libraries(ArborX_Callbacks.exe PRIVATE ArborX)
-
-add_executable(ArborX_DetailsConcepts.exe tstDetailsConcepts.cpp)
-target_link_libraries(ArborX_DetailsConcepts.exe PRIVATE ArborX)
-
-add_executable(ArborX_TypeRequirements.exe tstDetailsTypeRequirements.cpp)
-target_link_libraries(ArborX_TypeRequirements.exe PRIVATE ArborX)
+add_executable(ArborX_CompileOnly.exe
+  tstCompileOnlyAccessTraits.cpp
+  tstCompileOnlyCallbacks.cpp
+  tstCompileOnlyConcepts.cpp
+  tstCompileOnlyTypeRequirements.cpp
+  tstCompileOnlyMain.cpp
+)
+target_link_libraries(ArborX_CompileOnly.exe PRIVATE ArborX)
 
 add_executable(ArborX_DetailsUtils.exe tstDetailsUtils.cpp utf_main.cpp)
 # TODO link Boost::dynamic_linking interface target to enable dynamic linking

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -62,7 +62,7 @@ struct ArborX::Traits::Access<LegacyAccessTraits, Tag>
   static Point get(LegacyAccessTraits, int) { return {}; }
 };
 
-int main()
+void test_access_traits_compile_only()
 {
   Kokkos::View<ArborX::Point *> p;
   Kokkos::View<float **> v;

--- a/test/tstCompileOnlyCallbacks.cpp
+++ b/test/tstCompileOnlyCallbacks.cpp
@@ -94,7 +94,7 @@ struct LegacyNearestPredicateCallback
   }
 };
 
-int main()
+void test_callbacks_compile_only()
 {
   using ArborX::Details::check_valid_callback;
 

--- a/test/tstCompileOnlyConcepts.cpp
+++ b/test/tstCompileOnlyConcepts.cpp
@@ -11,13 +11,13 @@
 
 #include <ArborX_DetailsConcepts.hpp>
 
-#include <Kokkos_Core.hpp>
-
 #include <tuple>
+#include <type_traits>
 
-using ArborX::Details::first_template_parameter_t;
-static_assert(std::is_same<first_template_parameter_t<std::tuple<int, float>>,
-                           int>::value,
-              "");
-
-int main() {}
+void test_concepts_compile_only()
+{
+  using ArborX::Details::first_template_parameter_t;
+  static_assert(std::is_same<first_template_parameter_t<std::tuple<int, float>>,
+                             int>::value,
+                "");
+}

--- a/test/tstCompileOnlyMain.cpp
+++ b/test/tstCompileOnlyMain.cpp
@@ -1,0 +1,12 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+int main() { return 0; }

--- a/test/tstCompileOnlyTypeRequirements.cpp
+++ b/test/tstCompileOnlyTypeRequirements.cpp
@@ -62,5 +62,3 @@ void check_bounding_volume_and_predicate_geometry_type_requirements()
   tree.query(ExecutionSpace{}, nearest_predicates,
              KOKKOS_LAMBDA(NearestPredicate, int){});
 }
-
-int main() { return 0; }


### PR DESCRIPTION
Rational: reduce the number of CMake targets in the project and organize unit tests a bit better