### PR TITLE
Clean up atomics calls

### DIFF
--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -192,7 +192,7 @@ struct CountCallback
   KOKKOS_FUNCTION void operator()(Query const &query, int) const
   {
     auto const i = ArborX::getData(query);
-    Kokkos::atomic_fetch_add(&count_(i), 1);
+    Kokkos::atomic_increment(&count_(i));
   }
 };
 

--- a/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
+++ b/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
@@ -78,7 +78,7 @@ struct CountCallback
   KOKKOS_FUNCTION void operator()(Query const &query, int) const
   {
     auto const i = ArborX::getData(query);
-    Kokkos::atomic_fetch_add(&_counts(i), 1);
+    Kokkos::atomic_increment(&_counts(i));
   }
 };
 

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -189,7 +189,7 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
                          if (labels(i) < 0)
                            return;
 
-                         Kokkos::atomic_fetch_add(&cluster_sizes(labels(i)), 1);
+                         Kokkos::atomic_increment(&cluster_sizes(labels(i)));
                        });
 
   // This kernel serves dual purpose:

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -83,7 +83,7 @@ struct AccumRaySphereInterDist
     float const length = overlapDistance(ray, sphere);
     int const i = getData(predicate);
 
-    Kokkos::atomic_fetch_add(&_accumulator(i), length);
+    Kokkos::atomic_add(&_accumulator(i), length);
   }
 };
 

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -449,7 +449,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
                          if (vstat != old)
                            labels(i) = vstat;
 
-                         Kokkos::atomic_fetch_add(&cluster_sizes(labels(i)), 1);
+                         Kokkos::atomic_increment(&cluster_sizes(labels(i)));
                        });
   if (is_special_case)
   {

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -99,7 +99,7 @@ struct InsertGenerator
     auto &count = _counts(predicate_index);
 
     return _callback(raw_predicate, primitive_index, [&](ValueType const &) {
-      Kokkos::atomic_fetch_add(&count, 1);
+      Kokkos::atomic_increment(&count);
     });
   }
 

--- a/src/details/ArborX_DetailsFDBSCAN.hpp
+++ b/src/details/ArborX_DetailsFDBSCAN.hpp
@@ -33,7 +33,7 @@ struct CountUpToN
   KOKKOS_FUNCTION auto operator()(Query const &query, int) const
   {
     auto i = getData(query);
-    Kokkos::atomic_fetch_add(&_counts(i), 1);
+    Kokkos::atomic_increment(&_counts(i));
 
     if (_counts(i) < _n)
       return ArborX::CallbackTreeTraversalControl::normal_continuation;

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -128,7 +128,7 @@ struct CountUpToN_DenseBox
         int j = _permute(jj);
         if (distance(query_point, Access::get(_primitives, j)) <= eps)
         {
-          Kokkos::atomic_fetch_add(&count, 1);
+          Kokkos::atomic_increment(&count);
           if (count >= _n)
             return ArborX::CallbackTreeTraversalControl::early_exit;
         }
@@ -136,7 +136,7 @@ struct CountUpToN_DenseBox
     }
     else
     {
-      Kokkos::atomic_fetch_add(&count, 1);
+      Kokkos::atomic_increment(&count);
       if (count >= _n)
         return ArborX::CallbackTreeTraversalControl::early_exit;
     }


### PR DESCRIPTION
- Replace `atomic_fetch_[op]` with `atomic_[op]` when return value is not
  used
- Replace `atomic_add(&ptr, 1)` with `atomic_increment(&ptr)`

The performance check on Ascent showed no difference for Cuda and Serial, and speedup for OpenMP (which I don't trust on Ascent).