### PR TITLE
Avoid cluttering the console log in annotations tests

### DIFF
--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, const char *label,
          void const * /*ptr*/, uint64_t /*size*/) {
-        std::cout << label << '\n';
+        BOOST_TEST_MESSAGE(label);
         BOOST_TEST(
             (isPrefixedWith(label, "ArborX::BVH::") || // data member
              isPrefixedWith(label, "ArborX::BVH::BVH::") ||
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_query_allocations_prefixed, DeviceType,
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, const char *label,
          void const * /*ptr*/, uint64_t /*size*/) {
-        std::cout << label << '\n';
+        BOOST_TEST_MESSAGE(label);
         BOOST_TEST(
             (isPrefixedWith(label, "ArborX::BVH::query::") ||
              isPrefixedWith(label, "ArborX::TreeTraversal::spatial::") ||
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   auto const callback = [](char const *label, uint32_t, uint64_t *) {
-    std::cout << label << '\n';
+    BOOST_TEST_MESSAGE(label);
     BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
                 isPrefixedWith(label, "Kokkos::")));
   };
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
-    std::cout << label << '\n';
+    BOOST_TEST_MESSAGE(label);
     BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
                 isPrefixedWith(label, "Kokkos::")));
   });

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, const char *label,
          void const * /*ptr*/, uint64_t /*size*/) {
-        std::cout << label << '\n';
+        BOOST_TEST_MESSAGE(label);
         BOOST_TEST((isPrefixedWith(label, "ArborX::DistributedTree::") ||
                     isPrefixedWith(label, "ArborX::BVH::") ||
                     isPrefixedWith(label, "ArborX::Sorting::") ||
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, const char *label,
          void const * /*ptr*/, uint64_t /*size*/) {
-        std::cout << label << '\n';
+        BOOST_TEST_MESSAGE(label);
         BOOST_TEST((isPrefixedWith(label, "ArborX::DistributedTree::query::") ||
                     isPrefixedWith(label, "ArborX::Distributor::") ||
                     isPrefixedWith(label, "ArborX::BVH::query::") ||
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   auto const callback = [](char const *label, uint32_t, uint64_t *) {
-    std::cout << label << '\n';
+    BOOST_TEST_MESSAGE(label);
     BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
                 isPrefixedWith(label, "Kokkos::")));
   };
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
-    std::cout << label << '\n';
+    BOOST_TEST_MESSAGE(label);
     BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
                 isPrefixedWith(label, "Kokkos::")));
   });


### PR DESCRIPTION
Use `BOOST_TEST_MESSAGE` instead of printing to the standard outpout.
One can pass `--log_level=message` to get the verbose output.