### PR TITLE
Restrict HIP builds to MI60

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -334,7 +334,7 @@ pipeline {
                             dir "docker"
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:4.0'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES}'
-                            label 'rocm-docker && vega'
+                            label 'rocm-docker && vega && AMD_Radeon_Instinct_MI60'
                         }
                     }
                     steps {


### PR DESCRIPTION
In all releases, `Kokkos` requires to set a `HIP` architecture but our CI for HIP doesn't have a uniform architecture. At the moment we specify, that we build for MI60 so we should also make sure that the CI only runs on the machine that has a MI60.