### PR TITLE
Fixup Kokkos space accessibility checks

### DIFF
--- a/benchmarks/point_clouds/point_clouds.hpp
+++ b/benchmarks/point_clouds/point_clouds.hpp
@@ -12,7 +12,9 @@
 #ifndef ARBORX_POINT_CLOUDS_HPP
 #define ARBORX_POINT_CLOUDS_HPP
 
-#include <ArborX.hpp>
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
+#include <ArborX_Exception.hpp>
+#include <ArborX_Point.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -47,8 +49,7 @@ void filledBoxCloud(
     Kokkos::View<ArborX::Point *, Layout, DeviceType> random_points)
 {
   static_assert(
-      Kokkos::Impl::MemorySpaceAccess<
-          Kokkos::HostSpace, typename DeviceType::memory_space>::accessible,
+      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
       "The View should be accessible on the Host");
   std::uniform_real_distribution<double> distribution(-half_edge, half_edge);
   std::default_random_engine generator;
@@ -66,8 +67,7 @@ void hollowBoxCloud(
     Kokkos::View<ArborX::Point *, Layout, DeviceType> random_points)
 {
   static_assert(
-      Kokkos::Impl::MemorySpaceAccess<
-          Kokkos::HostSpace, typename DeviceType::memory_space>::accessible,
+      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
       "The View should be accessible on the Host");
   std::uniform_real_distribution<double> distribution(-half_edge, half_edge);
   std::default_random_engine generator;
@@ -130,8 +130,7 @@ void filledSphereCloud(
     Kokkos::View<ArborX::Point *, Layout, DeviceType> random_points)
 {
   static_assert(
-      Kokkos::Impl::MemorySpaceAccess<
-          Kokkos::HostSpace, typename DeviceType::memory_space>::accessible,
+      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
       "The View should be accessible on the Host");
   std::default_random_engine generator;
 
@@ -166,8 +165,7 @@ void hollowSphereCloud(
     Kokkos::View<ArborX::Point *, Layout, DeviceType> random_points)
 {
   static_assert(
-      Kokkos::Impl::MemorySpaceAccess<
-          Kokkos::HostSpace, typename DeviceType::memory_space>::accessible,
+      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
       "The View should be accessible on the Host");
   std::default_random_engine generator;
 

--- a/examples/viz/tree_visualization.cpp
+++ b/examples/viz/tree_visualization.cpp
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
 #include <ArborX_DetailsTreeVisualization.hpp>
 #include <ArborX_LinearBVH.hpp>
 
@@ -52,8 +53,7 @@ void writePointCloud(
 
 {
   static_assert(
-      Kokkos::Impl::MemorySpaceAccess<
-          Kokkos::HostSpace, typename DeviceType::memory_space>::accessible,
+      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
       "The View should be accessible on the Host");
   std::ofstream file(filename);
   if (file.is_open())

--- a/src/details/ArborX_DetailsKokkosExtAccessibilityTraits.hpp
+++ b/src/details/ArborX_DetailsKokkosExtAccessibilityTraits.hpp
@@ -30,8 +30,8 @@ struct is_accessible_from : std::false_type
 
 template <typename MemorySpace, typename ExecutionSpace>
 struct is_accessible_from<MemorySpace, ExecutionSpace,
-                          typename std::enable_if<Kokkos::SpaceAccessibility<
-                              ExecutionSpace, MemorySpace>::accessible>::type>
+                          std::enable_if_t<Kokkos::SpaceAccessibility<
+                              ExecutionSpace, MemorySpace>::accessible>>
     : std::true_type
 {
 };

--- a/test/ArborX_BoostRangeAdapters.hpp
+++ b/test/ArborX_BoostRangeAdapters.hpp
@@ -12,6 +12,7 @@
 #ifndef ARBORX_BOOST_RANGE_ADAPTERS_HPP
 #define ARBORX_BOOST_RANGE_ADAPTERS_HPP
 
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
 #include <ArborX_Exception.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -27,8 +28,7 @@ namespace boost
   static_assert(Traits::rank == 1,                                             \
                 "Adaptor to Boost.Range only available for Views of rank 1");  \
   static_assert(                                                               \
-      Kokkos::SpaceAccessibility<Kokkos::HostSpace,                            \
-                                 typename Traits::memory_space>::accessible,   \
+      KokkosExt::is_accessible_from_host<View>::value,                         \
       "Adaptor to Boost.Range only available when View memory space is "       \
       "accessible from host");
 


### PR DESCRIPTION
Rational: `Kokkos::Impl:: SpaceAccessibility ` is being marked as deprecated.  One is suppose to use `Kokkos:: SpaceAccessibility` instead (https://github.com/kokkos/kokkos/pull/3978).  As I was making sure we are not using it, I discovered we were using `Kokkos::Impl::MemorySpaceAccess` and we should not do that.