### PR TITLE
Change default DBSCAN implementation to FDBSCAN-DenseBox

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -176,7 +176,7 @@ struct Parameters
   // Print timers to standard output
   bool _print_timers = false;
   // Algorithm implementation (FDBSCAN or FDBSCAN-DenseBox)
-  Implementation _implementation = Implementation::FDBSCAN;
+  Implementation _implementation = Implementation::FDBSCAN_DenseBox;
 
   Parameters &setPrintTimers(bool print_timers)
   {


### PR DESCRIPTION
In most situations, it is faster than FDBSCAN.