### PR TITLE
Use Kokkos 3.4.01 in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ stages:
   extends: .LoadModules
   stage: buildDependencies
   script:
-    - git clone --depth=1 --branch 3.1.00 https://github.com/kokkos/kokkos.git &&
+    - git clone --depth=1 --branch 3.4.01 https://github.com/kokkos/kokkos.git &&
       cd kokkos &&
       mkdir build &&
       cd build &&


### PR DESCRIPTION
Since we require a newer Kokkos release, we also need to update the GitLab performance regression tests to keep the running.