### PR TITLE
Change ArborX hash to "hash-dirty" if worktree is not clean

### DIFF
--- a/cmake/SetupVersion.cmake
+++ b/cmake/SetupVersion.cmake
@@ -14,24 +14,24 @@
 # is called by through a target created by add_custom_target so that it is
 # always considered to be out-of-date.
 
-SET(ARBORX_GIT_COMMIT_HASH "No hash available")
+set(ARBORX_GIT_COMMIT_HASH "No hash available")
 
-IF(EXISTS ${SOURCE_DIR}/.git)
-  FIND_PACKAGE(Git QUIET)
-  IF(GIT_FOUND)
-    EXECUTE_PROCESS(
+if(EXISTS ${SOURCE_DIR}/.git)
+  find_package(Git QUIET)
+  if(GIT_FOUND)
+    execute_process(
       COMMAND          ${GIT_EXECUTABLE} rev-parse --verify --short HEAD
       OUTPUT_VARIABLE  ARBORX_GIT_COMMIT_HASH
       OUTPUT_STRIP_TRAILING_WHITESPACE)
-    EXECUTE_PROCESS(
+    execute_process(
       COMMAND          ${GIT_EXECUTABLE} status --porcelain --untracked-files=no
       OUTPUT_VARIABLE  ARBORX_GIT_WORKTREE_STATUS)
-    IF(ARBORX_GIT_WORKTREE_STATUS)
-      SET(ARBORX_GIT_COMMIT_HASH "${ARBORX_GIT_COMMIT_HASH}-dirty")
-    ENDIF()
-  ENDIF()
-ENDIF()
-MESSAGE(STATUS "ArborX hash = '${ARBORX_GIT_COMMIT_HASH}'")
+    if(ARBORX_GIT_WORKTREE_STATUS)
+      set(ARBORX_GIT_COMMIT_HASH "${ARBORX_GIT_COMMIT_HASH}-dirty")
+    endif()
+  endif()
+endif()
+message(STATUS "ArborX hash = '${ARBORX_GIT_COMMIT_HASH}'")
 
 configure_file(${SOURCE_DIR}/src/ArborX_Version.hpp.in
                ${BINARY_DIR}/include/ArborX_Version.hpp)


### PR DESCRIPTION
If a tree is dirty, it will print `<hash>-dirty`. This is helpful when we share logs.

One caveat is that if the `HEAD` points to an *annotated* tag, it will print a tag instead of a hash. However, I think we are only using lightweight tags, so I don't see much of an issue, and feel like it's worth doing this.