### PR TITLE
Reduce default value of cluster_min_size in DBSCAN to 1

### DIFF
--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -121,7 +121,7 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
                            LabelsView const &labels,
                            ClusterIndicesView &cluster_indices,
                            ClusterOffsetView &cluster_offset,
-                           int cluster_min_size = 2)
+                           int cluster_min_size = 1)
 {
   Kokkos::Profiling::pushRegion("ArborX::DBSCAN::sortAndFilterClusters");
 
@@ -146,7 +146,7 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
       std::is_same<typename ClusterOffsetView::memory_space, MemorySpace>{},
       "");
 
-  ARBORX_ASSERT(cluster_min_size >= 2);
+  ARBORX_ASSERT(cluster_min_size >= 1);
 
   int const n = labels.extent_int(0);
 
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
       ( "binary", bpo::bool_switch(&binary)->default_value(false), "binary file indicator")
       ( "max-num-points", bpo::value<int>(&max_num_points)->default_value(-1), "max number of points to read in")
       ( "eps", bpo::value<float>(&eps), "DBSCAN eps" )
-      ( "cluster-min-size", bpo::value<int>(&cluster_min_size)->default_value(2), "minimum cluster size")
+      ( "cluster-min-size", bpo::value<int>(&cluster_min_size)->default_value(1), "minimum cluster size")
       ( "core-min-size", bpo::value<int>(&core_min_size)->default_value(2), "DBSCAN min_pts")
       ( "verify", bpo::bool_switch(&verify)->default_value(false), "verify connected components")
       ( "samples", bpo::value<int>(&num_samples)->default_value(-1), "number of samples" )


### PR DESCRIPTION
This is useful for reproducibility in subtle sitations when a core point
may be stripped of all its border points, resulting in a cluster
consisting of a single core point. As this is triggered by different
algorithms and runs, it makes it challenging to compare the results
based on the number of clusters and the number of points in them.