### PR TITLE
Fixup isValid(Box) geometry algorithm

### DIFF
--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -59,7 +59,14 @@ bool isValid(Point const &p)
 KOKKOS_INLINE_FUNCTION
 bool isValid(Box const &b)
 {
-  return isValid(b.minCorner()) && isValid(b.maxCorner());
+  using KokkosExt::isFinite;
+  for (int d = 0; d < 3; ++d)
+  {
+    auto const r_d = b.maxCorner()[d] - b.minCorner()[d];
+    if (r_d < 0 || !isFinite(r_d))
+      return false;
+  }
+  return true;
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/src/details/ArborX_DetailsAlgorithms.hpp
+++ b/src/details/ArborX_DetailsAlgorithms.hpp
@@ -63,7 +63,7 @@ bool isValid(Box const &b)
   for (int d = 0; d < 3; ++d)
   {
     auto const r_d = b.maxCorner()[d] - b.minCorner()[d];
-    if (r_d < 0 || !isFinite(r_d))
+    if (r_d <= 0 || !isFinite(r_d))
       return false;
   }
   return true;

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -148,10 +148,8 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(!bg::is_valid(empty_box, message));
   BOOST_TEST(message == "Box has corners in wrong order");
 
-  // NOTE infinitesimal box around a point (here the origin) is considered as
-  // valid in ArborX but it is not according to Boost.Geometry
   details::Box a_box = {{{0., 0., 0.}}, {{0., 0., 0.}}};
-  BOOST_TEST(details::isValid(a_box));
+  BOOST_TEST(!details::isValid(a_box));
   BOOST_TEST(!bg::is_valid(a_box, message));
   BOOST_TEST(message == "Geometry has wrong topological dimension");
 

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -142,15 +142,14 @@ BOOST_AUTO_TEST_CASE(centroid)
 
 BOOST_AUTO_TEST_CASE(is_valid)
 {
-  // NOTE "empty" box is considered as valid in ArborX but it is
-  // not according to Boost.Geometry
   details::Box empty_box = {};
-  BOOST_TEST(details::isValid(empty_box));
+  BOOST_TEST(!details::isValid(empty_box));
   std::string message;
   BOOST_TEST(!bg::is_valid(empty_box, message));
   BOOST_TEST(message == "Box has corners in wrong order");
 
-  // Same issue with infinitesimal box around a point (here the origin)
+  // NOTE infinitesimal box around a point (here the origin) is considered as
+  // valid in ArborX but it is not according to Boost.Geometry
   details::Box a_box = {{{0., 0., 0.}}, {{0., 0., 0.}}};
   BOOST_TEST(details::isValid(a_box));
   BOOST_TEST(!bg::is_valid(a_box, message));
@@ -165,11 +164,26 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(!bg::is_valid(invalid_box, message));
   BOOST_TEST(message == "Geometry has point(s) with invalid coordinate(s)");
 
+  details::Box other_invalid_box = {{{1., 5., 3.}}, {{4., 3., 6.}}};
+  BOOST_TEST(!details::isValid(other_invalid_box));
+  BOOST_TEST(!bg::is_valid(other_invalid_box, message));
+  BOOST_TEST(message == "Box has corners in wrong order");
+
+  auto const infty = std::numeric_limits<double>::infinity();
+  other_invalid_box = {{{1., 5., 3.}}, {{infty, 3., 6.}}};
+  BOOST_TEST(!details::isValid(other_invalid_box));
+  BOOST_TEST(!bg::is_valid(other_invalid_box, message));
+  BOOST_TEST(message == "Geometry has point(s) with invalid coordinate(s)");
+
+  other_invalid_box = {{{1., 5., infty}}, {{4., 3., 6.}}};
+  BOOST_TEST(!details::isValid(other_invalid_box));
+  BOOST_TEST(!bg::is_valid(other_invalid_box, message));
+  BOOST_TEST(message == "Geometry has point(s) with invalid coordinate(s)");
+
   details::Point a_point = {{1., 2., 3.}};
   BOOST_TEST(details::isValid(a_point));
   BOOST_TEST(bg::is_valid(a_point));
 
-  auto const infty = std::numeric_limits<double>::infinity();
   details::Point invalid_point = {{infty, 1.41, 3.14}};
   BOOST_TEST(!details::isValid(invalid_point));
   BOOST_TEST(!bg::is_valid(invalid_point, message));
@@ -181,6 +195,7 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(!bg::is_empty(empty_box));
   BOOST_TEST(!bg::is_empty(a_box));
   BOOST_TEST(!bg::is_empty(unit_box));
+  BOOST_TEST(!bg::is_empty(a_point));
 }
 
 BOOST_AUTO_TEST_CASE(intersects)

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -164,7 +164,10 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(isValid(Box{{{0., 0., 0.}}, {{0., 0., 0.}}}));
   BOOST_TEST(!isValid(Box{{{0., 0., -infty}}, {{0., 0., 0.}}}));
   BOOST_TEST(!isValid(Box{{{0., 0., 0.}}, {{+infty, 0., 0.}}}));
-  BOOST_TEST(isValid(Box{}));
+  BOOST_TEST(!isValid(Box{}));
+  BOOST_TEST(!isValid(Box{{{1., 1., 1.}}, {{0., 0., 0.}}}));
+  BOOST_TEST(!isValid(Box{{{0., 0., 1.}}, {{0., 0., 0.}}}));
+  BOOST_TEST(!isValid(Box{{{0., 0., 0.}}, {{-1, 0., 0.}}}));
 
   BOOST_TEST(isValid(Sphere{{{1., 2., 3.}}, 4.}));
   BOOST_TEST(isValid(Sphere{{{0., 0., 0.}}, 0.}));

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(!isValid(Point{{0., infty, 0.}}));
 
   BOOST_TEST(isValid(Box{{{1., 2., 3.}}, {{4., 5., 6.}}}));
-  BOOST_TEST(isValid(Box{{{0., 0., 0.}}, {{0., 0., 0.}}}));
+  BOOST_TEST(!isValid(Box{{{0., 0., 0.}}, {{0., 0., 0.}}}));
   BOOST_TEST(!isValid(Box{{{0., 0., -infty}}, {{0., 0., 0.}}}));
   BOOST_TEST(!isValid(Box{{{0., 0., 0.}}, {{+infty, 0., 0.}}}));
   BOOST_TEST(!isValid(Box{}));


### PR DESCRIPTION
The goal of these changes is better alignment with Boost.Geometry

What motivated looking into this was a discussion on the kDOP PR that `isValid(Box{})` was returning `true` which we agreed was surprising.
There was no clear agreement on what should return `isValid(Box{p, p})`.  I propose we follow [Boost.Geometry](https://www.boost.org/doc/libs/1_75_0/libs/geometry/doc/html/geometry/reference/algorithms/is_valid/is_valid_2_with_failure_value.html) for now and revisit later if needs to be.