### PR TITLE
Fix warnings from hipcc

### DIFF
--- a/src/details/ArborX_DetailsDBSCANCallback.hpp
+++ b/src/details/ArborX_DetailsDBSCANCallback.hpp
@@ -28,6 +28,13 @@ struct DBSCANCallback
   UnionFind<MemorySpace> union_find_;
   CorePointsType is_core_point_;
 
+  DBSCANCallback(Kokkos::View<int *, MemorySpace> const &view,
+                 CorePointsType is_core_point)
+      : union_find_(view)
+      , is_core_point_(is_core_point)
+  {
+  }
+
   template <typename Query>
   KOKKOS_FUNCTION void operator()(Query const &query, int j) const
   {

--- a/src/details/ArborX_DetailsUnionFind.hpp
+++ b/src/details/ArborX_DetailsUnionFind.hpp
@@ -77,6 +77,11 @@ struct UnionFind
 {
   Kokkos::View<int *, MemorySpace> labels_;
 
+  UnionFind(Kokkos::View<int *, MemorySpace> labels)
+      : labels_(labels)
+  {
+  }
+
   // Per [1]:
   //
   // Note that the [`representative()`] code is re-entrant and synchronization


### PR DESCRIPTION
I am getting a bunch of warnings using rocm 4.2. hipcc wants `{}` around labels.

```
/home/users/ArborX/src/ArborX_DBSCAN.hpp:199:19: warning: suggest braces around initialization of subobject [-Wmissing-braces]
                  labels, CorePoints{num_neigh, core_min_size}});
                  ^~~~~~ 
                  {     }
```