### PR TITLE
Do not use `Kokkos::Impl::min_max_functor`

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -80,14 +80,19 @@ sortObjects(ExecutionSpace const &space, ViewType &view)
 {
   int const n = view.extent(0);
 
+  if (n == 0)
+  {
+    return Kokkos::View<SizeType *, typename ViewType::device_type> permute(
+        "ArborX::Sorting::permute", 0);
+  }
+
   using ValueType = typename ViewType::value_type;
   using CompType = Kokkos::BinOp1D<ViewType>;
 
   ValueType min_val;
   ValueType max_val;
-  if (n > 0) // non-empty view is precondition of minMax algorithm
-    std::tie(min_val, max_val) = ArborX::minMax(space, view);
-  if ((n == 0) || (min_val >= max_val))
+  std::tie(min_val, max_val) = ArborX::minMax(space, view);
+  if (min_val == max_val)
   {
     Kokkos::View<SizeType *, typename ViewType::device_type> permute(
         Kokkos::view_alloc(Kokkos::WithoutInitializing,

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -321,25 +321,25 @@ minMax(ExecutionSpace &&space, ViewType const &v)
   auto const n = v.extent(0);
   ARBORX_ASSERT(n > 0);
   using ValueType = typename ViewType::non_const_value_type;
-  Kokkos::MinMaxScalar<ValueType> result;
-  Kokkos::MinMax<ValueType> reducer(result);
+  ValueType min_val;
+  ValueType max_val;
   Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(
       "ArborX::Algorithms::minmax", policy,
-      KOKKOS_LAMBDA(int i, Kokkos::MinMaxScalar<ValueType> &local_minmax) {
+      KOKKOS_LAMBDA(int i, ValueType &local_min, ValueType &local_max) {
         auto const &val = v(i);
-        if (val < local_minmax.min_val)
+        if (val < local_min)
         {
-          local_minmax.min_val = val;
+          local_min = val;
         }
-        if (val > local_minmax.max_val)
+        if (val > local_max)
         {
-          local_minmax.max_val = val;
+          local_max = val;
         }
       },
-      reducer);
-  return std::make_pair(result.min_val, result.max_val);
+      Kokkos::Min<ValueType>(min_val), Kokkos::Max<ValueType>(max_val));
+  return std::make_pair(min_val, max_val);
 }
 
 template <typename ViewType>


### PR DESCRIPTION
We are not allowed to reach into the `Kokkos::Impl::` namespace.
Note that we could also use combined reducers.