### PR TITLE
Remove unnecessary variable in HIP Dockerfile

### DIFF
--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -95,9 +95,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 # Install Kokkos
 ARG KOKKOS_VERSION=3.3.01
 ARG KOKKOS_ARCH=Kokkos_ARCH_VEGA906
-# Temporary hack
-ENV KOKKOS_ARCH_TMP=${KOKKOS_ARCH:-Kokkos_ARCH_VEGA906} 
-ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -D${KOKKOS_ARCH_TMP}=ON"
+ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -D${KOKKOS_ARCH}=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
     KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \


### PR DESCRIPTION
I have update lascaux01 and lascaux01bis so the temporary variable is not necessary anymore.