### PR TITLE
Add scope-based profiling region utility

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -19,6 +19,7 @@
 #include <ArborX_DetailsBatchedQueries.hpp>
 #include <ArborX_DetailsConcepts.hpp>
 #include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
+#include <ArborX_DetailsKokkosExtScopedProfileRegion.hpp>
 #include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsPermutedData.hpp>
 #include <ArborX_DetailsSortUtils.hpp>
@@ -213,7 +214,7 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
                              "ArborX::BVH::internal_and_leaf_nodes"),
           _size > 0 ? 2 * _size - 1 : 0)
 {
-  Kokkos::Profiling::pushRegion("ArborX::BVH::BVH");
+  KokkosExt::ScopedProfileRegion guard("ArborX::BVH::BVH");
 
   Details::check_valid_access_traits(PrimitivesTag{}, primitives);
   using Access = AccessTraits<Primitives, PrimitivesTag>;
@@ -223,7 +224,6 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
 
   if (empty())
   {
-    Kokkos::Profiling::popRegion();
     return;
   }
 
@@ -247,7 +247,6 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
                      Kokkos::MemoryUnmanaged>(&_bounds),
         Kokkos::View<BoundingVolume, MemorySpace, Kokkos::MemoryUnmanaged>(
             &getBoundingVolume(getRoot())));
-    Kokkos::Profiling::popRegion();
     return;
   }
 
@@ -282,7 +281,6 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
       Kokkos::View<BoundingVolume, MemorySpace, Kokkos::MemoryUnmanaged>(
           &getBoundingVolume(getRoot())));
 
-  Kokkos::Profiling::popRegion();
   Kokkos::Profiling::popRegion();
 }
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -19,7 +19,6 @@
 #include <ArborX_DetailsBatchedQueries.hpp>
 #include <ArborX_DetailsConcepts.hpp>
 #include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
-#include <ArborX_DetailsKokkosExtScopedProfileRegion.hpp>
 #include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsPermutedData.hpp>
 #include <ArborX_DetailsSortUtils.hpp>
@@ -214,7 +213,7 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
                              "ArborX::BVH::internal_and_leaf_nodes"),
           _size > 0 ? 2 * _size - 1 : 0)
 {
-  KokkosExt::ScopedProfileRegion guard_constructor("ArborX::BVH::BVH");
+  Kokkos::Profiling::pushRegion("ArborX::BVH::BVH");
 
   Details::check_valid_access_traits(PrimitivesTag{}, primitives);
   using Access = AccessTraits<Primitives, PrimitivesTag>;
@@ -224,17 +223,19 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
 
   if (empty())
   {
+    Kokkos::Profiling::popRegion();
     return;
   }
 
-  Box bbox{};
-  { // determine the bounding box of the scene
-    KokkosExt::ScopedProfileRegion guard_calculate_scene_bounding_box(
-        "ArborX::BVH::BVH::calculate_scene_bounding_box");
+  Kokkos::Profiling::pushRegion(
+      "ArborX::BVH::BVH::calculate_scene_bounding_box");
 
-    Details::TreeConstruction::calculateBoundingBoxOfTheScene(space, primitives,
-                                                              bbox);
-  }
+  // determine the bounding box of the scene
+  Box bbox{};
+  Details::TreeConstruction::calculateBoundingBoxOfTheScene(space, primitives,
+                                                            bbox);
+
+  Kokkos::Profiling::popRegion();
 
   if (size() == 1)
   {
@@ -246,45 +247,43 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
                      Kokkos::MemoryUnmanaged>(&_bounds),
         Kokkos::View<BoundingVolume, MemorySpace, Kokkos::MemoryUnmanaged>(
             &getBoundingVolume(getRoot())));
+    Kokkos::Profiling::popRegion();
     return;
   }
 
-  Kokkos::View<unsigned int *, MemorySpace> morton_indices;
-  { // calculate Morton codes of all objects
-    KokkosExt::ScopedProfileRegion guard_assign_morton_codes(
-        "ArborX::BVH::BVH::assign_morton_codes");
+  Kokkos::Profiling::pushRegion("ArborX::BVH::BVH::assign_morton_codes");
 
-    morton_indices = Kokkos::View<unsigned int *, MemorySpace>(
-        Kokkos::view_alloc(Kokkos::WithoutInitializing,
-                           "ArborX::BVH::BVH::morton"),
-        size());
-    Details::TreeConstruction::assignMortonCodes(space, primitives,
-                                                 morton_indices, bbox);
-  }
+  // calculate Morton codes of all objects
+  Kokkos::View<unsigned int *, MemorySpace> morton_indices(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::BVH::BVH::morton"),
+      size());
+  Details::TreeConstruction::assignMortonCodes(space, primitives,
+                                               morton_indices, bbox);
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::pushRegion("ArborX::BVH::BVH::sort_morton_codes");
 
   // compute the ordering of primitives along Z-order space-filling curve
-  auto permutation_indices = [&space, &morton_indices]() {
-    KokkosExt::ScopedProfileRegion guard_sort_morton_codes(
-        "ArborX::BVH::BVH::sort_morton_codes");
+  auto permutation_indices = Details::sortObjects(space, morton_indices);
 
-    return Details::sortObjects(space, morton_indices);
-  }();
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::pushRegion("ArborX::BVH::BVH::generate_hierarchy");
 
-  { // generate bounding volume hierarchy
-    KokkosExt::ScopedProfileRegion guard_generate_hierarchy(
-        "ArborX::BVH::BVH::generate_hierarchy");
+  // generate bounding volume hierarchy
+  Details::TreeConstruction::generateHierarchy(
+      space, primitives, permutation_indices, morton_indices, getLeafNodes(),
+      getInternalNodes());
 
-    Details::TreeConstruction::generateHierarchy(
-        space, primitives, permutation_indices, morton_indices, getLeafNodes(),
-        getInternalNodes());
+  Kokkos::deep_copy(
+      space,
+      Kokkos::View<BoundingVolume, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(
+          &_bounds),
+      Kokkos::View<BoundingVolume, MemorySpace, Kokkos::MemoryUnmanaged>(
+          &getBoundingVolume(getRoot())));
 
-    Kokkos::deep_copy(
-        space,
-        Kokkos::View<BoundingVolume, Kokkos::HostSpace,
-                     Kokkos::MemoryUnmanaged>(&_bounds),
-        Kokkos::View<BoundingVolume, MemorySpace, Kokkos::MemoryUnmanaged>(
-            &getBoundingVolume(getRoot())));
-  }
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::popRegion();
 }
 
 template <typename MemorySpace, typename BoundingVolume, typename Enable>
@@ -303,18 +302,16 @@ void BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::query(
       (std::is_same<Tag, Details::SpatialPredicateTag>{} ? "spatial"
                                                          : "nearest");
 
-  KokkosExt::ScopedProfileRegion guard_query(profiling_prefix);
+  Kokkos::Profiling::pushRegion(profiling_prefix);
 
   if (policy._sort_predicates)
   {
-    auto permute = [&]() {
-      KokkosExt::ScopedProfileRegion guard_compute_permutation(
-          profiling_prefix + "::compute_permutation");
-
-      using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
-      return Details::BatchedQueries<DeviceType>::sortQueriesAlongZOrderCurve(
-          space, static_cast<Box>(bounds()), predicates);
-    }();
+    Kokkos::Profiling::pushRegion(profiling_prefix + "::compute_permutation");
+    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
+    auto permute =
+        Details::BatchedQueries<DeviceType>::sortQueriesAlongZOrderCurve(
+            space, static_cast<Box>(bounds()), predicates);
+    Kokkos::Profiling::popRegion();
 
     using PermutedPredicates =
         Details::PermutedData<Predicates, decltype(permute)>;
@@ -325,6 +322,8 @@ void BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::query(
   {
     Details::traverse(space, *this, predicates, callback);
   }
+
+  Kokkos::Profiling::popRegion();
 }
 
 } // namespace ArborX

--- a/src/details/ArborX_DetailsKokkosExtScopedProfileRegion.hpp
+++ b/src/details/ArborX_DetailsKokkosExtScopedProfileRegion.hpp
@@ -1,0 +1,37 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_SCOPED_PROFILE_REGION_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_SCOPED_PROFILE_REGION_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <string>
+
+namespace KokkosExt
+{
+
+class ScopedProfileRegion
+{
+public:
+  ScopedProfileRegion(ScopedProfileRegion const &) = delete;
+  ScopedProfileRegion &operator=(ScopedProfileRegion const &) = delete;
+
+  explicit ScopedProfileRegion(std::string const &name)
+  {
+    Kokkos::Profiling::pushRegion(name);
+  }
+  ~ScopedProfileRegion() { Kokkos::Profiling::popRegion(); }
+};
+
+} // namespace KokkosExt
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,6 +121,7 @@ add_executable(ArborX_QueryTree.exe
   tstQueryTreeTraversalPolicy.cpp
   tstQueryTreeIntersectsKDOP.cpp
   tstKokkosToolsAnnotations.cpp
+  tstScopedProfileRegion.cpp
   utf_main.cpp)
 target_link_libraries(ArborX_QueryTree.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_QueryTree.exe PRIVATE BOOST_TEST_DYN_LINK)

--- a/test/tstScopedProfileRegion.cpp
+++ b/test/tstScopedProfileRegion.cpp
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <ArborX_DetailsKokkosExtScopedProfileRegion.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <stack>
+#include <string>
+#include <type_traits>
+
+#if (KOKKOS_VERSION >= 30200) // callback registration from within the program
+                              // was added in Kokkkos v3.2
+
+namespace
+{
+std::stack<std::string> arborx_test_region_stack;
+
+// NOTE: cannot use lambdas because they can only be converted to function
+// pointers if they don't capture anything
+void arborx_test_push_region(char const *label)
+{
+  BOOST_TEST_MESSAGE(std::string("push ") + label);
+  arborx_test_region_stack.push(label);
+}
+
+void arborx_test_pop_region()
+{
+  auto const &label = arborx_test_region_stack.top();
+  BOOST_TEST_MESSAGE(std::string("pop ") + label);
+  arborx_test_region_stack.pop();
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(KokkosToolsAnnotations)
+
+BOOST_AUTO_TEST_CASE(scoped_profile_region)
+{
+  Kokkos::Tools::Experimental::set_push_region_callback(
+      arborx_test_push_region);
+  Kokkos::Tools::Experimental::set_pop_region_callback(arborx_test_pop_region);
+
+  BOOST_TEST(arborx_test_region_stack.empty());
+
+  // Unnamed guard!  Profile region is popped at the end of the statement.
+  KokkosExt::ScopedProfileRegion("bug");
+
+  BOOST_TEST(arborx_test_region_stack.empty());
+
+  {
+    std::string outer_identifier = "outer";
+    KokkosExt::ScopedProfileRegion guard_outer(outer_identifier);
+
+    BOOST_TEST(arborx_test_region_stack.size() == 1);
+    BOOST_TEST(arborx_test_region_stack.top() == outer_identifier);
+
+    {
+      std::string inner_identifier = "inner";
+      KokkosExt::ScopedProfileRegion guard_inner(inner_identifier);
+      BOOST_TEST(arborx_test_region_stack.size() == 2);
+      BOOST_TEST(arborx_test_region_stack.top() == inner_identifier);
+    }
+
+    BOOST_TEST(arborx_test_region_stack.size() == 1);
+    BOOST_TEST(arborx_test_region_stack.top() == outer_identifier);
+  }
+
+  BOOST_TEST(arborx_test_region_stack.empty());
+
+  // Unset callbacks
+  Kokkos::Tools::Experimental::set_push_region_callback(nullptr);
+  Kokkos::Tools::Experimental::set_pop_region_callback(nullptr);
+}
+
+static_assert(
+    !std::is_default_constructible<KokkosExt::ScopedProfileRegion>::value, "");
+static_assert(
+    !std::is_copy_constructible<KokkosExt::ScopedProfileRegion>::value, "");
+static_assert(
+    !std::is_move_constructible<KokkosExt::ScopedProfileRegion>::value, "");
+static_assert(!std::is_copy_assignable<KokkosExt::ScopedProfileRegion>::value,
+              "");
+static_assert(!std::is_move_assignable<KokkosExt::ScopedProfileRegion>::value,
+              "");
+
+BOOST_AUTO_TEST_SUITE_END()
+
+#endif


### PR DESCRIPTION
Motivation: Calling `Kokkos::Profiling::popRegion()` at all the right places can be tedious and error-prone.  I ran into issues while using Kokkos tools on some ongoing work (HDBSCAN).

NOTE: I changed `<ArborX_LinearBVH.hpp>` to illustrate how one would guard profiling regions, I am not suggesting we absolutely should use the utility everywhere