### PR TITLE
Change API and reorganize DBSCAN structure

### DIFF
--- a/examples/dbscan/ArborX_DBSCAN.hpp
+++ b/examples/dbscan/ArborX_DBSCAN.hpp
@@ -89,38 +89,44 @@ struct DBSCANCorePoints
   }
 };
 
-template <typename ExecutionSpace, typename Primitives,
-          typename ClusterIndicesView, typename ClusterOffsetView>
-void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
-            ClusterIndicesView &cluster_indices,
-            ClusterOffsetView &cluster_offset, float eps, int core_min_size,
-            int cluster_min_size = 2, bool verbose = false, bool verify = false)
+struct Parameters
 {
-  static_assert(Kokkos::is_view<ClusterIndicesView>{}, "");
-  static_assert(Kokkos::is_view<ClusterOffsetView>{}, "");
-  static_assert(std::is_same<typename ClusterIndicesView::value_type, int>{},
-                "");
-  static_assert(std::is_same<typename ClusterOffsetView::value_type, int>{},
-                "");
+  // Print timers to standard output
+  bool _print_timers = false;
+
+  Parameters &setPrintTimers(bool print_timers)
+  {
+    _print_timers = print_timers;
+    return *this;
+  }
+};
+
+} // namespace DBSCAN
+
+template <typename ExecutionSpace, typename Primitives, typename LabelsView>
+void dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
+            float eps, int core_min_size, LabelsView &labels,
+            DBSCAN::Parameters const &parameters = DBSCAN::Parameters())
+{
+  Kokkos::Profiling::pushRegion("ArborX::dbscan");
+
+  static_assert(Kokkos::is_view<LabelsView>{}, "");
 
   using MemorySpace = typename Primitives::memory_space;
-  static_assert(
-      std::is_same<typename ClusterIndicesView::memory_space, MemorySpace>{},
-      "");
-  static_assert(
-      std::is_same<typename ClusterOffsetView::memory_space, MemorySpace>{},
-      "");
 
+  static_assert(std::is_same<typename LabelsView::value_type, int>{}, "");
+  static_assert(std::is_same<typename LabelsView::memory_space, MemorySpace>{},
+                "");
+
+  ARBORX_ASSERT(eps > 0);
   ARBORX_ASSERT(core_min_size >= 2);
-  ARBORX_ASSERT(cluster_min_size >= 2);
+
   bool const is_special_case = (core_min_size == 2);
 
-  Kokkos::Profiling::pushRegion("ArborX::DBSCAN");
-
-  Kokkos::Timer timer_total;
   Kokkos::Timer timer;
   std::map<std::string, double> elapsed;
 
+  bool const verbose = parameters._print_timers;
   auto timer_start = [&exec_space, verbose](Kokkos::Timer &timer) {
     if (verbose)
       exec_space.fence();
@@ -132,36 +138,31 @@ void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
     return timer.seconds();
   };
 
-  timer_start(timer_total);
-
   auto const predicates = buildPredicates(primitives, eps);
 
   int const n = primitives.extent_int(0);
 
   // Build the tree
   timer_start(timer);
-  Kokkos::Profiling::pushRegion("ArborX::DBSCAN::tree_construction");
+  Kokkos::Profiling::pushRegion("ArborX::dbscan::tree_construction");
   ArborX::BVH<MemorySpace> bvh(exec_space, primitives);
   Kokkos::Profiling::popRegion();
   elapsed["construction"] = timer_seconds(timer);
 
   timer_start(timer);
-  Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters");
+  Kokkos::Profiling::pushRegion("ArborX::dbscan::clusters");
 
-  Kokkos::View<int *, MemorySpace> stat(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, "ArborX::DBSCAN::stat"),
-      n);
-  ArborX::iota(exec_space, stat);
+  Kokkos::resize(Kokkos::WithoutInitializing, labels, n);
+  ArborX::iota(exec_space, labels);
   if (is_special_case)
   {
     // Perform the queries and build clusters through callback
-
-    using CorePoints = CCSCorePoints;
+    using CorePoints = DBSCAN::CCSCorePoints;
     CorePoints core_points;
-    Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters::query");
+    Kokkos::Profiling::pushRegion("ArborX::dbscan::clusters::query");
     bvh.query(
         exec_space, predicates,
-        Details::DBSCANCallback<MemorySpace, CorePoints>{stat, core_points});
+        Details::DBSCANCallback<MemorySpace, CorePoints>{labels, core_points});
     Kokkos::Profiling::popRegion();
   }
   else
@@ -169,22 +170,23 @@ void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
     // Determine core points
     Kokkos::Timer timer_local;
     timer_start(timer_local);
-    Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters::num_neigh");
-    Kokkos::View<int *, MemorySpace> num_neigh("ArborX::DBSCAN::num_neighbors",
+    Kokkos::Profiling::pushRegion("ArborX::dbscan::clusters::num_neigh");
+    Kokkos::View<int *, MemorySpace> num_neigh("ArborX::dbscan::num_neighbors",
                                                n);
     bvh.query(exec_space, predicates,
-              NumNeighEarlyExitCallback<MemorySpace>{num_neigh, core_min_size});
+              DBSCAN::NumNeighEarlyExitCallback<MemorySpace>{num_neigh,
+                                                             core_min_size});
     Kokkos::Profiling::popRegion();
     elapsed["neigh"] = timer_seconds(timer_local);
 
-    using CorePoints = DBSCANCorePoints<MemorySpace>;
+    using CorePoints = DBSCAN::DBSCANCorePoints<MemorySpace>;
 
     // Perform the queries and build clusters through callback
     timer_start(timer_local);
-    Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters:query");
+    Kokkos::Profiling::pushRegion("ArborX::dbscan::clusters:query");
     bvh.query(exec_space, predicates,
               Details::DBSCANCallback<MemorySpace, CorePoints>{
-                  stat, CorePoints{num_neigh, core_min_size}});
+                  labels, CorePoints{num_neigh, core_min_size}});
     Kokkos::Profiling::popRegion();
     elapsed["query"] = timer_seconds(timer_local);
   }
@@ -195,114 +197,25 @@ void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
   // The finalization kernel will, ultimately, make all parents
   // point directly to the representative.
   // ```
-  Kokkos::parallel_for("ArborX::DBSCAN::flatten_stat",
+  Kokkos::parallel_for("ArborX::dbscan::finalize_labels",
                        Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
                        KOKKOS_LAMBDA(int const i) {
                          // ##### ECL license (see LICENSE.ECL) #####
                          int next;
-                         int vstat = stat(i);
+                         int vstat = labels(i);
                          int const old = vstat;
-                         while (vstat > (next = stat(vstat)))
+                         while (vstat > (next = labels(vstat)))
                          {
                            vstat = next;
                          }
                          if (vstat != old)
-                           stat(i) = vstat;
+                           labels(i) = vstat;
                        });
   Kokkos::Profiling::popRegion();
   elapsed["query+cluster"] = timer_seconds(timer);
 
-  // Use new name to clearly demonstrate the meaning of this view from now on
-  auto const &clusters = stat;
-
-  if (verify)
-  {
-    timer_start(timer);
-    Kokkos::Profiling::pushRegion("ArborX::DBSCAN::verify");
-
-    Kokkos::View<int *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
-    Kokkos::View<int *, MemorySpace> offset("ArborX::DBSCAN::offset", 0);
-    ArborX::query(bvh, exec_space, predicates, indices, offset);
-
-    auto passed = Details::verifyClusters(exec_space, indices, offset, clusters,
-                                          core_min_size);
-    printf("Verification %s\n", (passed ? "passed" : "failed"));
-
-    Kokkos::Profiling::popRegion();
-    elapsed["verify"] = timer_seconds(timer);
-  }
-
-  // find clusters
-  timer_start(timer);
-  Kokkos::Profiling::pushRegion("ArborX::DBSCAN::sort_and_filter_clusters");
-
-  Kokkos::View<int *, MemorySpace> cluster_sizes(
-      "ArborX::DBSCAN::cluster_sizes", n);
-  Kokkos::parallel_for("ArborX::DBSCAN::compute_cluster_sizes",
-                       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
-                       KOKKOS_LAMBDA(int const i) {
-                         Kokkos::atomic_fetch_add(&cluster_sizes(clusters(i)),
-                                                  1);
-                       });
-
-  // This kernel serves dual purpose:
-  // - it constructs an offset array through exclusive prefix sum, with a
-  //   caveat that small clusters (of size < cluster_min_size) are filtered out
-  // - it creates a mapping from a cluster index into the cluster's position in
-  //   the offset array
-  // We reuse the cluster_sizes array for the second, creating a new alias for
-  // it for clarity.
-  auto &map_cluster_to_offset_position = cluster_sizes;
-  int constexpr IGNORED_CLUSTER = -1;
-  int num_clusters;
-  reallocWithoutInitializing(cluster_offset, n + 1);
-  Kokkos::parallel_scan(
-      "ArborX::DBSCAN::compute_cluster_offset_with_filter",
-      Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
-      KOKKOS_LAMBDA(int const i, int &update, bool final_pass) {
-        bool is_cluster_too_small = (cluster_sizes(i) < cluster_min_size);
-        if (!is_cluster_too_small)
-        {
-          if (final_pass)
-          {
-            cluster_offset(update) = cluster_sizes(i);
-            map_cluster_to_offset_position(i) = update;
-          }
-          ++update;
-        }
-        else
-        {
-          if (final_pass)
-            map_cluster_to_offset_position(i) = IGNORED_CLUSTER;
-        }
-      },
-      num_clusters);
-  Kokkos::resize(Kokkos::WithoutInitializing, cluster_offset, num_clusters + 1);
-  exclusivePrefixSum(exec_space, cluster_offset);
-
-  auto cluster_starts = clone(exec_space, cluster_offset);
-  reallocWithoutInitializing(cluster_indices, lastElement(cluster_offset));
-  Kokkos::parallel_for("ArborX::DBSCAN::compute_cluster_indices",
-                       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
-                       KOKKOS_LAMBDA(int const i) {
-                         auto offset_pos =
-                             map_cluster_to_offset_position(clusters(i));
-                         if (offset_pos != IGNORED_CLUSTER)
-                         {
-                           auto position = Kokkos::atomic_fetch_add(
-                               &cluster_starts(offset_pos), 1);
-                           cluster_indices(position) = i;
-                         }
-                       });
-
-  Kokkos::Profiling::popRegion();
-  elapsed["cluster"] = timer_seconds(timer);
-
-  elapsed["total"] = timer_seconds(timer_total) - elapsed["verify"];
-
   if (verbose)
   {
-    printf("total time          : %10.3f\n", elapsed["total"]);
     printf("-- construction     : %10.3f\n", elapsed["construction"]);
     printf("-- query+cluster    : %10.3f\n", elapsed["query+cluster"]);
     if (!is_special_case)
@@ -310,15 +223,11 @@ void dbscan(ExecutionSpace exec_space, Primitives const &primitives,
       printf("---- neigh          : %10.3f\n", elapsed["neigh"]);
       printf("---- query          : %10.3f\n", elapsed["query"]);
     }
-    printf("-- postprocess      : %10.3f\n", elapsed["cluster"]);
-    if (verify)
-      printf("verify              : %10.3f\n", elapsed["verify"]);
   }
 
   Kokkos::Profiling::popRegion();
 }
 
-} // namespace DBSCAN
 } // namespace ArborX
 
 #endif

--- a/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
+++ b/examples/dbscan/ArborX_DetailsDBSCANVerification.hpp
@@ -65,7 +65,8 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
   return (num_incorrect == 0);
 }
 
-// Check that boundary points share index with at least one core point
+// Check that boundary points share index with at least one core point, and
+// that noise points have index -1
 template <typename ExecutionSpace, typename IndicesView, typename OffsetView,
           typename LabelsView>
 bool verifyBoundaryAndNoisePoints(ExecutionSpace const &exec_space,
@@ -101,12 +102,20 @@ bool verifyBoundaryAndNoisePoints(ExecutionSpace const &exec_space,
             }
           }
 
+          // Boundary point must be connected to a core point
           if (is_boundary && !have_shared_core)
           {
 #ifndef __SYCL_DEVICE_ONLY__
-            printf("Boundary point does not belong to a cluster: "
-                   "%d [%d]\n",
-                   i, clusters(i));
+            printf("Boundary point does not belong to a cluster: %d [%d]\n", i,
+                   labels(i));
+#endif
+            update++;
+          }
+          // Noise points must have index -1
+          if (!is_boundary && labels(i) != -1)
+          {
+#ifndef __SYCL_DEVICE_ONLY__
+            printf("Noise point does have index -1: %d [%d]\n", i, labels(i));
 #endif
             update++;
           }

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -284,8 +284,8 @@ int main(int argc, char *argv[])
 
   Kokkos::ScopeGuard guard(argc, argv);
 
-  std::cout << "ArborX version: " << ArborX::version() << std::endl;
-  std::cout << "ArborX hash   : " << ArborX::gitCommitHash() << std::endl;
+  std::cout << "ArborX version    : " << ArborX::version() << std::endl;
+  std::cout << "ArborX hash       : " << ArborX::gitCommitHash() << std::endl;
 
   namespace bpo = boost::program_options;
 
@@ -323,6 +323,16 @@ int main(int argc, char *argv[])
     std::cout << desc << '\n';
     return 1;
   }
+
+  // Print out the runtime parameters
+  printf("eps               : %f\n", eps);
+  printf("minpts            : %d\n", core_min_size);
+  printf("cluster min size  : %d\n", cluster_min_size);
+  printf("filename          : %s [%s, max_pts = %d]\n", filename.c_str(),
+         (binary ? "binary" : "text"), max_num_points);
+  printf("verify            : %s\n", (verify ? "true" : "false"));
+  printf("print timers      : %s\n", (print_dbscan_timers ? "true" : "false"));
+  printf("output centers    : %s\n", (print_sizes_centers ? "true" : "false"));
 
   // read in data
   auto const primitives = vec2view<MemorySpace>(

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -135,6 +135,10 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
   Kokkos::parallel_for("ArborX::DBSCAN::compute_cluster_sizes",
                        Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
                        KOKKOS_LAMBDA(int const i) {
+                         // Ignore noise points
+                         if (labels(i) < 0)
+                           return;
+
                          Kokkos::atomic_fetch_add(&cluster_sizes(labels(i)), 1);
                        });
 
@@ -179,6 +183,10 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
   Kokkos::parallel_for("ArborX::DBSCAN::compute_cluster_indices",
                        Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
                        KOKKOS_LAMBDA(int const i) {
+                         // Ignore noise points
+                         if (labels(i) < 0)
+                           return;
+
                          auto offset_pos =
                              map_cluster_to_offset_position(labels(i));
                          if (offset_pos != IGNORED_CLUSTER)

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -21,7 +21,8 @@
 #include <fstream>
 
 std::vector<ArborX::Point> parsePoints(std::string const &filename,
-                                       bool binary = false)
+                                       bool binary = false,
+                                       int max_num_points = -1)
 {
   std::cout << "Reading in \"" << filename << "\" in "
             << (binary ? "binary" : "text") << " mode...";
@@ -65,6 +66,13 @@ std::vector<ArborX::Point> parsePoints(std::string const &filename,
     input.read(reinterpret_cast<char *>(z.data()), num_points * sizeof(float));
   }
   input.close();
+  if (max_num_points != -1)
+  {
+    num_points = std::min(num_points, max_num_points);
+    x.resize(num_points);
+    y.resize(num_points);
+    z.resize(num_points);
+  }
   std::cout << "done\nRead in " << num_points << " points" << std::endl;
 
   std::vector<ArborX::Point> v(num_points);
@@ -281,6 +289,7 @@ int main(int argc, char *argv[])
   float eps;
   int cluster_min_size;
   int core_min_size;
+  int max_num_points;
 
   bpo::options_description desc("Allowed options");
   // clang-format off
@@ -288,6 +297,7 @@ int main(int argc, char *argv[])
       ( "help", "help message" )
       ( "filename", bpo::value<std::string>(&filename), "filename containing data" )
       ( "binary", bpo::bool_switch(&binary)->default_value(false), "binary file indicator")
+      ( "max-num-points", bpo::value<int>(&max_num_points)->default_value(-1), "max number of points to read in")
       ( "eps", bpo::value<float>(&eps), "DBSCAN eps" )
       ( "cluster-min-size", bpo::value<int>(&cluster_min_size)->default_value(2), "minimum cluster size")
       ( "core-min-size", bpo::value<int>(&core_min_size)->default_value(2), "DBSCAN min_pts")
@@ -307,8 +317,8 @@ int main(int argc, char *argv[])
   }
 
   // read in data
-  auto const primitives =
-      vec2view<MemorySpace>(parsePoints(filename, binary), "primitives");
+  auto const primitives = vec2view<MemorySpace>(
+      parsePoints(filename, binary, max_num_points), "primitives");
 
   ExecutionSpace exec_space;
 

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -348,9 +348,8 @@ int main(int argc, char *argv[])
 
   timer_start(timer_total);
 
-  Kokkos::View<int *, MemorySpace> labels("Testing::labels", 0);
-  ArborX::dbscan(
-      exec_space, primitives, eps, core_min_size, labels,
+  auto labels = ArborX::dbscan(
+      exec_space, primitives, eps, core_min_size,
       ArborX::DBSCAN::Parameters().setPrintTimers(print_dbscan_timers));
 
   timer_start(timer);


### PR DESCRIPTION
Trying to align DBSCAN API with [Python DBSCAN package](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html) and [R DBSCAN package](https://cran.r-project.org/web/packages/dbscan/index.html). The goal is to simplify the main `dbscan()` call API, and allow to easily extend its functionality.

- Main `dbscan` call signature was aligned more with other implementations
- A new `DBSCAN::Parameters` was introduced to expand functionality later
- Main `dbscan` call now returns labels
  This is similar to dbscan implementations in Python and R
- Verify was moved out of the main dbscan call
- Computing cluster CRS graph was now moved into the main file
  It is unclear whether that's the final form, but as it is unknown, it
  should not live in ArborX space right now
- Noise is marked as `-1`
  This introduced an additional kernel launch and extra memory array (`cluster_sizes`). I have not observed any noticable difference in performance.

Remaining things to discuss:
- Both Python and R packages return a DBSCAN structure as a result to `dbscan` call. The structure contains `eps`, `minpts`, `labels`, and possibly `core_indices`. I'm not sure why. It may be because of their ML nature, somehow.
- Should `labels` be passed as a reference argument, or returned as view?
- Where should conversion of CRS graph live? I would be fine leaving it outside of `ArborX` namespace.
- Both Python and R packages allow `X` argument (primitives for us so far) to also be a distance matrix. I don't think it is necessary for us at this point.