### PR TITLE
Replace deprecated Kokkos::ViewAllocateWithoutInitializing

### DIFF
--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -101,7 +101,8 @@ Kokkos::View<ArborX::Point *, DeviceType>
 constructPoints(int n_values, PointCloudType point_cloud_type)
 {
   Kokkos::View<ArborX::Point *, DeviceType> random_points(
-      Kokkos::ViewAllocateWithoutInitializing("random_points"), n_values);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "random_points"),
+      n_values);
   // Generate random points uniformly distributed within a box.  The edge
   // length of the box chosen such that object density (here objects will be
   // boxes 2x2x2 centered around a random point) will remain constant as
@@ -118,12 +119,14 @@ makeSpatialQueries(int n_values, int n_queries, int n_neighbors,
                    PointCloudType target_point_cloud_type)
 {
   Kokkos::View<ArborX::Point *, DeviceType> random_points(
-      Kokkos::ViewAllocateWithoutInitializing("random_points"), n_queries);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "random_points"),
+      n_queries);
   auto const a = std::cbrt(n_values);
   generatePointCloud(target_point_cloud_type, a, random_points);
 
   Kokkos::View<decltype(ArborX::intersects(ArborX::Sphere{})) *, DeviceType>
-      queries(Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
+      queries(Kokkos::view_alloc(Kokkos::WithoutInitializing, "queries"),
+              n_queries);
   // Radius is computed so that the number of results per query for a uniformly
   // distributed points in a [-a,a]^3 box is approximately n_neighbors.
   // Calculation: n_values*(4/3*M_PI*r^3)/(2a)^3 = n_neighbors
@@ -143,12 +146,13 @@ makeNearestQueries(int n_values, int n_queries, int n_neighbors,
                    PointCloudType target_point_cloud_type)
 {
   Kokkos::View<ArborX::Point *, DeviceType> random_points(
-      Kokkos::ViewAllocateWithoutInitializing("random_points"), n_queries);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "random_points"),
+      n_queries);
   auto const a = std::cbrt(n_values);
   generatePointCloud(target_point_cloud_type, a, random_points);
 
   Kokkos::View<ArborX::Nearest<ArborX::Point> *, DeviceType> queries(
-      Kokkos::ViewAllocateWithoutInitializing("queries"), n_queries);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "queries"), n_queries);
   using ExecutionSpace = typename DeviceType::execution_space;
   Kokkos::parallel_for(
       "bvh_driver:setup_knn_search_queries",

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -296,9 +296,11 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   }
 
   Kokkos::View<ArborX::Point *, DeviceType> random_values(
-      Kokkos::ViewAllocateWithoutInitializing("Testing::values"), n_values);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::values"),
+      n_values);
   Kokkos::View<ArborX::Point *, DeviceType> random_queries(
-      Kokkos::ViewAllocateWithoutInitializing("Testing::queries"), n_queries);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::queries"),
+      n_queries);
   {
     double a = 0.;
     double offset_x = 0.;
@@ -359,7 +361,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     // The boxes in which the points are placed have side length two, centered
     // around offset_[xyz] and scaled by a.
     Kokkos::View<ArborX::Point *, DeviceType> random_points(
-        Kokkos::ViewAllocateWithoutInitializing("Testing::points"),
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::points"),
         std::max(n_values, n_queries));
     auto random_points_host = Kokkos::create_mirror_view(random_points);
     for (int i = 0; i < random_points.extent_int(0); ++i)
@@ -400,7 +402,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   }
 
   Kokkos::View<ArborX::Box *, DeviceType> bounding_boxes(
-      Kokkos::ViewAllocateWithoutInitializing("Testing::bounding_boxes"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "Testing::bounding_boxes"),
       n_values);
   Kokkos::parallel_for("bvh_driver:construct_bounding_boxes",
                        Kokkos::RangePolicy<ExecutionSpace>(0, n_values),

--- a/examples/dbscan/ArborX_DBSCANVerification.hpp
+++ b/examples/dbscan/ArborX_DBSCANVerification.hpp
@@ -168,8 +168,8 @@ bool verifyClustersAreUnique(ExecutionSpace const &exec_space,
   // is already on the host.
   decltype(Kokkos::create_mirror_view(Kokkos::HostSpace{},
                                       std::declval<LabelsView>()))
-      labels_host(Kokkos::ViewAllocateWithoutInitializing(
-                      "ArborX::DBSCAN::labels_host"),
+      labels_host(Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                     "ArborX::DBSCAN::labels_host"),
                   labels.size());
   Kokkos::deep_copy(exec_space, labels_host, labels);
   auto offset_host =

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -262,7 +262,7 @@ void printClusterSizesAndCenters(ExecutionSpace const &exec_space,
   using MemorySpace = typename ClusterIndicesView::memory_space;
 
   Kokkos::View<ArborX::Point *, MemorySpace> cluster_centers(
-      Kokkos::ViewAllocateWithoutInitializing("Testing::centers"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::centers"),
       num_clusters);
   Kokkos::parallel_for(
       "Testing::compute_centers",

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
   // The centers of spheres are uniformly sampling the domain. The radii of
   // spheres have Gaussian (mu_R, sigma_R) sampling.
   Kokkos::View<ArborX::Sphere *, MemorySpace> spheres(
-      Kokkos::ViewAllocateWithoutInitializing("spheres"), num_spheres);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "spheres"), num_spheres);
   auto spheres_host = Kokkos::create_mirror_view(spheres);
   for (int i = 0; i < num_spheres; ++i)
   {
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
   // A detailed description can be found in the slides here (slide 47):
   // https://cg.informatik.uni-freiburg.de/course_notes/graphics2_08_renderingEquation.pdf
   Kokkos::View<ArborX::Experimental::Ray *, MemorySpace> rays(
-      Kokkos::ViewAllocateWithoutInitializing("rays"), num_rays);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "rays"), num_rays);
   auto rays_host = Kokkos::create_mirror_view(rays);
 
   for (int i = 0; i < num_rays; ++i)

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -73,9 +73,10 @@ template <typename ExecutionSpace, typename Primitives>
 BruteForce<MemorySpace>::BruteForce(ExecutionSpace const &space,
                                     Primitives const &primitives)
     : _size(AccessTraits<Primitives, PrimitivesTag>::size(primitives))
-    , _bounding_volumes(Kokkos::ViewAllocateWithoutInitializing(
-                            "ArborX::BruteForce::bounding_volumes"),
-                        _size)
+    , _bounding_volumes(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                             "ArborX::BruteForce::bounding_volumes"),
+          _size)
 {
   static_assert(
       KokkosExt::is_accessible_from<MemorySpace, ExecutionSpace>::value, "");

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -233,7 +233,8 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
                                              0);
 
   Kokkos::View<int *, MemorySpace> labels(
-      Kokkos::ViewAllocateWithoutInitializing("ArborX::DBSCAN::labels"), n);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "ArborX::DBSCAN::labels"),
+      n);
   ArborX::iota(exec_space, labels);
 
   if (parameters._implementation == DBSCAN::Implementation::FDBSCAN)

--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -149,9 +149,9 @@ DistributedTree<MemorySpace, Enable>::DistributedTree(
   MPI_Comm_size(getComm(), &comm_size);
 
   Kokkos::View<Box *, MemorySpace> boxes(
-      Kokkos::ViewAllocateWithoutInitializing(
-          "ArborX::DistributedTree::DistributedTree::"
-          "rank_bounding_boxes"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::DistributedTree::DistributedTree::"
+                         "rank_bounding_boxes"),
       comm_size);
   // FIXME when we move to MPI with CUDA-aware support, we will not need to
   // copy from the device to the host
@@ -169,8 +169,9 @@ DistributedTree<MemorySpace, Enable>::DistributedTree(
                                 "size_calculation");
 
   _bottom_tree_sizes = Kokkos::View<size_type *, MemorySpace>(
-      Kokkos::ViewAllocateWithoutInitializing("ArborX::DistributedTree::"
-                                              "leave_count_in_local_trees"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::DistributedTree::"
+                         "leave_count_in_local_trees"),
       comm_size);
   auto bottom_tree_sizes_host = Kokkos::create_mirror_view(_bottom_tree_sizes);
   bottom_tree_sizes_host(comm_rank) = _bottom_tree.size();

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -208,9 +208,10 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
     BasicBoundingVolumeHierarchy(ExecutionSpace const &space,
                                  Primitives const &primitives)
     : _size(AccessTraits<Primitives, PrimitivesTag>::size(primitives))
-    , _internal_and_leaf_nodes(Kokkos::ViewAllocateWithoutInitializing(
-                                   "ArborX::BVH::internal_and_leaf_nodes"),
-                               _size > 0 ? 2 * _size - 1 : 0)
+    , _internal_and_leaf_nodes(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                             "ArborX::BVH::internal_and_leaf_nodes"),
+          _size > 0 ? 2 * _size - 1 : 0)
 {
   Kokkos::Profiling::pushRegion("ArborX::BVH::BVH");
 
@@ -254,7 +255,8 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
 
   // calculate Morton codes of all objects
   Kokkos::View<unsigned int *, MemorySpace> morton_indices(
-      Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::BVH::morton"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::BVH::BVH::morton"),
       size());
   Details::TreeConstruction::assignMortonCodes(space, primitives,
                                                morton_indices, bbox);

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -56,7 +56,8 @@ public:
     auto const n_queries = Access::size(predicates);
 
     Kokkos::View<unsigned int *, DeviceType> morton_codes(
-        Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::query::morton"),
+        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                           "ArborX::BVH::query::morton"),
         n_queries);
     Kokkos::parallel_for(
         "ArborX::BatchedQueries::assign_morton_codes_to_queries",
@@ -90,7 +91,7 @@ public:
     using T = std::decay_t<decltype(
         Access::get(std::declval<Predicates const &>(), std::declval<int>()))>;
     Kokkos::View<T *, DeviceType> w(
-        Kokkos::ViewAllocateWithoutInitializing("predicates"), n);
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "predicates"), n);
     Kokkos::parallel_for(
         "ArborX::BatchedQueries::permute_entries",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -275,8 +275,9 @@ void queryImpl(ExecutionSpace const &space, Tree const &tree,
     Kokkos::Profiling::pushRegion(
         "ArborX::CrsGraphWrapper::two_pass:copy_values");
 
-    OutputView tmp_out(Kokkos::ViewAllocateWithoutInitializing(out.label()),
-                       n_results);
+    OutputView tmp_out(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, out.label()),
+        n_results);
 
     Kokkos::parallel_for(
         "ArborX::CrsGraphWrapper::copy_valid_values",

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -66,10 +66,10 @@ determineBufferLayout(ExecutionSpace const &space, InputView batched_ranks,
   // these ranks and the corresponding offsets in a new container that we can be
   // sure to be large enough.
   Kokkos::View<int *, DeviceType> compact_offsets(
-      Kokkos::ViewAllocateWithoutInitializing(batched_offsets.label()),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, batched_offsets.label()),
       batched_offsets.size());
   Kokkos::View<int *, DeviceType> compact_ranks(
-      Kokkos::ViewAllocateWithoutInitializing(batched_ranks.label()),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, batched_ranks.label()),
       batched_ranks.size());
 
   // Note that we never touch the first element of compact_offsets below.
@@ -151,7 +151,8 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
   using DeviceType = typename InputView::traits::device_type;
 
   Kokkos::View<int *, DeviceType> device_ranks_duplicate(
-      Kokkos::ViewAllocateWithoutInitializing(ranks.label()), ranks.size());
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, ranks.label()),
+      ranks.size());
   Kokkos::deep_copy(space, device_ranks_duplicate, ranks);
   auto device_permutation_indices =
       Kokkos::create_mirror_view(DeviceType(), permutation_indices);
@@ -195,8 +196,8 @@ class Distributor
 public:
   Distributor(MPI_Comm comm)
       : _comm(comm)
-      , _permute{Kokkos::ViewAllocateWithoutInitializing(
-                     "ArborX::Distributor::permute"),
+      , _permute{Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                    "ArborX::Distributor::permute"),
                  0}
   {
   }

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -248,7 +248,8 @@ computeCellIndices(ExecutionSpace const &exec_space,
   auto const n = Access::size(primitives);
 
   Kokkos::View<size_t *, MemorySpace> cell_indices(
-      Kokkos::ViewAllocateWithoutInitializing("ArborX::DBSCAN::cell_indices"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::DBSCAN::cell_indices"),
       n);
   Kokkos::parallel_for("ArborX::DBSCAN::compute_cell_indices",
                        Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
@@ -274,7 +275,8 @@ computeOffsetsInOrderedView(ExecutionSpace const &exec_space, View view)
 
   int num_offsets;
   Kokkos::View<int *, MemorySpace> offsets(
-      Kokkos::ViewAllocateWithoutInitializing("ArborX::DBSCAN::offsets"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::DBSCAN::offsets"),
       n + 1);
   Kokkos::parallel_scan(
       "ArborX::DBSCAN::compute_offsets",

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -91,7 +91,9 @@ sortObjects(ExecutionSpace const &space, ViewType &view)
   if (result.min_val == result.max_val)
   {
     Kokkos::View<SizeType *, typename ViewType::device_type> permute(
-        Kokkos::ViewAllocateWithoutInitializing("ArborX::Sorting::permute"), n);
+        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                           "ArborX::Sorting::permute"),
+        n);
     iota(space, permute);
     return permute;
   }
@@ -126,7 +128,8 @@ Kokkos::View<SizeType *, typename ViewType::device_type> sortObjects(
                 "");
 
   Kokkos::View<SizeType *, typename ViewType::device_type> permute(
-      Kokkos::ViewAllocateWithoutInitializing("ArborX::Sorting::permutation"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::Sorting::permutation"),
       n);
   ArborX::iota(space, permute);
 
@@ -159,7 +162,8 @@ sortObjects(Kokkos::Experimental::SYCL const &space, ViewType &view)
       "");
 
   Kokkos::View<SizeType *, typename ViewType::device_type> permute(
-      Kokkos::ViewAllocateWithoutInitializing("ArborX::Sorting::permutation"),
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::Sorting::permutation"),
       n);
   ArborX::iota(space, permute);
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -162,9 +162,9 @@ public:
       , _sorted_morton_codes(sorted_morton_codes)
       , _leaf_nodes(leaf_nodes)
       , _internal_nodes(internal_nodes)
-      , _ranges(
-            Kokkos::ViewAllocateWithoutInitializing("ArborX::BVH::BVH::ranges"),
-            internal_nodes.extent(0))
+      , _ranges(Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                   "ArborX::BVH::BVH::ranges"),
+                internal_nodes.extent(0))
       , _num_internal_nodes(_internal_nodes.extent_int(0))
   {
     Kokkos::deep_copy(space, _ranges, UNTOUCHED_NODE);

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -214,8 +214,8 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
   {
     auto const n_queries = Access::size(_predicates);
 
-    Offset offset(Kokkos::ViewAllocateWithoutInitializing(
-                      "ArborX::TreeTraversal::nearest::offset"),
+    Offset offset(Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                     "ArborX::TreeTraversal::nearest::offset"),
                   n_queries + 1);
     // NOTE workaround to avoid implicit capture of *this
     auto const &predicates = _predicates;
@@ -231,8 +231,8 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     // It is not possible to anticipate how much memory to allocate since the
     // number of nearest neighbors k is only known at runtime.
 
-    Buffer buffer(Kokkos::ViewAllocateWithoutInitializing(
-                      "ArborX::TreeTraversal::nearest::buffer"),
+    Buffer buffer(Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                     "ArborX::TreeTraversal::nearest::buffer"),
                   _buffersize);
     _buffer = BufferProvider{buffer, offset};
   }

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -111,7 +111,8 @@ inline auto create_layout_right_mirror_view_and_copy(
   Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
                typename ExecutionSpace::memory_space>
       layout_right_view(
-          Kokkos::ViewAllocateWithoutInitializing(
+          Kokkos::view_alloc(
+              Kokkos::WithoutInitializing,
               std::string(src.label()).append("_layout_right_mirror")),
           src.extent(0),
           pointer_depth > 1 ? src.extent(1) : KOKKOS_INVALID_INDEX,
@@ -526,8 +527,8 @@ void reallocWithoutInitializing(View &v,
                                 size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
 {
   static_assert(View::is_managed, "Can only realloc managed views");
-  v = View(Kokkos::ViewAllocateWithoutInitializing(v.label()), n0, n1, n2, n3,
-           n4, n5, n6, n7);
+  v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), n0, n1,
+           n2, n3, n4, n5, n6, n7);
 }
 
 template <typename View>
@@ -535,21 +536,21 @@ void reallocWithoutInitializing(View &v,
                                 const typename View::array_layout &layout)
 {
   static_assert(View::is_managed, "Can only realloc managed views");
-  v = View(Kokkos::ViewAllocateWithoutInitializing(v.label()), layout);
+  v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), layout);
 }
 
 template <typename View>
 typename View::non_const_type cloneWithoutInitializingNorCopying(View &v)
 {
   return typename View::non_const_type(
-      Kokkos::ViewAllocateWithoutInitializing(v.label()), v.layout());
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), v.layout());
 }
 
 template <typename ExecutionSpace, typename View>
 typename View::non_const_type clone(ExecutionSpace &&space, View &v)
 {
   typename View::non_const_type w(
-      Kokkos::ViewAllocateWithoutInitializing(v.label()), v.layout());
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), v.layout());
   Kokkos::deep_copy(std::forward<ExecutionSpace>(space), w, v);
   return w;
 }

--- a/test/tstDetailsCrsGraphWrapperImpl.cpp
+++ b/test/tstDetailsCrsGraphWrapperImpl.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(query_impl, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::deep_copy(offset, buffer_size);
 
   Kokkos::View<unsigned int *, DeviceType> permute(
-      Kokkos::ViewAllocateWithoutInitializing("Testing::permute"), n);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::permute"), n);
   ArborX::iota(ExecutionSpace{}, permute);
 
   ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_spatial_predicate, TreeTypeTraits,
 
   int const n = 10;
   Kokkos::View<ArborX::Point *, DeviceType> points(
-      Kokkos::ViewAllocateWithoutInitializing("points"), n);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   ArborX::Point const origin = {{0., 0., 0.}};
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        KOKKOS_LAMBDA(int i) {
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_nearest_predicate, TreeTypeTraits,
 
   int const n = 10;
   Kokkos::View<ArborX::Point *, DeviceType> points(
-      Kokkos::ViewAllocateWithoutInitializing("points"), n);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   ArborX::Point const origin = {{0., 0., 0.}};
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        KOKKOS_LAMBDA(int i) {
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_spatial_predicate,
 
   int const n = 10;
   Kokkos::View<ArborX::Point *, DeviceType> points(
-      Kokkos::ViewAllocateWithoutInitializing("points"), n);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   ArborX::Point const origin = {{0., 0., 0.}};
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        KOKKOS_LAMBDA(int i) {
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_nearest_predicate,
 
   int const n = 10;
   Kokkos::View<ArborX::Point *, DeviceType> points(
-      Kokkos::ViewAllocateWithoutInitializing("points"), n);
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   ArborX::Point const origin = {{0., 0., 0.}};
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n),
                        KOKKOS_LAMBDA(int i) {


### PR DESCRIPTION
`Kokkos::ViewAllocateWithoutInitializing` was deprecated in https://github.com/kokkos/kokkos/pull/4155.