### PR TITLE
Update SYCL in CI to fix building the compiler

### DIFF
--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -43,7 +43,7 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV SYCL_DIR=/opt/sycl
-RUN SYCL_VERSION=20201207 && \
+RUN SYCL_VERSION=20210303 && \
     SYCL_URL=https://github.com/intel/llvm/archive/sycl-nightly && \
     SYCL_ARCHIVE=${SYCL_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \


### PR DESCRIPTION
CI in https://github.com/arborx/ArborX/pull/486 fails since the SYCL compiler can't be built. We had the same problem in Kokkos and using this newer version helped to fix it.