### PR TITLE
Update CI to ROCm 4.2

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -327,12 +327,12 @@ pipeline {
                     }
                 }
 
-                stage('HIP-4.0') {
+                stage('HIP-4.2') {
                     agent {
                         dockerfile {
                             filename "Dockerfile.hipcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:4.0 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:4.2 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES}'
                             label 'rocm-docker && vega'
                         }

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -1,4 +1,4 @@
-ARG BASE=rocm/dev-ubuntu-20.04:4.0
+ARG BASE=rocm/dev-ubuntu-20.04:4.2
 FROM $BASE
 
 ARG NPROCS=4

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -143,15 +143,10 @@ void boost_rtree_nearest_predicate()
 
   BoostExt::RTree<decltype(cloud)::value_type> rtree(ExecutionSpace{}, cloud);
 
-  // FIXME check currently sporadically fails when using the HIP backend
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, nearest_queries,
                          query(ExecutionSpace{}, rtree, nearest_queries_host));
 }
 
-// FIXME temporary workaround bug in HIP-Clang (register spill)
-#ifdef KOKKOS_ENABLE_HIP
-BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(1))
-#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
                               TreeTypeTraitsList)
 {
@@ -203,16 +198,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
 
   BoostExt::RTree<decltype(cloud)::value_type> rtree(ExecutionSpace{}, cloud);
 
-  // FIXME check currently sporadically fails when using the HIP backend
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, within_queries,
                          query(ExecutionSpace{}, rtree, within_queries_host));
 }
 
 #ifndef ARBORX_TEST_DISABLE_NEAREST_QUERY
-// FIXME temporary workaround bug in HIP-Clang (register spill)
-#ifdef KOKKOS_ENABLE_HIP
-BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(1))
-#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate_point,
                               TreeTypeTraits, TreeTypeTraitsList)
 {

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -25,10 +25,6 @@ BOOST_AUTO_TEST_SUITE(ManufacturedSolution)
 
 namespace tt = boost::test_tools;
 
-// FIXME temporary workaround bug in HIP-Clang (register spill)
-#if defined(KOKKOS_ENABLE_HIP)
-BOOST_TEST_DECORATOR(*boost::unit_test::expected_failures(3))
-#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
                               TreeTypeTraitsList)
 {


### PR DESCRIPTION
ROCm 4.1 fixes a lot of register of spills. Let's see if that fixes the CI