### PR TITLE
Cancel previous CI builds when changes are pushed to the branch

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -1,4 +1,7 @@
 pipeline {
+    options {
+        disableConcurrentBuilds(abortPrevious: true)
+    }
     triggers {
         issueCommentTrigger('.*test this please.*')
     }


### PR DESCRIPTION
I just realized this is now supported for Multibranch Pipeline and our server has a recent enough version of the plugins.
https://issues.jenkins.io/browse/JENKINS-43353

This will cancel previous builds of your PR if you push to the branch.  I am not quite sure if it disallow testing two different PRs at the same time but this is fine.