### PR TITLE
Fix compiler warnings

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -274,11 +274,11 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     throw HelpPrinted();
   }
 
-  if (vm.count("do-not-perform-knn-search"))
+  if (vm.count("do-not-perform-knn-search") > 0)
     perform_knn_search = false;
-  if (vm.count("do-not-perform-radius-search"))
+  if (vm.count("do-not-perform-radius-search") > 0)
     perform_radius_search = false;
-  if (vm.count("shift-queries"))
+  if (vm.count("shift-queries") > 0)
     shift_queries = true;
 
   if (comm_rank == 0)

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -267,7 +267,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   int comm_size;
   MPI_Comm_size(comm, &comm_size);
 
-  if (vm.count("help"))
+  if (vm.count("help") > 0)
   {
     if (comm_rank == 0)
       std::cout << desc << '\n';

--- a/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
+++ b/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
   float const r = 0.1f;
   float const shift = 2.f;
 
-  if (vm.count("help"))
+  if (vm.count("help") > 0)
   {
     std::cout << desc << '\n';
     return 1;
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
   std::vector<ArborX::BVH<MemorySpace>> trees;
   for (int p = 0; p < num_problems; ++p)
   {
-    auto &exec_space = instances[p % num_exec_spaces];
+    auto const &exec_space = instances[p % num_exec_spaces];
 
     trees.emplace_back(
         exec_space, Kokkos::subview(primitives, Kokkos::pair<int, int>(
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
   query_time.reset();
   for (int p = 0; p < num_problems; ++p)
   {
-    auto &exec_space = instances[p % num_exec_spaces];
+    auto const &exec_space = instances[p % num_exec_spaces];
 
     trees[p].query(
         exec_space,


### PR DESCRIPTION
Fixes the compiler warnings in https://cloud.cees.ornl.gov/jenkins-ci/job/ArborX/job/PR-540/2/clang-tidy/#categoryContent (https://github.com/arborx/ArborX/pull/540).