### PR TITLE
Add and install ArborXConfigVersion.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,13 @@ configure_package_config_file(cmake/ArborXConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/ArborXConfig.cmake
   INSTALL_DESTINATION lib/cmake/ArborX
 )
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ArborXConfigVersion.cmake
+  VERSION ${ARBORX_VERSION_STRING}
+  COMPATIBILITY SameMajorVersion
+)
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/ArborXConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/ArborXConfigVersion.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/ArborXSettings.cmake
   DESTINATION lib/cmake/ArborX )
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   cmake_minimum_required(VERSION 3.12)
   project(ArborXExamples CXX)
-  find_package(ArborX REQUIRED)
+  find_package(ArborX 1.1 REQUIRED)
   enable_testing()
 endif()
 


### PR DESCRIPTION
We don't export the version in a way that's useful for CMake, i.e., `find_package(ArborX 1.0)` does not work. This PR fixes that. We need to decide what kind of compatibility we want. Currently if you require 1.1, 1.2 will work but 2.0 won't.