### PR TITLE
Fixup do not attempt to retrieve gpg key in SYCL image

### DIFF
--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -34,7 +34,6 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
     wget --quiet ${CMAKE_URL}/${CMAKE_SHA256} && \
     wget --quiet ${CMAKE_URL}/${CMAKE_SHA256}.asc && \
     wget --quiet ${CMAKE_URL}/${CMAKE_SCRIPT} && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys ${CMAKE_KEY} && \
     gpg --verify ${CMAKE_SHA256}.asc ${CMAKE_SHA256} && \
     grep ${CMAKE_SCRIPT} ${CMAKE_SHA256} | sha256sum --check && \
     mkdir -p ${CMAKE_DIR} && \


### PR DESCRIPTION
Caused failure in #539 
Key is already present in the keydump so we don't need to retrieve it from the server.  This was an oversight, all other images had already been updated.