### PR TITLE
Avoid using > comparison in min_max calculations

### DIFF
--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -333,7 +333,7 @@ minMax(ExecutionSpace &&space, ViewType const &v)
         {
           local_min = val;
         }
-        if (val > local_max)
+        if (local_max < val)
         {
           local_max = val;
         }


### PR DESCRIPTION
This allows function to work when only `operator<()` is provided.