### PR TITLE
Ignore cv qualifiers in arithmetic traits 

### DIFF
--- a/src/details/ArborX_DetailsKokkosExtArithmeticTraits.hpp
+++ b/src/details/ArborX_DetailsKokkosExtArithmeticTraits.hpp
@@ -14,10 +14,13 @@
 
 #include <cfloat> // DBL_MAX, DBL_EPSILON
 #include <cmath>  // HUGE_VAL
+#include <type_traits>
 
 namespace KokkosExt
 {
 namespace ArithmeticTraits
+{
+namespace Details
 {
 
 template <typename T>
@@ -63,6 +66,23 @@ template <>
 struct epsilon<double>
 {
   static constexpr double value = DBL_EPSILON;
+};
+
+} // namespace Details
+
+template <class T>
+struct infinity : Details::infinity<std::remove_cv_t<T>>
+{
+};
+
+template <class T>
+struct max : Details::max<std::remove_cv_t<T>>
+{
+};
+
+template <class T>
+struct epsilon : Details::epsilon<std::remove_cv_t<T>>
+{
 };
 
 } // namespace ArithmeticTraits

--- a/src/details/ArborX_DetailsKokkosExtArithmeticTraits.hpp
+++ b/src/details/ArborX_DetailsKokkosExtArithmeticTraits.hpp
@@ -12,6 +12,25 @@
 #ifndef ARBORX_DETAILS_KOKKOS_EXT_ARITHMETIC_TRAITS_HPP
 #define ARBORX_DETAILS_KOKKOS_EXT_ARITHMETIC_TRAITS_HPP
 
+#include <Kokkos_Macros.hpp>
+#if KOKKOS_VERSION >= 30599
+#include <Kokkos_NumericTraits.hpp>
+namespace KokkosExt
+{
+namespace ArithmeticTraits
+{
+template <class T>
+using infinity = Kokkos::Experimental::infinity<T>;
+
+template <class T>
+using max = Kokkos::Experimental::finite_max<T>;
+
+template <class T>
+using epsilon = Kokkos::Experimental::epsilon<T>;
+} // namespace ArithmeticTraits
+} // namespace KokkosExt
+
+#else
 #include <cfloat> // DBL_MAX, DBL_EPSILON
 #include <cmath>  // HUGE_VAL
 #include <type_traits>
@@ -88,5 +107,6 @@ struct epsilon : Details::epsilon<std::remove_cv_t<T>>
 } // namespace ArithmeticTraits
 
 } // namespace KokkosExt
+#endif
 
 #endif


### PR DESCRIPTION
Also alias to Kokkos numeric traits when available