### PR TITLE
Cleanup query tree unit tests

### DIFF
--- a/test/ArborXTest_TreeTypeTraits.hpp
+++ b/test/ArborXTest_TreeTypeTraits.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012-2021 by the ArborX authors                            *
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -18,9 +18,9 @@
 #include "boost_ext/CompressedStorageComparison.hpp"
 // clang-format on
 
-#include "ArborX_BoostRTreeHelpers.hpp"
 #include "ArborX_EnableViewComparison.hpp"
 #ifdef ARBORX_ENABLE_MPI
+#include "ArborX_BoostRTreeHelpers.hpp"
 #include <ArborX_DistributedTree.hpp>
 #endif
 

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012-2021 by the ArborX authors                            *
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -9,8 +9,6 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include <ArborX_LinearBVH.hpp>
-
 #include <boost/test/unit_test.hpp>
 
 #include <numeric>

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012-2021 by the ArborX authors                            *
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <functional>
-#include <iostream>
 #include <random>
 
 #include "Search_UnitTestHelpers.hpp"

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -10,7 +10,6 @@
  ****************************************************************************/
 
 #include "ArborX_BoostRTreeHelpers.hpp"
-#include <ArborX_LinearBVH.hpp>
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012-2021 by the ArborX authors                            *
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -9,8 +9,6 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include <ArborX_LinearBVH.hpp>
-
 #include <boost/test/unit_test.hpp>
 
 #include <vector>

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012-2021 by the ArborX authors                            *
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -9,8 +9,6 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include <ArborX_LinearBVH.hpp>
-
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>

--- a/test/tstQueryTreeTraversalPolicy.cpp
+++ b/test/tstQueryTreeTraversalPolicy.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2012-2021 by the ArborX authors                            *
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *


### PR DESCRIPTION
Fixing up typo in the copyrights and a few unnecessary header includes spotted on the kDOP PR