### PR TITLE
Provide ARBORX_DEVICE_NO_HOST_TYPES for testing

### DIFF
--- a/test/ArborX_EnableDeviceTypes.hpp.in
+++ b/test/ArborX_EnableDeviceTypes.hpp.in
@@ -17,5 +17,6 @@
 #include <tuple>
 
 using ARBORX_DEVICE_TYPES = std::tuple<@ARBORX_DEVICE_TYPES@>;
+using ARBORX_DEVICE_NO_HOST_TYPES = std::tuple<@ARBORX_DEVICE_NO_HOST_TYPES@>;
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,16 @@ if(Kokkos_ENABLE_SYCL)
   list(APPEND ARBORX_DEVICE_TYPES Kokkos::Experimental::SYCL::device_type)
 endif()
 
+set(ARBORX_DEVICE_NO_HOST_TYPES "${ARBORX_DEVICE_TYPES}")
+if(Kokkos_ENABLE_SERIAL)
+  list(REMOVE_ITEM ARBORX_DEVICE_NO_HOST_TYPES Kokkos::Serial::device_type)
+endif()
+if(Kokkos_ENABLE_OPENMP)
+  list(REMOVE_ITEM ARBORX_DEVICE_NO_HOST_TYPES Kokkos::OpenMP::device_type)
+endif()
+
 string(REPLACE ";" "," ARBORX_DEVICE_TYPES "${ARBORX_DEVICE_TYPES}")
+string(REPLACE ";" "," ARBORX_DEVICE_NO_HOST_TYPES "${ARBORX_DEVICE_NO_HOST_TYPES}")
 
 if(NOT ARBORX_DEVICE_TYPES)
   message(SEND_ERROR "Kokkos_DEVICES must include at least one of 'SERIAL', 'OPENMP', 'CUDA', 'HIP', 'OPENMPTARGET', 'SYCL' or 'THREADS'!")


### PR DESCRIPTION
This allows easier disabling of tests for host architectures. The main
motivation is to allow testing functionality that uses sorting with
custom comparator operation or complicated types, which are not
supported by Kokkos::BinSort.