### PR TITLE
Cleanup box-ray intersection

### DIFF
--- a/src/details/ArborX_Ray.hpp
+++ b/src/details/ArborX_Ray.hpp
@@ -166,7 +166,7 @@ bool intersects(Ray const &ray, Box const &box)
   auto const &origin = ray.origin();
   auto const &direction = ray.direction();
 
-  auto const inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
+  constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
   float max_min = -inf;
   float min_max = inf;
 


### PR DESCRIPTION
Minor (hopefully uncontroversial) code cleanup before upcoming PR

The only change worth mentioning IMO is not bothering with `isnan` since the comparison would evaluate to false and the assignment would not happen anyway.