### PR TITLE
Fix a subtle bug in DBSCAN noise marking

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -140,6 +140,9 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
   timer_start(timer);
   Kokkos::Profiling::pushRegion("ArborX::dbscan::clusters");
 
+  Kokkos::View<int *, MemorySpace> num_neigh("ArborX::dbscan::num_neighbors",
+                                             0);
+
   Kokkos::View<int *, MemorySpace> labels(
       Kokkos::ViewAllocateWithoutInitializing("ArborX::DBSCAN::labels"), n);
   ArborX::iota(exec_space, labels);
@@ -160,8 +163,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
     Kokkos::Timer timer_local;
     timer_start(timer_local);
     Kokkos::Profiling::pushRegion("ArborX::dbscan::clusters::num_neigh");
-    Kokkos::View<int *, MemorySpace> num_neigh("ArborX::dbscan::num_neighbors",
-                                               n);
+    Kokkos::resize(num_neigh, n);
     bvh.query(exec_space, predicates,
               Details::CountUpToN<MemorySpace>{num_neigh, core_min_size});
     Kokkos::Profiling::popRegion();
@@ -203,12 +205,26 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
 
                          Kokkos::atomic_fetch_add(&cluster_sizes(labels(i)), 1);
                        });
-  Kokkos::parallel_for("ArborX::dbscan::mark_noise",
-                       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
-                       KOKKOS_LAMBDA(int const i) {
-                         if (cluster_sizes(labels(i)) == 1)
-                           labels(i) = -1;
-                       });
+  if (is_special_case)
+  {
+    // Cannot use CCSCore as it always returns true
+    Kokkos::parallel_for("ArborX::dbscan::mark_noise",
+                         Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
+                         KOKKOS_LAMBDA(int const i) {
+                           if (cluster_sizes(labels(i)) == 1)
+                             labels(i) = -1;
+                         });
+  }
+  else
+  {
+    DBSCAN::DBSCANCorePoints<MemorySpace> is_core{num_neigh, core_min_size};
+    Kokkos::parallel_for("ArborX::dbscan::mark_noise",
+                         Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
+                         KOKKOS_LAMBDA(int const i) {
+                           if (cluster_sizes(labels(i)) == 1 && !is_core(i))
+                             labels(i) = -1;
+                         });
+  }
   Kokkos::Profiling::popRegion();
   elapsed["query+cluster"] = timer_seconds(timer);
 

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -207,7 +207,12 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
                        });
   if (is_special_case)
   {
-    // Cannot use CCSCore as it always returns true
+    // Ideally, this kernel would have had the exactly same form as in the
+    // else() clause. But there's no available valid is_core() for use here:
+    // - CCSCorePoints cannot be used as it always returns true, which is OK
+    //   inside the callback, but not here
+    // - DBSCANCorePoints cannot be used either as num_neigh is not initialized
+    //   in the special case.
     Kokkos::parallel_for("ArborX::dbscan::mark_noise",
                          Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
                          KOKKOS_LAMBDA(int const i) {

--- a/test/tstDBSCAN.cpp
+++ b/test/tstDBSCAN.cpp
@@ -126,6 +126,36 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
         !verifyDBSCAN(space, points, 1, 4,
                       buildView<DeviceType, int>({5, 5, 5, 5, 5, 5, 5})));
   }
+
+  {
+    // check where a core point is connected to only boundary points, but which
+    // are stripped by a second core point
+
+    // o - core, x - border
+    //     -1 0 1 2
+    //    ----------
+    //  2 | x o x
+    //  1 |   x   x
+    //  0 |   o x o
+    // -1 |   x   x
+    // -2 | x o x
+    // clang-format off
+    auto points = buildView<DeviceType, Point>({
+        {0, -2, 0}, {-1, -2, 0}, {1, -2, 0}, {0, -1, 0}, // bottom
+        {0, 2, 0}, {-1, 2, 0}, {1, 2, 0}, {0, 1, 0}, // top
+        {2, 0, 0}, {2, -1, 0}, {2, 1, 0}, {1, 0, 0}, // right
+        {0, 0, 0}  // stripped core
+    });
+    // clang-format on
+
+    BOOST_TEST(verifyDBSCAN(
+        space, points, 1, 4,
+        buildView<DeviceType, int>({0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 5})));
+    // make sure the stripped core is not marked as noise
+    BOOST_TEST(!verifyDBSCAN(
+        space, points, 1, 4,
+        buildView<DeviceType, int>({0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, -1})));
+  }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
@@ -197,6 +227,32 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
         verifyDBSCAN(space, points, 1.0, 3, dbscan(space, points, 1, 3)));
     BOOST_TEST(
         verifyDBSCAN(space, points, 1.0, 4, dbscan(space, points, 1, 4)));
+  }
+
+  {
+    // check where a core point is connected to only boundary points, but which
+    // are stripped by a second core point
+
+    // o - core, x - border
+    //     -1 0 1 2
+    //    ----------
+    //  2 | x o x
+    //  1 |   x   x
+    //  0 |   o x o
+    // -1 |   x   x
+    // -2 | x o x
+    // clang-format off
+    auto points = buildView<DeviceType, Point>({
+        {0, -2, 0}, {-1, -2, 0}, {1, -2, 0}, {0, -1, 0}, // bottom
+        {0, 2, 0}, {-1, 2, 0}, {1, 2, 0}, {0, 1, 0}, // top
+        {2, 0, 0}, {2, -1, 0}, {2, 1, 0}, {1, 0, 0}, // right
+        {0, 0, 0}  // stripped core
+    });
+    // clang-format on
+
+    // This does *not* guarantee to trigger the issue, as it depends on the
+    // specific implementation and runtime. But it may.
+    BOOST_TEST(verifyDBSCAN(space, points, 1, 4, dbscan(space, points, 1, 4)));
   }
 }
 


### PR DESCRIPTION
Situation: a core point is connected to only boundary points. However,
those boundary are connected to other core points. So it may happen that
the boundary points are assigned to other clusters, resulting in a
cluster with a single point (core).

The bug was that those single core clusters were marked as noise.

The fix is ugly as heck, but I don't know how to do better.