### PR TITLE
Prefer std::sort over Kokkos::BinSort for serial

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -72,6 +72,101 @@ namespace ArborX
 namespace Details
 {
 
+// Helper functions and structs for applyPermutations
+namespace PermuteHelper
+{
+template <class DstViewType, class SrcViewType, int Rank = DstViewType::Rank>
+struct CopyOp;
+
+template <class DstViewType, class SrcViewType>
+struct CopyOp<DstViewType, SrcViewType, 1>
+{
+  KOKKOS_INLINE_FUNCTION
+  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
+                   size_t i_src)
+  {
+    dst(i_dst) = src(i_src);
+  }
+};
+
+template <class DstViewType, class SrcViewType>
+struct CopyOp<DstViewType, SrcViewType, 2>
+{
+  KOKKOS_INLINE_FUNCTION
+  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
+                   size_t i_src)
+  {
+    for (unsigned int j = 0; j < dst.extent(1); j++)
+      dst(i_dst, j) = src(i_src, j);
+  }
+};
+
+template <class DstViewType, class SrcViewType>
+struct CopyOp<DstViewType, SrcViewType, 3>
+{
+  KOKKOS_INLINE_FUNCTION
+  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
+                   size_t i_src)
+  {
+    for (unsigned int j = 0; j < dst.extent(1); j++)
+      for (unsigned int k = 0; k < dst.extent(2); k++)
+        dst(i_dst, j, k) = src(i_src, j, k);
+  }
+};
+} // namespace PermuteHelper
+
+template <typename ExecutionSpace, typename PermutationView, typename InputView,
+          typename OutputView>
+void applyInversePermutation(ExecutionSpace const &space,
+                             PermutationView const &permutation,
+                             InputView const &input_view,
+                             OutputView const &output_view)
+{
+  static_assert(std::is_integral<typename PermutationView::value_type>::value,
+                "");
+  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
+  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
+
+  Kokkos::parallel_for(
+      "ArborX::Sorting::inverse_permute",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
+      KOKKOS_LAMBDA(int i) {
+        PermuteHelper::CopyOp<OutputView, InputView>::copy(
+            output_view, permutation(i), input_view, i);
+      });
+}
+
+template <typename ExecutionSpace, typename PermutationView, typename InputView,
+          typename OutputView>
+void applyPermutation(ExecutionSpace const &space,
+                      PermutationView const &permutation,
+                      InputView const &input_view,
+                      OutputView const &output_view)
+{
+  static_assert(std::is_integral<typename PermutationView::value_type>::value,
+                "");
+  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
+  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
+
+  Kokkos::parallel_for(
+      "ArborX::Sorting::permute",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
+      KOKKOS_LAMBDA(int i) {
+        PermuteHelper::CopyOp<OutputView, InputView>::copy(
+            output_view, i, input_view, permutation(i));
+      });
+}
+
+template <typename ExecutionSpace, typename PermutationView, typename View>
+void applyPermutation(ExecutionSpace const &space,
+                      PermutationView const &permutation, View &view)
+{
+  static_assert(std::is_integral<typename PermutationView::value_type>::value,
+                "");
+  auto scratch_view = clone(space, view);
+  applyPermutation(space, permutation, scratch_view, view);
+}
+
 // NOTE returns the permutation indices **and** sorts the input view
 template <typename ExecutionSpace, typename ViewType,
           class SizeType = unsigned int>
@@ -174,101 +269,6 @@ sortObjects(Kokkos::Experimental::SYCL const &space, ViewType &view)
   return permute;
 }
 #endif
-
-// Helper functions and structs for applyPermutations
-namespace PermuteHelper
-{
-template <class DstViewType, class SrcViewType, int Rank = DstViewType::Rank>
-struct CopyOp;
-
-template <class DstViewType, class SrcViewType>
-struct CopyOp<DstViewType, SrcViewType, 1>
-{
-  KOKKOS_INLINE_FUNCTION
-  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
-                   size_t i_src)
-  {
-    dst(i_dst) = src(i_src);
-  }
-};
-
-template <class DstViewType, class SrcViewType>
-struct CopyOp<DstViewType, SrcViewType, 2>
-{
-  KOKKOS_INLINE_FUNCTION
-  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
-                   size_t i_src)
-  {
-    for (unsigned int j = 0; j < dst.extent(1); j++)
-      dst(i_dst, j) = src(i_src, j);
-  }
-};
-
-template <class DstViewType, class SrcViewType>
-struct CopyOp<DstViewType, SrcViewType, 3>
-{
-  KOKKOS_INLINE_FUNCTION
-  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
-                   size_t i_src)
-  {
-    for (unsigned int j = 0; j < dst.extent(1); j++)
-      for (unsigned int k = 0; k < dst.extent(2); k++)
-        dst(i_dst, j, k) = src(i_src, j, k);
-  }
-};
-} // namespace PermuteHelper
-
-template <typename ExecutionSpace, typename PermutationView, typename InputView,
-          typename OutputView>
-void applyInversePermutation(ExecutionSpace const &space,
-                             PermutationView const &permutation,
-                             InputView const &input_view,
-                             OutputView const &output_view)
-{
-  static_assert(std::is_integral<typename PermutationView::value_type>::value,
-                "");
-  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
-  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
-
-  Kokkos::parallel_for(
-      "ArborX::Sorting::inverse_permute",
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
-      KOKKOS_LAMBDA(int i) {
-        PermuteHelper::CopyOp<OutputView, InputView>::copy(
-            output_view, permutation(i), input_view, i);
-      });
-}
-
-template <typename ExecutionSpace, typename PermutationView, typename InputView,
-          typename OutputView>
-void applyPermutation(ExecutionSpace const &space,
-                      PermutationView const &permutation,
-                      InputView const &input_view,
-                      OutputView const &output_view)
-{
-  static_assert(std::is_integral<typename PermutationView::value_type>::value,
-                "");
-  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
-  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
-
-  Kokkos::parallel_for(
-      "ArborX::Sorting::permute",
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
-      KOKKOS_LAMBDA(int i) {
-        PermuteHelper::CopyOp<OutputView, InputView>::copy(
-            output_view, i, input_view, permutation(i));
-      });
-}
-
-template <typename ExecutionSpace, typename PermutationView, typename View>
-void applyPermutation(ExecutionSpace const &space,
-                      PermutationView const &permutation, View &view)
-{
-  static_assert(std::is_integral<typename PermutationView::value_type>::value,
-                "");
-  auto scratch_view = clone(space, view);
-  applyPermutation(space, permutation, scratch_view, view);
-}
 
 } // namespace Details
 


### PR DESCRIPTION
Need to do performance analysis on this. But one of the use cases where `Kokkos::BinSort` is pretty terrible is repeated indices, which could happen, for example, if the predicates are outside of the scene bounding box of primitives, in which case they will be assigned same Morton codes.
As a concrete example of real application where it happens, see NimbleSM/NimbleSM#244.