### PR TITLE
Modify testing queries when comparing with Boost for kNN

### DIFF
--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -235,6 +235,28 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate, TreeTypeTraits,
   }
 
   {
+    auto sources = make_random_cloud<ArborX::Point>(Lx, Ly, Lz, nx * ny * nz);
+    // Make seed the size of the point cloud for the tree. This way we
+    // guarantee that the query points are different from the tree points.
+    int const seed = sources.size();
+    auto targets =
+        make_random_cloud<ArborX::Point>(Lx, Ly, Lz, n_queries, seed);
+
+    std::vector<int> ks(n_queries);
+    std::default_random_engine generator;
+    std::uniform_int_distribution<int> distribution_k(
+        1, std::floor(sqrt(nx * nx + ny * ny + nz * nz)));
+    for (unsigned int i = 0; i < n_queries; ++i)
+    {
+      // make sure that at least few have k = 1 (common use case)
+      bool const use_k1 = (i == 0 || (i % 13 == 0));
+      ks[i] = (!use_k1 ? distribution_k(generator) : 1);
+    }
+
+    test_nearest_predicate<Tree, DeviceType>(sources, targets, ks);
+  }
+
+  {
     auto sources = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
     auto targets = make_random_cloud<ArborX::Box>(Lx, Ly, Lz, n_queries);
 

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -51,11 +51,11 @@ make_random_cloud(double Lx, double Ly, double Lz, int n);
 
 template <>
 inline Kokkos::View<ArborX::Point *, Kokkos::HostSpace>
-make_random_cloud(double Lx, double Ly, double Lz, int n)
+make_random_cloud(double Lx, double Ly, double Lz, int n, int seed = 0)
 {
   Kokkos::View<ArborX::Point *, Kokkos::HostSpace> cloud(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "random_cloud"), n);
-  std::default_random_engine generator;
+  std::default_random_engine generator(seed);
   std::uniform_real_distribution<double> distribution_x(0.0, Lx);
   std::uniform_real_distribution<double> distribution_y(0.0, Ly);
   std::uniform_real_distribution<double> distribution_z(0.0, Lz);

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(ComparisonWithBoost)
 namespace tt = boost::test_tools;
 
 inline std::vector<ArborX::Point>
-make_stuctured_cloud(double Lx, double Ly, double Lz, int nx, int ny, int nz)
+make_structured_cloud(double Lx, double Ly, double Lz, int nx, int ny, int nz)
 {
   std::function<int(int, int, int)> ind = [nx, ny](int i, int j, int k) {
     return i + j * nx + k * (nx * ny);
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
   int const n_queries = 100;
 
   {
-    auto sources = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+    auto sources = make_structured_cloud(Lx, Ly, Lz, nx, ny, nz);
     auto targets = make_random_cloud<ArborX::Point>(Lx, Ly, Lz, n_queries);
 
     // use random number k of for the kNN search
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate, TreeTypeTraits,
   int const n_queries = 100;
 
   {
-    auto sources = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+    auto sources = make_structured_cloud(Lx, Ly, Lz, nx, ny, nz);
     auto targets = make_random_cloud<ArborX::Point>(Lx, Ly, Lz, n_queries);
 
     // use random number k of for the kNN search
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate, TreeTypeTraits,
   }
 
   {
-    auto sources = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+    auto sources = make_structured_cloud(Lx, Ly, Lz, nx, ny, nz);
     auto targets = make_random_cloud<ArborX::Box>(Lx, Ly, Lz, n_queries);
 
     // use random number k of for the kNN search

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -26,122 +26,140 @@ BOOST_AUTO_TEST_SUITE(ComparisonWithBoost)
 
 namespace tt = boost::test_tools;
 
-inline Kokkos::View<ArborX::Point *, Kokkos::HostSpace>
+inline std::vector<ArborX::Point>
 make_stuctured_cloud(double Lx, double Ly, double Lz, int nx, int ny, int nz)
 {
   std::function<int(int, int, int)> ind = [nx, ny](int i, int j, int k) {
     return i + j * nx + k * (nx * ny);
   };
-  Kokkos::View<ArborX::Point *, Kokkos::HostSpace> cloud(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, "structured_cloud"),
-      nx * ny * nz);
+  std::vector<ArborX::Point> cloud(nx * ny * nz);
   for (int i = 0; i < nx; ++i)
     for (int j = 0; j < ny; ++j)
       for (int k = 0; k < nz; ++k)
-      {
         cloud[ind(i, j, k)] = {
             {i * Lx / (nx - 1), j * Ly / (ny - 1), k * Lz / (nz - 1)}};
-      }
   return cloud;
 }
 
 template <typename Geometry>
-Kokkos::View<Geometry *, Kokkos::HostSpace>
-make_random_cloud(double Lx, double Ly, double Lz, int n);
+std::vector<Geometry> make_random_cloud(double Lx, double Ly, double Lz, int n,
+                                        int seed = 0);
 
 template <>
-inline Kokkos::View<ArborX::Point *, Kokkos::HostSpace>
-make_random_cloud(double Lx, double Ly, double Lz, int n, int seed = 0)
+inline std::vector<ArborX::Point> make_random_cloud(double Lx, double Ly,
+                                                    double Lz, int n, int seed)
 {
-  Kokkos::View<ArborX::Point *, Kokkos::HostSpace> cloud(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, "random_cloud"), n);
   std::default_random_engine generator(seed);
   std::uniform_real_distribution<double> distribution_x(0.0, Lx);
   std::uniform_real_distribution<double> distribution_y(0.0, Ly);
   std::uniform_real_distribution<double> distribution_z(0.0, Lz);
+
+  std::vector<ArborX::Point> cloud;
+  cloud.reserve(n);
   for (int i = 0; i < n; ++i)
   {
     double x = distribution_x(generator);
     double y = distribution_y(generator);
     double z = distribution_z(generator);
-    cloud[i] = {{x, y, z}};
+    cloud.emplace_back(x, y, z);
   }
   return cloud;
 }
 
 template <>
-inline Kokkos::View<ArborX::Box *, Kokkos::HostSpace>
-make_random_cloud(double Lx, double Ly, double Lz, int n)
+inline std::vector<ArborX::Box> make_random_cloud(double Lx, double Ly,
+                                                  double Lz, int n, int seed)
 {
-  Kokkos::View<ArborX::Box *, Kokkos::HostSpace> cloud(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, "random_cloud"), n);
-  std::default_random_engine generator;
-  std::uniform_real_distribution<double> distribution_x(0.0, Lx);
-  std::uniform_real_distribution<double> distribution_y(0.0, Ly);
-  std::uniform_real_distribution<double> distribution_z(0.0, Lz);
-  double const min_xyz = std::min(std::min(Lx, Ly), Lz);
-  // We divide min_xyz by n in order to avoid a large number of overlapping
-  // boxes
-  std::uniform_real_distribution<double> distribution_l(
-      0.0, min_xyz / static_cast<double>(n));
+  auto const min_xyz = std::min(std::min(Lx, Ly), Lz);
+  std::default_random_engine generator(seed);
+  std::uniform_real_distribution<float> distribution_l(
+      0.0, min_xyz / (float)n); // divide by n to avoid too many overlaps
+
+  auto point_cloud = make_random_cloud<ArborX::Point>(Lx, Ly, Lz, n, seed);
+  std::vector<ArborX::Box> cloud;
+  cloud.reserve(n);
   for (int i = 0; i < n; ++i)
   {
-    float x = distribution_x(generator);
-    float y = distribution_y(generator);
-    float z = distribution_z(generator);
     float length = distribution_l(generator);
-    cloud[i] = {{x, y, z}, {x + length, y + length, z + length}};
+    auto const &min_corner = point_cloud[i];
+    ArborX::Point max_corner{min_corner[0] + length, min_corner[1] + length,
+                             min_corner[2] + length};
+    cloud.emplace_back(min_corner, max_corner);
   }
   return cloud;
 }
 
-template <typename Tree, typename ExecutionSpace, typename DeviceType,
-          typename PrimitiveGeometry>
-void boost_rtree_nearest_predicate()
+template <typename Tree, typename DeviceType, typename PrimitiveGeometry,
+          typename PredicateGeometry>
+void test_spatial_predicate(std::vector<PrimitiveGeometry> const &sources,
+                            std::vector<PredicateGeometry> const &targets,
+                            std::vector<float> const &radii)
 {
-  // construct a cloud of points (nodes of a structured grid)
-  double Lx = 10.0;
-  double Ly = 10.0;
-  double Lz = 10.0;
-  int nx = 11;
-  int ny = 11;
-  int nz = 11;
-  auto cloud = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
 
-  // random objects for kNN queries
-  // compare our solution against Boost R-tree
-  int const n_queries = 100;
-  using MemorySpace = typename Tree::memory_space;
-  auto geometry_objects = Kokkos::create_mirror_view_and_copy(
-      MemorySpace{},
-      make_random_cloud<PrimitiveGeometry>(Lx, Ly, Lz, n_queries));
+  assert(targets.size() == radii.size());
 
-  Kokkos::View<int *, ExecutionSpace> k("k", n_queries);
-  auto k_host = Kokkos::create_mirror_view(k);
-  // use random number k of for the kNN search
-  std::default_random_engine generator;
-  std::uniform_int_distribution<int> distribution_k(
-      1, std::floor(sqrt(nx * nx + ny * ny + nz * nz)));
-  for (unsigned int i = 0; i < n_queries; ++i)
-  {
-    k_host[i] = distribution_k(generator);
-  }
+  Kokkos::View<PrimitiveGeometry *, DeviceType> primitives(
+      "Testing::primitives", sources.size());
+  auto primitives_host = Kokkos::create_mirror_view(primitives);
+  Kokkos::deep_copy(primitives_host,
+                    Kokkos::View<PrimitiveGeometry const *, Kokkos::HostSpace,
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>{
+                        sources.data(), sources.size()});
+  Kokkos::deep_copy(primitives, primitives_host);
 
-  Kokkos::deep_copy(k, k_host);
-
-  Kokkos::View<ArborX::Nearest<PrimitiveGeometry> *, DeviceType>
-      nearest_queries("nearest_queries", n_queries);
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace>(0, n_queries), KOKKOS_LAMBDA(int i) {
-        nearest_queries(i) = ArborX::nearest(geometry_objects(i), k(i));
-      });
-  auto nearest_queries_host = Kokkos::create_mirror_view(nearest_queries);
-  Kokkos::deep_copy(nearest_queries_host, nearest_queries);
+  auto const n_queries = targets.size();
+  Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
+      within_queries("Testing::within_queries", n_queries);
+  auto within_queries_host = Kokkos::create_mirror_view(within_queries);
+  for (int i = 0; i < (int)n_queries; ++i)
+    within_queries_host(i) =
+        ArborX::intersects(ArborX::Sphere{targets[i], radii[i]});
+  Kokkos::deep_copy(within_queries, within_queries_host);
 
   Tree tree(ExecutionSpace{},
-            Kokkos::create_mirror_view_and_copy(MemorySpace{}, cloud));
+            Kokkos::create_mirror_view_and_copy(MemorySpace{}, primitives));
 
-  BoostExt::RTree<decltype(cloud)::value_type> rtree(ExecutionSpace{}, cloud);
+  BoostExt::RTree<PrimitiveGeometry> rtree(ExecutionSpace{}, primitives_host);
+
+  // FIXME check currently sporadically fails when using the HIP backend
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, within_queries,
+                         query(ExecutionSpace{}, rtree, within_queries_host));
+}
+
+template <typename Tree, typename DeviceType, typename PrimitiveGeometry,
+          typename PredicateGeometry>
+void test_nearest_predicate(std::vector<PrimitiveGeometry> const &sources,
+                            std::vector<PredicateGeometry> const &targets,
+                            std::vector<int> const &ks)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+
+  assert(targets.size() == ks.size());
+
+  Kokkos::View<PrimitiveGeometry *, DeviceType> primitives(
+      "Testing::primitives", sources.size());
+  auto primitives_host = Kokkos::create_mirror_view(primitives);
+  Kokkos::deep_copy(primitives_host,
+                    Kokkos::View<PrimitiveGeometry const *, Kokkos::HostSpace,
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>{
+                        sources.data(), sources.size()});
+  Kokkos::deep_copy(primitives, primitives_host);
+
+  auto const n_queries = targets.size();
+  Kokkos::View<ArborX::Nearest<PredicateGeometry> *, DeviceType>
+      nearest_queries("Testing::nearest_queries", n_queries);
+  auto nearest_queries_host = Kokkos::create_mirror_view(nearest_queries);
+  for (int i = 0; i < (int)n_queries; ++i)
+    nearest_queries_host(i) = ArborX::nearest(targets[i], ks[i]);
+  Kokkos::deep_copy(nearest_queries, nearest_queries_host);
+
+  Tree tree(ExecutionSpace{},
+            Kokkos::create_mirror_view_and_copy(MemorySpace{}, primitives));
+
+  BoostExt::RTree<PrimitiveGeometry> rtree(ExecutionSpace{}, primitives_host);
 
   // FIXME check currently sporadically fails when using the HIP backend
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, nearest_queries,
@@ -156,56 +174,30 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
                               TreeTypeTraitsList)
 {
   using Tree = typename TreeTypeTraits::type;
-  using ExecutionSpace = typename TreeTypeTraits::execution_space;
   using DeviceType = typename TreeTypeTraits::device_type;
 
-  // construct a cloud of points (nodes of a structured grid)
   double Lx = 10.0;
   double Ly = 10.0;
   double Lz = 10.0;
   int nx = 11;
   int ny = 11;
   int nz = 11;
-  auto cloud = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+  int const n_queries = 100;
 
-  // random points for radius search
-  // compare our solution against Boost R-tree
-  int const n_points = 100;
-  using MemorySpace = typename Tree::memory_space;
-  auto points = Kokkos::create_mirror_view_and_copy(
-      MemorySpace{}, make_random_cloud<ArborX::Point>(Lx, Ly, Lz, n_points));
-
-  Kokkos::View<double *, ExecutionSpace> radii("radii", n_points);
-  auto radii_host = Kokkos::create_mirror_view(radii);
-  // use random radius for the search
-  std::default_random_engine generator;
-  std::uniform_real_distribution<double> distribution_radius(
-      0.0, std::sqrt(Lx * Lx + Ly * Ly + Lz * Lz));
-  for (unsigned int i = 0; i < n_points; ++i)
   {
-    radii_host[i] = distribution_radius(generator);
+    auto sources = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+    auto targets = make_random_cloud<ArborX::Point>(Lx, Ly, Lz, n_queries);
+
+    // use random number k of for the kNN search
+    std::vector<float> radii(n_queries);
+    std::default_random_engine generator;
+    std::uniform_real_distribution<float> distribution_radius(
+        0.f, std::sqrt(Lx * Lx + Ly * Ly + Lz * Lz));
+    for (unsigned int i = 0; i < n_queries; ++i)
+      radii[i] = distribution_radius(generator);
+
+    test_spatial_predicate<Tree, DeviceType>(sources, targets, radii);
   }
-
-  Kokkos::deep_copy(radii, radii_host);
-
-  Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
-      within_queries("within_queries", n_points);
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace>(0, n_points), KOKKOS_LAMBDA(int i) {
-        within_queries(i) =
-            ArborX::intersects(ArborX::Sphere{points(i), radii(i)});
-      });
-  auto within_queries_host = Kokkos::create_mirror_view(within_queries);
-  Kokkos::deep_copy(within_queries_host, within_queries);
-
-  Tree tree(ExecutionSpace{},
-            Kokkos::create_mirror_view_and_copy(MemorySpace{}, cloud));
-
-  BoostExt::RTree<decltype(cloud)::value_type> rtree(ExecutionSpace{}, cloud);
-
-  // FIXME check currently sporadically fails when using the HIP backend
-  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, within_queries,
-                         query(ExecutionSpace{}, rtree, within_queries_host));
 }
 
 #ifndef ARBORX_TEST_DISABLE_NEAREST_QUERY
@@ -213,26 +205,49 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
 #ifdef KOKKOS_ENABLE_HIP
 BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(1))
 #endif
-BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate_point,
-                              TreeTypeTraits, TreeTypeTraitsList)
-{
-  using Tree = typename TreeTypeTraits::type;
-  using ExecutionSpace = typename TreeTypeTraits::execution_space;
-  using DeviceType = typename TreeTypeTraits::device_type;
-
-  boost_rtree_nearest_predicate<Tree, ExecutionSpace, DeviceType,
-                                ArborX::Point>();
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate_box, TreeTypeTraits,
+BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate, TreeTypeTraits,
                               TreeTypeTraitsList)
 {
   using Tree = typename TreeTypeTraits::type;
-  using ExecutionSpace = typename TreeTypeTraits::execution_space;
   using DeviceType = typename TreeTypeTraits::device_type;
 
-  boost_rtree_nearest_predicate<Tree, ExecutionSpace, DeviceType,
-                                ArborX::Box>();
+  double Lx = 10.0;
+  double Ly = 10.0;
+  double Lz = 10.0;
+  int nx = 11;
+  int ny = 11;
+  int nz = 11;
+  int const n_queries = 100;
+
+  {
+    auto sources = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+    auto targets = make_random_cloud<ArborX::Point>(Lx, Ly, Lz, n_queries);
+
+    // use random number k of for the kNN search
+    std::vector<int> ks(n_queries);
+    std::default_random_engine generator;
+    std::uniform_int_distribution<int> distribution_k(
+        1, std::floor(sqrt(nx * nx + ny * ny + nz * nz)));
+    for (unsigned int i = 0; i < n_queries; ++i)
+      ks[i] = distribution_k(generator);
+
+    test_nearest_predicate<Tree, DeviceType>(sources, targets, ks);
+  }
+
+  {
+    auto sources = make_stuctured_cloud(Lx, Ly, Lz, nx, ny, nz);
+    auto targets = make_random_cloud<ArborX::Box>(Lx, Ly, Lz, n_queries);
+
+    // use random number k of for the kNN search
+    std::vector<int> ks(n_queries);
+    std::default_random_engine generator;
+    std::uniform_int_distribution<int> distribution_k(
+        1, std::floor(sqrt(nx * nx + ny * ny + nz * nz)));
+    for (unsigned int i = 0; i < n_queries; ++i)
+      ks[i] = distribution_k(generator);
+
+    test_nearest_predicate<Tree, DeviceType>(sources, targets, ks);
+  }
 }
 #endif
 


### PR DESCRIPTION
When working on trying to optimize kNN with k=1, I produced a buggy                                                                                                                                                                                                                                                                                                                      
code. However, the current version of the test never caught it. I played                                                                                                                                                                                                                                                                                                                 
around with the test, trying to find out why that was the case. While I                                                                                                                                                                                                                                                                                                                  
have not determined the root cause, I found the following:                                                                                                                                                                                                                                                                                                                               
- Using a structured grid for the tree always made the test pass                                                                                                                                                                                                                                                                                                                         
- Using a random cloud for the tree with query points being subset of                                                                                                                                                                                                                                                                                                                    
  that cloud made it pass
                                                                                                                                                                                                                                                                                                                                                                
Thus, I decided to switch to using a random cloud for source, and make                                                                                                                                                                                                                                                                                                                   
query points distinct.