### PR TITLE
Silence warning in SYCL backend for unknown CUDA version in installed version

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -435,6 +435,7 @@ pipeline {
                                         -D CMAKE_BUILD_TYPE=Release \
                                         -D CMAKE_CXX_COMPILER=clang++ \
                                         -D CMAKE_CXX_EXTENSIONS=OFF \
+                                        -D CMAKE_CXX_FLAGS="-Wno-unknown-cuda-version" \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR;$ONE_DPL_DIR" \
                                     examples \
                                 '''


### PR DESCRIPTION
This should avoid us seeing warnings related to `-Wno-unknown-cuda-version`.