### PR TITLE
Add -w flag to ignore in Boost build of b2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,7 +102,7 @@ RUN BOOST_VERSION=1.75.0 && \
     mkdir -p boost && \
     tar -xf ${BOOST_ARCHIVE} -C boost --strip-components=1 && \
     cd boost && \
-    ./bootstrap.sh \
+    CXXFLAGS="-w" ./bootstrap.sh \
         --prefix=${BOOST_DIR} \
         && \
     echo "using mpi ;" >> project-config.jam && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -70,7 +70,7 @@ RUN BOOST_VERSION=1.72.0 && \
     mkdir -p boost && \
     tar -xf ${BOOST_ARCHIVE} -C boost --strip-components=1 && \
     cd boost && \
-    ./bootstrap.sh \
+    CXXFLAGS="-w" ./bootstrap.sh \
         --prefix=${BOOST_DIR} \
         && \
     ./b2 -j${NPROCS} \

--- a/docker/Dockerfile.pgi
+++ b/docker/Dockerfile.pgi
@@ -71,7 +71,7 @@ RUN BOOST_VERSION=1.71.0 && \
     mkdir -p boost && \
     tar -xf ${BOOST_ARCHIVE} -C boost --strip-components=1 && \
     cd boost && \
-    ./bootstrap.sh \
+    CXXFLAGS="-w" ./bootstrap.sh \
         --prefix=${BOOST_DIR} \
         && \
     echo "using mpi ;" >> project-config.jam && \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -94,7 +94,7 @@ RUN BOOST_VERSION=1.72.0 && \
     mkdir -p boost && \
     tar -xf ${BOOST_ARCHIVE} -C boost --strip-components=1 && \
     cd boost && \
-    ./bootstrap.sh \
+    CXXFLAGS="-w" ./bootstrap.sh \
         --prefix=${BOOST_DIR} \
         && \
     ./b2 -j${NPROCS} \


### PR DESCRIPTION
The warning we are getting looks like this:
```
  debugger.cpp:165:11: warning: ignoring return value of 'int
  fscanf(FILE*, const char*, ...)', declared with attribute
  warn_unused_result [-Wunused-result]
     fscanf( in, "%d", &len );
     ~~~~~~^~~~~~~~~~~~~~~~~~
```
It is coming from the command
```
  ./bootstrash.sh <args>
```
and file `boost/tools/build/src/engine/debugger.cpp`.