### PR TITLE
Bugfix bounding volume accesses in generate hierarchy

### DIFF
--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -334,6 +334,10 @@ public:
 
         delta_right = delta(range_right);
 
+        // Memory synchronization below ensures write from other threads to the
+        // child bounding volume memory location are visible from the current
+        // thread.
+        // NOTE we need acquire semantics at the device scope
         Kokkos::load_fence();
         expand(bounding_volume, getNodePtr(right_child)->bounding_volume);
       }

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -334,6 +334,7 @@ public:
 
         delta_right = delta(range_right);
 
+        Kokkos::load_fence();
         expand(bounding_volume, getNodePtr(right_child)->bounding_volume);
       }
       else
@@ -355,6 +356,7 @@ public:
 
         delta_left = delta(range_left - 1);
 
+        Kokkos::load_fence();
         expand(bounding_volume, getNodePtr(left_child)->bounding_volume);
       }
 
@@ -367,7 +369,6 @@ public:
       setRightChild(parent_node, right_child);
       setRope(parent_node, range_right, delta_right);
       parent_node->bounding_volume = bounding_volume;
-      Kokkos::memory_fence();
 
       i = karras_parent;
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -333,8 +333,9 @@ public:
           right_child += leaf_nodes_shift;
 
         delta_right = delta(range_right);
-
-        expand(bounding_volume, getNodePtr(right_child)->bounding_volume);
+        auto const right_child_bounding_volume =
+            Kokkos::volatile_load(&getNodePtr(right_child)->bounding_volume);
+        expand(bounding_volume, right_child_bounding_volume);
       }
       else
       {
@@ -354,8 +355,9 @@ public:
         right_child = i;
 
         delta_left = delta(range_left - 1);
-
-        expand(bounding_volume, getNodePtr(left_child)->bounding_volume);
+        auto const left_child_bounding_volume =
+            Kokkos::volatile_load(&getNodePtr(left_child)->bounding_volume);
+        expand(bounding_volume, left_child_bounding_volume);
       }
 
       // Having the full range for the parent, we can compute the Karras index.
@@ -366,7 +368,7 @@ public:
       parent_node->left_child = left_child;
       setRightChild(parent_node, right_child);
       setRope(parent_node, range_right, delta_right);
-      parent_node->bounding_volume = bounding_volume;
+      Kokkos::volatile_store(&parent_node->bounding_volume, bounding_volume);
 
       i = karras_parent;
 

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -333,9 +333,8 @@ public:
           right_child += leaf_nodes_shift;
 
         delta_right = delta(range_right);
-        auto const right_child_bounding_volume =
-            Kokkos::volatile_load(&getNodePtr(right_child)->bounding_volume);
-        expand(bounding_volume, right_child_bounding_volume);
+
+        expand(bounding_volume, getNodePtr(right_child)->bounding_volume);
       }
       else
       {
@@ -355,9 +354,8 @@ public:
         right_child = i;
 
         delta_left = delta(range_left - 1);
-        auto const left_child_bounding_volume =
-            Kokkos::volatile_load(&getNodePtr(left_child)->bounding_volume);
-        expand(bounding_volume, left_child_bounding_volume);
+
+        expand(bounding_volume, getNodePtr(left_child)->bounding_volume);
       }
 
       // Having the full range for the parent, we can compute the Karras index.
@@ -368,7 +366,8 @@ public:
       parent_node->left_child = left_child;
       setRightChild(parent_node, right_child);
       setRope(parent_node, range_right, delta_right);
-      Kokkos::volatile_store(&parent_node->bounding_volume, bounding_volume);
+      parent_node->bounding_volume = bounding_volume;
+      Kokkos::memory_fence();
 
       i = karras_parent;
 


### PR DESCRIPTION
Fix #574 

~~Only a draft because current solution does not play well with #575~~
nevermind it does not use `HappyTreeFriends::getBoundingVolume`