### PR TITLE
Let abstraction for Euclidean vector be strongly typed

### DIFF
--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
     float xi_2 = rand_uniform();
 
     rays_host(i) = {ArborX::Point{rand_uniform() * L, rand_uniform() * L, 0.f},
-                    ArborX::Experimental::Ray::Vector{
+                    ArborX::Experimental::Vector{
                         float(std::cos(2 * M_PI * xi_2) * std::sqrt(xi_1)),
                         float(std::sin(2 * M_PI * xi_2) * std::sqrt(xi_1)),
                         std::sqrt(1.f - xi_1)}};

--- a/src/details/ArborX_Ray.hpp
+++ b/src/details/ArborX_Ray.hpp
@@ -26,9 +26,52 @@ namespace ArborX
 {
 namespace Experimental
 {
+
+struct Vector : private Point
+{
+  using Point::Point;
+  using Point::operator[];
+};
+
+KOKKOS_INLINE_FUNCTION constexpr Vector makeVector(Point const &begin,
+                                                   Point const &end)
+{
+  Vector v;
+  for (int d = 0; d < 3; ++d)
+  {
+    v[d] = end[d] - begin[d];
+  }
+  return v;
+}
+
+KOKKOS_INLINE_FUNCTION constexpr auto dotProduct(Vector const &v,
+                                                 Vector const &w)
+{
+  return v[0] * w[0] + v[1] * w[1] + v[2] * w[2];
+}
+
+KOKKOS_INLINE_FUNCTION constexpr Vector crossProduct(Vector const &v,
+                                                     Vector const &w)
+{
+  return {v[1] * w[2] - v[2] * w[1], v[2] * w[0] - v[0] * w[2],
+          v[0] * w[1] - v[1] * w[0]};
+}
+
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(Vector const &v,
+                                                 Vector const &w)
+{
+  return v[0] == w[0] && v[1] == w[1] && v[2] == w[2];
+}
+
+KOKKOS_INLINE_FUNCTION constexpr bool equals(Vector const &v, Vector const &w)
+{
+  return v == w;
+}
+
 struct Ray
 {
-  using Vector = Point; // will regret this later
+  Point _origin = {};
+  Vector _direction = {0.f, 0.f, 0.f};
 
   using Scalar = std::decay_t<decltype(std::declval<Vector>()[0])>;
 
@@ -72,8 +115,8 @@ struct Ray
   KOKKOS_FUNCTION
   constexpr Vector const &direction() const { return _direction; }
 
-  Point _origin = {};
-  Vector _direction = {{0.f, 0.f, 0.f}};
+  // FIXME avoid breaking Wenjun's code
+  using Vector [[deprecated]] = ArborX::Experimental::Vector;
 };
 
 KOKKOS_INLINE_FUNCTION
@@ -148,12 +191,6 @@ bool intersects(Ray const &ray, Box const &box)
   return max_min <= min_max && (min_max >= 0);
 }
 
-KOKKOS_INLINE_FUNCTION float dotProduct(Ray::Vector const &v1,
-                                        Ray::Vector const &v2)
-{
-  return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2];
-}
-
 // Solves a*x^2 + b*x + c = 0.
 // If a solution exists, return true and stores roots at x1, x2.
 // If a solution does not exist, returns false.
@@ -206,9 +243,9 @@ KOKKOS_INLINE_FUNCTION float overlapDistance(Ray const &ray,
   auto const &r = sphere.radius();
 
   // Vector oc = (origin_of_ray - center_of_sphere)
-  Ray::Vector const oc{ray.origin()[0] - sphere.centroid()[0],
-                       ray.origin()[1] - sphere.centroid()[1],
-                       ray.origin()[2] - sphere.centroid()[2]};
+  Vector const oc{ray.origin()[0] - sphere.centroid()[0],
+                  ray.origin()[1] - sphere.centroid()[1],
+                  ray.origin()[2] - sphere.centroid()[2]};
 
   float const a2 = 1.f; // directions are normalized
   float const a1 = 2.f * dotProduct(ray.direction(), oc);

--- a/src/details/ArborX_Ray.hpp
+++ b/src/details/ArborX_Ray.hpp
@@ -243,9 +243,7 @@ KOKKOS_INLINE_FUNCTION float overlapDistance(Ray const &ray,
   auto const &r = sphere.radius();
 
   // Vector oc = (origin_of_ray - center_of_sphere)
-  Vector const oc{ray.origin()[0] - sphere.centroid()[0],
-                  ray.origin()[1] - sphere.centroid()[1],
-                  ray.origin()[2] - sphere.centroid()[2]};
+  Vector const oc = makeVector(sphere.centroid(), ray.origin());
 
   float const a2 = 1.f; // directions are normalized
   float const a1 = 2.f * dotProduct(ray.direction(), oc);

--- a/test/tstRay.cpp
+++ b/test/tstRay.cpp
@@ -227,6 +227,14 @@ BOOST_AUTO_TEST_CASE(overlap_distance_sphere,
 }
 
 #define STATIC_ASSERT(cond) static_assert(cond, "");
+BOOST_AUTO_TEST_CASE(make_euclidean_vector)
+{
+  using ArborX::Experimental::makeVector;
+  using ArborX::Experimental::Vector;
+  STATIC_ASSERT((makeVector({0, 0, 0}, {1, 2, 3}) == Vector{1, 2, 3}));
+  STATIC_ASSERT((makeVector({1, 2, 3}, {4, 5, 6}) == Vector{3, 3, 3}));
+}
+
 BOOST_AUTO_TEST_CASE(dot_product)
 {
   using ArborX::Experimental::dotProduct;

--- a/test/tstRay.cpp
+++ b/test/tstRay.cpp
@@ -225,3 +225,27 @@ BOOST_AUTO_TEST_CASE(overlap_distance_sphere,
   BOOST_TEST(overlapDistance(Ray{{half_sqrtf_3, 0.5, 0}, {1, 0, 0}},
                              unit_sphere) == 0.f);
 }
+
+#define STATIC_ASSERT(cond) static_assert(cond, "");
+BOOST_AUTO_TEST_CASE(dot_product)
+{
+  using ArborX::Experimental::dotProduct;
+  STATIC_ASSERT(dotProduct({1, 0, 0}, {1, 0, 0}) == 1);
+  STATIC_ASSERT(dotProduct({1, 0, 0}, {0, 1, 0}) == 0);
+  STATIC_ASSERT(dotProduct({1, 0, 0}, {0, 0, 1}) == 0);
+  STATIC_ASSERT(dotProduct({1, 1, 1}, {1, 1, 1}) == 3);
+}
+
+BOOST_AUTO_TEST_CASE(cross_product)
+{
+  using ArborX::Experimental::crossProduct;
+  using ArborX::Experimental::Vector;
+  STATIC_ASSERT((crossProduct({1, 0, 0}, {1, 0, 0}) == Vector{0, 0, 0}));
+  STATIC_ASSERT((crossProduct({1, 0, 0}, {0, 1, 0}) == Vector{0, 0, 1}));
+  STATIC_ASSERT((crossProduct({1, 0, 0}, {0, 0, 1}) == Vector{0, -1, 0}));
+  STATIC_ASSERT((crossProduct({0, 1, 0}, {1, 0, 0}) == Vector{0, 0, -1}));
+  STATIC_ASSERT((crossProduct({0, 1, 0}, {0, 1, 0}) == Vector{0, 0, 0}));
+  STATIC_ASSERT((crossProduct({0, 1, 0}, {0, 0, 1}) == Vector{1, 0, 0}));
+  STATIC_ASSERT((crossProduct({1, 1, 1}, {1, 1, 1}) == Vector{0, 0, 0}));
+}
+#undef STATIC_ASSERT


### PR DESCRIPTION
Rational: I had taken a shortcut when I aliased `Vector` to `Point` and now actually regret it as I look into ray-triangle intersection

Note that I intentionally omitted conversion to and from `Point`.

@wjge please review