### PR TITLE
Require CMake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 project(ArborX CXX)
 
 find_package(Kokkos 3.1 REQUIRED)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN KEYDUMP_URL=https://cloud.cees.ornl.gov/download && \
 
 # Install CMake
 ENV CMAKE_DIR=/opt/cmake
-RUN CMAKE_VERSION=3.13.4 && \
+RUN CMAKE_VERSION=3.16.9 && \
     CMAKE_KEY=2D2CEF1034921684 && \
     CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
     CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \

--- a/docker/Dockerfile.pgi
+++ b/docker/Dockerfile.pgi
@@ -38,7 +38,7 @@ RUN KEYDUMP_URL=https://cloud.cees.ornl.gov/download && \
 
 # Install CMake
 ENV CMAKE_DIR=/opt/cmake
-RUN CMAKE_VERSION=3.13.4 && \
+RUN CMAKE_VERSION=3.16.9 && \
     CMAKE_KEY=2D2CEF1034921684 && \
     CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
     CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \


### PR DESCRIPTION
Per our discussion at the developers meeting.
Kokkos also [requires 3.16 as the minimum version](https://github.com/kokkos/kokkos/blob/897b79da51c1719b620990de4eabba154094bffe/CMakeLists.txt#L75) and I would like several features that are only available from that version (target-dependent generator expression in `add_test`, support for faster builds, etc.)