### PR TITLE
Remove "fast" label initialization

### DIFF
--- a/src/details/ArborX_DetailsDBSCANCallback.hpp
+++ b/src/details/ArborX_DetailsDBSCANCallback.hpp
@@ -142,10 +142,6 @@ struct DBSCANCallback
     auto i = self;
     auto j = neighbor;
 
-    // initialize to the first neighbor that's smaller
-    if (Kokkos::atomic_compare_exchange(&labels_(i), i, j) == i)
-      return;
-
     // ##### ECL license (see LICENSE.ECL) #####
     int vstat = representative(i);
     int ostat = representative(j);


### PR DESCRIPTION
The logic is not strictly necessary, and does not really bring any
performance gains. It also interferes with implementing other
algorithms, like pair traversal and dense box. So, let's just remove it.