### PR TITLE
Check View sizes in reallocWithoutInitializing

### DIFF
--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -526,9 +526,21 @@ void reallocWithoutInitializing(View &v,
                                 size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                                 size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
 {
-  static_assert(View::is_managed, "Can only realloc managed views");
-  v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), n0, n1,
-           n2, n3, n4, n5, n6, n7);
+  size_t ranks[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
+  bool allocation_necessary = false;
+  for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
+    if (ranks[dim] != v.extent(dim))
+    {
+      allocation_necessary = true;
+      break;
+    }
+
+  if (allocation_necessary)
+  {
+    static_assert(View::is_managed, "Can only realloc managed views");
+    v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), n0, n1,
+             n2, n3, n4, n5, n6, n7);
+  }
 }
 
 template <typename View>

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -526,6 +526,8 @@ void reallocWithoutInitializing(View &v,
                                 size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                                 size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
 {
+  static_assert(View::is_managed, "Can only realloc managed views");
+
   size_t ranks[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
   bool allocation_necessary = false;
   for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
@@ -536,11 +538,8 @@ void reallocWithoutInitializing(View &v,
     }
 
   if (allocation_necessary)
-  {
-    static_assert(View::is_managed, "Can only realloc managed views");
     v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), n0, n1,
              n2, n3, n4, n5, n6, n7);
-  }
 }
 
 template <typename View>

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -528,16 +528,16 @@ void reallocWithoutInitializing(View &v,
 {
   static_assert(View::is_managed, "Can only realloc managed views");
 
-  size_t ranks[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool allocation_necessary = false;
+  size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
+  bool has_requested_extents = true;
   for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
-    if (ranks[dim] != v.extent(dim))
+    if (new_extents[dim] != v.extent(dim))
     {
-      allocation_necessary = true;
+      has_requested_extents = false;
       break;
     }
 
-  if (allocation_necessary)
+  if (!has_requested_extents)
     v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), n0, n1,
              n2, n3, n4, n5, n6, n7);
 }


### PR DESCRIPTION
In https://github.com/arborx/ArborX/pull/538, it turned out to be useful to avoid allocating memory in `reallocWithoutInitializing` when the sizes already fit allowing to resize `Kokkos::Views` used in `query` beforehand and thus avoiding some synchronizations.