### PR TITLE
Rename "boundary" to "border" in DBSCAN

### DIFF
--- a/src/details/ArborX_DetailsFDBSCAN.hpp
+++ b/src/details/ArborX_DetailsFDBSCAN.hpp
@@ -71,23 +71,23 @@ struct FDBSCANCallback
       return;
     }
 
-    bool is_boundary_point =
+    bool is_border_point =
         !is_core_point_(i); // is_core_point_(j) is aready true
 
-    if (is_boundary_point && union_find_.representative(i) == i)
+    if (is_border_point && union_find_.representative(i) == i)
     {
-      // For a boundary point that was not processed before (labels_(i) == i),
+      // For a border point that was not processed before (labels_(i) == i),
       // set its representative to that of the core point. This way, when
       // another neighbor that is core point appears later, we won't process
       // this point.
       //
-      // NOTE: DO NOT USE merge(i, j) here. This may set this boundary
+      // NOTE: DO NOT USE merge(i, j) here. This may set this border
       // point as a representative for the whole cluster. This would mean that
       // a) labels_(i) == i still (so it would be processed later, and b) it may
       // be combined with a different cluster later forming a bridge.
       union_find_.merge_into(i, j);
     }
-    else if (!is_boundary_point && i > j)
+    else if (!is_border_point && i > j)
     {
       // For a core point that is connected to another core point, do the
       // standard CCS algorithm

--- a/test/tstHeapOperations.cpp
+++ b/test/tstHeapOperations.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(min_heap)
   // This helped resolving an issue with ProprityQueue::pop() that was not
   // exposed by other unit tests in this file, partly because they were too
   // trivial.  The bug was only showing with real kNN search problems when
-  // comparing results from BoundaryVolumeHierarchy with boost::rtree.
+  // comparing results from BoundingVolumeHierarchy with boost::rtree.
   Kokkos::Array<int, 9> a = {1, 2, 3, 17, 19, 36, 7, 25, 100};
   Kokkos::Array<int, 9> ref;
   for (int i = 0; i < 9; ++i)


### PR DESCRIPTION
🤦‍♂️ 
Border is the correct name, not sure where I came up with boundary.

Per Ester et al '96 paper:
```
[snip] there are two kinds of points in a cluster, 
points inside of the cluster (core points) and
points on the border of the cluster (border points).
```