### PR TITLE
Remove duplicate line from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@
 **Enhancements:**
 
 - Add `KOKKOS_FUNCTION` to `AccessTraits::size()` in View specialization [\#463](https://github.com/arborx/ArborX/pull/463)
-- Change signature of the nearest callback [\#366](https://github.com/arborx/ArborX/pull/366)
 - Add `query()` free function [\#425](https://github.com/arborx/ArborX/pull/425)
 - Improve performance for the HIP backend through the use of rocThrust for sorting [\#424](https://github.com/arborx/ArborX/pull/424)
 - Support for SYCL and OpenMPTarget [\#422](https://github.com/arborx/ArborX/pull/422)


### PR DESCRIPTION
The entry was listed both in Enhancements and Backward incompatible changes. Removed it from Enhancements.