### PR TITLE
Use CUDA-aware MPI in DistributedTree constructor

### DIFF
--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -153,14 +153,25 @@ DistributedTree<MemorySpace, Enable>::DistributedTree(
                          "ArborX::DistributedTree::DistributedTree::"
                          "rank_bounding_boxes"),
       comm_size);
-  // FIXME when we move to MPI with CUDA-aware support, we will not need to
-  // copy from the device to the host
+#ifdef ARBORX_USE_CUDA_AWARE_MPI
+  Box bottom_tree_bounds;
+  if (!_bottom_tree.empty())
+    Details::expand(bottom_tree_bounds, _bottom_tree.bounds());
+  Kokkos::deep_copy(Kokkos::subview(boxes, comm_rank), bottom_tree_bounds);
+
+  MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                static_cast<void *>(boxes.data()), sizeof(Box), MPI_BYTE,
+                getComm());
+#else
   auto boxes_host = Kokkos::create_mirror_view(boxes);
   boxes_host(comm_rank) = _bottom_tree.bounds();
+
   MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
                 static_cast<void *>(boxes_host.data()), sizeof(Box), MPI_BYTE,
                 getComm());
+
   Kokkos::deep_copy(space, boxes, boxes_host);
+#endif
 
   _top_tree = BVH<MemorySpace>{space, boxes};
 

--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -154,10 +154,9 @@ DistributedTree<MemorySpace, Enable>::DistributedTree(
                          "rank_bounding_boxes"),
       comm_size);
 #ifdef ARBORX_USE_CUDA_AWARE_MPI
-  Box bottom_tree_bounds;
-  if (!_bottom_tree.empty())
-    Details::expand(bottom_tree_bounds, _bottom_tree.bounds());
-  Kokkos::deep_copy(Kokkos::subview(boxes, comm_rank), bottom_tree_bounds);
+  Kokkos::deep_copy(space, Kokkos::subview(boxes, comm_rank),
+                    _bottom_tree.bounds());
+  space.fence();
 
   MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
                 static_cast<void *>(boxes.data()), sizeof(Box), MPI_BYTE,


### PR DESCRIPTION
Cleanup of #174. In the past couple years we had several developments that make this easy to implement. So might as well finish it.

I decided to not force push in #174, so that we can compare the PRs. 