### PR TITLE
Refactor ray-box and ray-sphere intersection algorithms

### DIFF
--- a/src/details/ArborX_DetailsKokkosExtSwap.hpp
+++ b/src/details/ArborX_DetailsKokkosExtSwap.hpp
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * Copyright (c) 2017-2021 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_SWAP_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_SWAP_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace KokkosExt
+{
+
+template <class T>
+KOKKOS_FUNCTION constexpr void
+swap(T &a, T &b) noexcept(std::is_nothrow_move_constructible<T>::value
+                              &&std::is_nothrow_move_assignable<T>::value)
+{
+  T tmp = std::move(a);
+  a = std::move(b);
+  b = std::move(tmp);
+}
+
+} // namespace KokkosExt
+
+#endif

--- a/src/details/ArborX_Ray.hpp
+++ b/src/details/ArborX_Ray.hpp
@@ -265,13 +265,10 @@ KOKKOS_INLINE_FUNCTION bool intersection(Ray const &ray, Sphere const &sphere,
 
     return true;
   }
-  else
-  {
-    constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
-    tmin = inf;
-    tmax = -inf;
-    return false;
-  }
+  constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
+  tmin = inf;
+  tmax = -inf;
+  return false;
 }
 
 KOKKOS_INLINE_FUNCTION float overlapDistance(Ray const &ray,

--- a/src/details/ArborX_Ray.hpp
+++ b/src/details/ArborX_Ray.hpp
@@ -279,14 +279,8 @@ KOKKOS_INLINE_FUNCTION float overlapDistance(Ray const &ray,
 {
   float tmin;
   float tmax;
-  if (!intersection(ray, sphere, tmin, tmax))
+  if (!intersection(ray, sphere, tmin, tmax) || (tmax < 0))
   {
-    return 0.f;
-  }
-
-  if (tmax < 0)
-  {
-    // Half-ray does not intersect with the sphere
     return 0.f;
   }
 


### PR DESCRIPTION
Introduce `intersection(Ray, {Box,Sphere}, float&, float&} -> bool` functions.
The return value indicates whether the ray intersects with the geometry.  The trailing (output) parameters `tmin` and `tmax` provide the entry and exit point of the ray.

This is still a work in progress but I'd like feedback on the intent.