### PR TITLE
Update contributing to point to ArborX style in wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,5 @@ repository](https://github.com/ArborX/ArborX). Please allow edits from
 maintainers in the pull request.
 
 Your pull request must pass ArborX's tests. It is also desired that it follows
-the coding style (provided by `.clang-format`).
+the coding style used in ArborX (see
+[wiki](https://github.com/arborx/ArborX/wiki/CodeStyle)).


### PR DESCRIPTION
The purpose of the PR is two-fold:
- Point contributors to the wiki
- Avoid confusion about the specific version of clang-format to use (Wiki contains the exact version, 7)