### PR TITLE
Auto adjust cell size in FDBSCAN-DenseBox based on input parameter

### DIFF
--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -21,8 +21,9 @@
 
 #include <fstream>
 
-std::vector<ArborX::Point> loadData(std::string const &filename,
-                                    bool binary = true, int max_num_points = -1)
+std::pair<std::vector<ArborX::Point>, int> loadData(std::string const &filename,
+                                                    bool binary = true,
+                                                    int max_num_points = -1)
 {
   std::cout << "Reading in \"" << filename << "\" in "
             << (binary ? "binary" : "text") << " mode...";
@@ -98,7 +99,7 @@ std::vector<ArborX::Point> loadData(std::string const &filename,
   std::cout << "done\nRead in " << num_points << " " << dim << "D points"
             << std::endl;
 
-  return v;
+  return std::make_pair(v, dim);
 }
 
 std::vector<ArborX::Point> sampleData(std::vector<ArborX::Point> const &data,
@@ -359,7 +360,9 @@ int main(int argc, char *argv[])
   printf("print timers      : %s\n", (print_dbscan_timers ? "true" : "false"));
 
   // read in data
-  std::vector<ArborX::Point> data = loadData(filename, binary, max_num_points);
+  std::vector<ArborX::Point> data;
+  int dim;
+  std::tie(data, dim) = loadData(filename, binary, max_num_points);
   if (num_samples > 0 && num_samples < (int)data.size())
     data = sampleData(data, num_samples);
   auto const primitives = vec2view<MemorySpace>(data, "primitives");
@@ -387,7 +390,8 @@ int main(int argc, char *argv[])
   auto labels = ArborX::dbscan(exec_space, primitives, eps, core_min_size,
                                ArborX::DBSCAN::Parameters()
                                    .setPrintTimers(print_dbscan_timers)
-                                   .setImplementation(implementation));
+                                   .setImplementation(implementation)
+                                   .setDimension(dim));
 
   timer_start(timer);
   Kokkos::View<int *, MemorySpace> cluster_indices("Testing::cluster_indices",

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -177,6 +177,10 @@ struct Parameters
   bool _print_timers = false;
   // Algorithm implementation (FDBSCAN or FDBSCAN-DenseBox)
   Implementation _implementation = Implementation::FDBSCAN_DenseBox;
+  // FIXME: as ArborX::Point is hardcoded to 3D right now, the only way to pass
+  // the dimension is through a parameter.
+  // NOTE: this is only useful for FDBSCAN-DenseBox algorithm
+  int _dim = 3;
 
   Parameters &setPrintTimers(bool print_timers)
   {
@@ -186,6 +190,12 @@ struct Parameters
   Parameters &setImplementation(Implementation impl)
   {
     _implementation = impl;
+    return *this;
+  }
+  Parameters &setDimension(int dim)
+  {
+    ARBORX_ASSERT(0 < dim && dim <= 3);
+    _dim = dim;
     return *this;
   }
 };
@@ -297,7 +307,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
 
     // The cell length is chosen to be eps/sqrt(dimension), so that any two
     // points within the same cell are within eps distance of each other.
-    float const h = eps / std::sqrt(3); // 3D (for 2D change to std::sqrt(2))
+    float const h = eps / std::sqrt(parameters._dim);
     Details::CartesianGrid const grid(bounds, h);
 
     auto cell_indices =


### PR DESCRIPTION
The cell's length `h = eps/sqrt(dim);`. It has been hardcoded to 3. This patch allows passing an extra DBSCAN parameter specifying dimension. In the future, it should be deduced from `ArborX::Point` (which right now is hardcoded to 3).

This change may have *slight* performance implications for some datasets and parameter configurations.