### PR TITLE
Adding couple features to DBSCAN cmd line interface

### DIFF
--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -97,7 +97,7 @@ std::vector<ArborX::Point> sampleData(std::vector<ArborX::Point> const &data,
     int rn = N - in;
     int rm = M - im;
     if (rand() % rn < rm)
-      sampled_data[im++] = data[in + 1];
+      sampled_data[im++] = data[in];
   }
   return sampled_data;
 }

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -84,6 +84,21 @@ std::vector<ArborX::Point> parsePoints(std::string const &filename,
   return v;
 }
 
+template <typename MemorySpace>
+void writeLabelsData(std::string const &filename,
+                     Kokkos::View<int *, MemorySpace> labels)
+{
+  std::ofstream out(filename, std::ofstream::binary);
+  ARBORX_ASSERT(out.good());
+
+  auto labels_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, labels);
+
+  int n = labels_host.size();
+  out.write((char *)&n, sizeof(int));
+  out.write((char *)labels_host.data(), sizeof(int) * n);
+}
+
 template <typename... P, typename T>
 auto vec2view(std::vector<T> const &in, std::string const &label = "")
 {
@@ -299,6 +314,7 @@ int main(int argc, char *argv[])
   int core_min_size;
   int max_num_points;
   int num_samples;
+  std::string filename_labels;
 
   bpo::options_description desc("Allowed options");
   // clang-format off
@@ -312,6 +328,7 @@ int main(int argc, char *argv[])
       ( "core-min-size", bpo::value<int>(&core_min_size)->default_value(2), "DBSCAN min_pts")
       ( "verify", bpo::bool_switch(&verify)->default_value(false), "verify connected components")
       ( "samples", bpo::value<int>(&num_samples)->default_value(-1), "number of samples" )
+      ( "labels", bpo::value<std::string>(&filename_labels)->default_value(""), "clutering results output" )
       ( "print-dbscan-timers", bpo::bool_switch(&print_dbscan_timers)->default_value(false), "print dbscan timers")
       ( "output-sizes-and-centers", bpo::bool_switch(&print_sizes_centers)->default_value(false), "print cluster sizes and centers")
       ;
@@ -332,6 +349,7 @@ int main(int argc, char *argv[])
   printf("cluster min size  : %d\n", cluster_min_size);
   printf("filename          : %s [%s, max_pts = %d]\n", filename.c_str(),
          (binary ? "binary" : "text"), max_num_points);
+  printf("filename [labels] : %s [binary]\n", filename_labels.c_str());
   printf("samples           : %d\n", num_samples);
   printf("verify            : %s\n", (verify ? "true" : "false"));
   printf("print timers      : %s\n", (print_dbscan_timers ? "true" : "false"));
@@ -400,6 +418,9 @@ int main(int argc, char *argv[])
                                                 core_min_size, labels);
     printf("Verification %s\n", (passed ? "passed" : "failed"));
   }
+
+  if (filename_labels != "")
+    writeLabelsData(filename_labels, labels);
 
   if (print_sizes_centers)
     printClusterSizesAndCenters(exec_space, primitives, cluster_indices,

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -84,6 +84,24 @@ std::vector<ArborX::Point> parsePoints(std::string const &filename,
   return v;
 }
 
+std::vector<ArborX::Point> sampleData(std::vector<ArborX::Point> &data,
+                                      int num_samples)
+{
+  std::vector<ArborX::Point> sampled_data(num_samples);
+
+  // Knuth algorithm
+  auto const N = (int)data.size();
+  auto const M = num_samples;
+  for (int in = 0, im = 0; in < N && im < M; ++in)
+  {
+    int rn = N - in;
+    int rm = M - im;
+    if (rand() % rn < rm)
+      sampled_data[im++] = data[in + 1];
+  }
+  return sampled_data;
+}
+
 template <typename MemorySpace>
 void writeLabelsData(std::string const &filename,
                      Kokkos::View<int *, MemorySpace> labels)
@@ -359,21 +377,7 @@ int main(int argc, char *argv[])
   std::vector<ArborX::Point> data =
       parsePoints(filename, binary, max_num_points);
   if (num_samples > 0 && num_samples < (int)data.size())
-  {
-    std::vector<ArborX::Point> sampled_data(num_samples);
-
-    // Knuth algorithm
-    auto const N = (int)data.size();
-    auto const M = num_samples;
-    for (int in = 0, im = 0; in < N && im < M; ++in)
-    {
-      int rn = N - in;
-      int rm = M - im;
-      if (rand() % rn < rm)
-        sampled_data[im++] = data[in + 1];
-    }
-    data = sampled_data;
-  }
+    data = sampleData(data, num_samples);
   auto const primitives = vec2view<MemorySpace>(data, "primitives");
 
   ExecutionSpace exec_space;

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -84,7 +84,7 @@ std::vector<ArborX::Point> parsePoints(std::string const &filename,
   return v;
 }
 
-std::vector<ArborX::Point> sampleData(std::vector<ArborX::Point> &data,
+std::vector<ArborX::Point> sampleData(std::vector<ArborX::Point> const &data,
                                       int num_samples)
 {
   std::vector<ArborX::Point> sampled_data(num_samples);
@@ -423,7 +423,7 @@ int main(int argc, char *argv[])
     printf("Verification %s\n", (passed ? "passed" : "failed"));
   }
 
-  if (filename_labels != "")
+  if (!filename_labels.empty())
     writeLabelsData(filename_labels, labels);
 
   if (print_sizes_centers)


### PR DESCRIPTION
- Sampling
  Allows to select a random subset of the read in set. The random nature allows to preserve the basis characteristics, while the sample size allows to control the size. Useful for comparison with other codes that are unable to run full datasets, or to perform scaling studies on a single dataset. The caveat is that typically increasing sampling increases density.
- Saving labels
  Saving labels allows to later visualize the clustering results if given together with the data file.