### PR TITLE
Add support for MI 100 in CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -332,7 +332,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile.hipcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:4.0'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:4.0 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES}'
                             label 'rocm-docker && vega'
                         }

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -94,7 +94,10 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 
 # Install Kokkos
 ARG KOKKOS_VERSION=3.3.01
-ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA906=ON"
+ARG KOKKOS_ARCH=Kokkos_ARCH_VEGA906
+# Temporary hack
+ENV KOKKOS_ARCH_TMP=${KOKKOS_ARCH:-Kokkos_ARCH_VEGA906} 
+ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -D${KOKKOS_ARCH_TMP}=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
     KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -93,7 +93,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     rm -rf ${SCRATCH_DIR}
 
 # Install Kokkos
-ARG KOKKOS_VERSION=3.2.00
+ARG KOKKOS_VERSION=3.3.01
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA906=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \


### PR DESCRIPTION
With this PR the tests can pass on MI60 and MI100. There is a way to make this nicer but we need to wait for @dalg24 to come back because I don't have access to `lascaux01`.