### PR TITLE
Print kokkos version in performance drivers

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -227,6 +227,7 @@ int main(int argc, char *argv[])
 
   std::cout << "ArborX version: " << ArborX::version() << std::endl;
   std::cout << "ArborX hash   : " << ArborX::gitCommitHash() << std::endl;
+  std::cout << "Kokkos version: " << KokkosExt::version() << std::endl;
 
   if (vm.count("help") > 0)
   {

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -505,6 +505,7 @@ int main(int argc, char *argv[])
   {
     std::cout << "ArborX version: " << ArborX::version() << std::endl;
     std::cout << "ArborX hash   : " << ArborX::gitCommitHash() << std::endl;
+    std::cout << "Kokkos version: " << KokkosExt::version() << std::endl;
   }
 
   // Strip "--help" and "--kokkos-help" from the flags passed to Kokkos if we

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -299,6 +299,7 @@ int main(int argc, char *argv[])
 
   std::cout << "ArborX version    : " << ArborX::version() << std::endl;
   std::cout << "ArborX hash       : " << ArborX::gitCommitHash() << std::endl;
+  std::cout << "Kokkos version    : " << KokkosExt::version() << std::endl;
 
   namespace bpo = boost::program_options;
   using ArborX::DBSCAN::Implementation;

--- a/examples/molecular_dynamics/example_molecular_dynamics.cpp
+++ b/examples/molecular_dynamics/example_molecular_dynamics.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include <ArborX.hpp>
+#include <ArborX_Version.hpp>
 
 #include <Kokkos_Random.hpp>
 
@@ -52,6 +53,10 @@ struct ExcludeSelfCollision
 int main(int argc, char *argv[])
 {
   Kokkos::ScopeGuard guard(argc, argv);
+
+  std::cout << "ArborX version    : " << ArborX::version() << std::endl;
+  std::cout << "ArborX hash       : " << ArborX::gitCommitHash() << std::endl;
+  std::cout << "Kokkos version    : " << KokkosExt::version() << std::endl;
 
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
   using MemorySpace = ExecutionSpace::memory_space;

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -121,6 +121,7 @@ int main(int argc, char *argv[])
 
   std::cout << "ArborX version: " << ArborX::version() << std::endl;
   std::cout << "ArborX hash   : " << ArborX::gitCommitHash() << std::endl;
+  std::cout << "Kokkos version: " << KokkosExt::version() << std::endl;
 
   std::uniform_real_distribution<float> uniform{0.0, 1.0};
   std::default_random_engine gen;

--- a/src/details/ArborX_KokkosExtVersion.hpp
+++ b/src/details/ArborX_KokkosExtVersion.hpp
@@ -9,22 +9,25 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#ifndef ARBORX_VERSION_HPP
-#define ARBORX_VERSION_HPP
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_VERSION_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_VERSION_HPP
 
-#include <ArborX_Config.hpp>
+#include <Kokkos_Macros.hpp>
 
-#include <ArborX_KokkosExtVersion.hpp>
-
+#include <sstream>
 #include <string>
 
-namespace ArborX
+namespace KokkosExt
 {
 
-inline std::string version() { return "@ARBORX_VERSION_STRING@"; }
+inline std::string version()
+{
+  std::stringstream sstr;
+  sstr << KOKKOS_VERSION / 10000 << "." << (KOKKOS_VERSION % 10000) / 100 << "."
+       << KOKKOS_VERSION % 100;
+  return sstr.str();
+}
 
-inline std::string gitCommitHash() { return "@ARBORX_GIT_COMMIT_HASH@"; }
-
-} // namespace ArborX
+} // namespace KokkosExt
 
 #endif


### PR DESCRIPTION
When testing out different combinations in #579, I had to switch between multiple Kokkos versions. It occurred to me that it was impossible to figure out which Kokkos version was used just from the log files.

This patch introduces a new function, `kokkosVersion()` in `ArborX::Details` so that we can use it for saving that information. The implementation is taken from `Kokkos::Impl::<anonymous namespace>::version_string_from_int()` which we can't use.

The output looks like this:
```
ArborX version    : 1.2 (dev)
ArborX hash       : febd2b03-dirty
Kokkos version    : 3.4.1
```

The only thing I'm not certain is where this function should leave. I'm sure @dalg24 has strong opinions on that.

I would have liked to also know the Kokkos hash, but I did not find it in Kokkos.