### PR TITLE
Add facility to compute the minimum spanning tree

### DIFF
--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -41,8 +41,8 @@ public:
   // order, it returns the permutation indices.  applyPermutation() was added
   // in that purpose.  reversePermutation() is able to restore the initial
   // order on the results that are in "compressed row storage" format.  You
-  // may notice it is not used any more in the code that performs the batched
-  // queries.  We found that it was slighly more performant to add a level of
+  // may notice it is not used anymore in the code that performs the batched
+  // queries.  We found that it was slightly more performant to add a level of
   // indirection when recording results rather than using that function at
   // the end.  We decided to keep reversePermutation around for now.
 

--- a/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
+++ b/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
@@ -89,6 +89,17 @@ struct MutualReachability
   }
 };
 
+struct Euclidean
+{
+  using value_type = float;
+  using size_type = int;
+  KOKKOS_FUNCTION value_type operator()(size_type /*i*/, size_type /*j*/,
+                                        value_type distance_ij) const
+  {
+    return distance_ij;
+  }
+};
+
 } // namespace Details
 
 } // namespace ArborX

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -1,0 +1,516 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_MINIMUM_SPANNING_TREE_HPP
+#define ARBORX_MINIMUM_SPANNING_TREE_HPP
+
+#include <ArborX_AccessTraits.hpp>
+#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
+#include <ArborX_DetailsMutualReachabilityDistance.hpp>
+#include <ArborX_DetailsTreeNodeLabeling.hpp>
+#include <ArborX_DetailsUtils.hpp>
+#include <ArborX_LinearBVH.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#if KOKKOS_VERSION < 30500
+#error requiring atomic operations from Kokkos 3.5
+#endif
+
+namespace ArborX
+{
+namespace Details
+{
+
+struct WeightedEdge
+{
+  int source;
+  int target;
+  float weight;
+
+private:
+  // performs lexicographical comparison by comparing first the weights and then
+  // the unordered pair of vertices
+  friend KOKKOS_FUNCTION constexpr bool operator<(WeightedEdge const &lhs,
+                                                  WeightedEdge const &rhs)
+  {
+    if (lhs.weight != rhs.weight)
+    {
+      return (lhs.weight < rhs.weight);
+    }
+    using KokkosExt::min;
+    auto const lhs_min = min(lhs.source, lhs.target);
+    auto const rhs_min = min(rhs.source, rhs.target);
+    if (lhs_min != rhs_min)
+    {
+      return (lhs_min < rhs_min);
+    }
+    using KokkosExt::max;
+    auto const lhs_max = max(lhs.source, lhs.target);
+    auto const rhs_max = max(rhs.source, rhs.target);
+    return (lhs_max < rhs_max);
+  }
+};
+
+template <class BVH, class Labels, class Edges, class Metric, class Radii>
+struct FindComponentNearestNeighbors
+{
+  BVH _bvh;
+  Labels _labels;
+  Edges _edges;
+  Metric _metric;
+  Radii _radii;
+
+  template <class ExecutionSpace>
+  FindComponentNearestNeighbors(ExecutionSpace const &space, BVH const &bvh,
+                                Labels const &labels, Edges const &edges,
+                                Metric const &metric, Radii const &radii)
+      : _bvh(bvh)
+      , _labels(labels)
+      , _edges(edges)
+      , _metric{metric}
+      , _radii(radii)
+  {
+    auto const n = bvh.size();
+    ARBORX_ASSERT(labels.extent(0) == 2 * n - 1);
+    ARBORX_ASSERT(edges.extent(0) == n);
+    ARBORX_ASSERT(radii.extent(0) == n);
+
+    Kokkos::parallel_for(
+        "ArborX::MST::find_component_nearest_neighbors",
+        Kokkos::RangePolicy<ExecutionSpace>(space, n - 1, 2 * n - 1), *this);
+  }
+
+  KOKKOS_FUNCTION void operator()(int i) const
+  {
+    constexpr int undetermined = -1;
+    constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
+
+    auto const distance = [bounding_volume_i =
+                               HappyTreeFriends::getBoundingVolume(_bvh, i),
+                           &bvh = _bvh](int j) {
+      using Details::distance;
+      return distance(bounding_volume_i,
+                      HappyTreeFriends::getBoundingVolume(bvh, j));
+    };
+
+    auto const component = _labels(i);
+    auto const predicate = [label_i = component, &labels = _labels](int j) {
+      return label_i != labels(j);
+    };
+    auto const leaf_permutation_i =
+        HappyTreeFriends::getLeafPermutationIndex(_bvh, i);
+
+    WeightedEdge current_best{i, undetermined, inf};
+
+    auto const n = _bvh.size();
+    auto &radius = _radii(component - n + 1);
+
+    constexpr int SENTINEL = -1;
+    int stack[64];
+    auto *stack_ptr = stack;
+    *stack_ptr++ = SENTINEL;
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+    float stack_distance[64];
+    auto *stack_distance_ptr = stack_distance;
+    *stack_distance_ptr++ = 0;
+#endif
+
+    int node = HappyTreeFriends::getRoot(_bvh);
+    float distance_node = 0;
+
+    // Important! The truncation radius is computed using the provided metric,
+    // rather than just assigning the Euclidean distance. This only works for
+    // metrics that return a value greater or equal to Euclidean distance
+    // (e.g., mutual reachability metric). Metrics that do not satisfy this
+    // criteria may return wrong results.
+    do
+    {
+      bool traverse_left = false;
+      bool traverse_right = false;
+
+      int left_child;
+      int right_child;
+      float distance_left = inf;
+      float distance_right = inf;
+
+      // Note it is <= instead of < when comparing with radius here and below.
+      // The reason is that in Boruvka it matters which of the equidistant
+      // points we take so that they don't create a cycle among component
+      // connectivity. This requires us to uniquely resolve equidistant
+      // neighbors, so we cannot skip any of them.
+      if (distance_node <= radius)
+      {
+        // Insert children into the stack and make sure that the closest one
+        // ends on top.
+        left_child = HappyTreeFriends::getLeftChild(_bvh, node);
+        right_child = HappyTreeFriends::getRightChild(_bvh, node);
+        distance_left = distance(left_child);
+        distance_right = distance(right_child);
+
+        if (predicate(left_child) && distance_left <= radius)
+        {
+          if (HappyTreeFriends::isLeaf(_bvh, left_child))
+          {
+            float const candidate_dist = _metric(
+                leaf_permutation_i,
+                HappyTreeFriends::getLeafPermutationIndex(_bvh, left_child),
+                distance_left);
+            WeightedEdge const candidate_edge{i, left_child, candidate_dist};
+            if (candidate_edge < current_best)
+            {
+              current_best = candidate_edge;
+              Kokkos::atomic_min(&radius, candidate_dist);
+            }
+          }
+          else
+          {
+            traverse_left = true;
+          }
+        }
+
+        // Note: radius may have been already updated here from the left child
+        if (predicate(right_child) && distance_right <= radius)
+        {
+          if (HappyTreeFriends::isLeaf(_bvh, right_child))
+          {
+            float const candidate_dist = _metric(
+                leaf_permutation_i,
+                HappyTreeFriends::getLeafPermutationIndex(_bvh, right_child),
+                distance_right);
+            WeightedEdge const candidate_edge{i, right_child, candidate_dist};
+            if (candidate_edge < current_best)
+            {
+              current_best = candidate_edge;
+              Kokkos::atomic_min(&radius, candidate_dist);
+            }
+          }
+          else
+          {
+            traverse_right = true;
+          }
+        }
+      }
+
+      if (!traverse_left && !traverse_right)
+      {
+        node = *--stack_ptr;
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+        if (node != SENTINEL)
+        {
+          // This is a theoretically unnecessary duplication of distance
+          // calculation for stack nodes. However, for Cuda it's better than
+          // putting the distances in stack.
+          distance_node = distance(node);
+        }
+#else
+        distance_node = *--stack_distance_ptr;
+#endif
+      }
+      else
+      {
+        node = (traverse_left &&
+                (distance_left <= distance_right || !traverse_right))
+                   ? left_child
+                   : right_child;
+        distance_node = (node == left_child ? distance_left : distance_right);
+        if (traverse_left && traverse_right)
+        {
+          *stack_ptr++ = (node == left_child ? right_child : left_child);
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+          *stack_distance_ptr++ =
+              (node == left_child ? distance_right : distance_left);
+#endif
+        }
+      }
+    } while (node != SENTINEL);
+
+    // This check is only here to reduce hammering the atomics for large
+    // components. Otherwise, for a large number of points and a small number of
+    // components it becomes extremely expensive.
+    auto &component_edge = _edges(component - n + 1);
+    if (current_best < component_edge)
+    {
+      Kokkos::atomic_min(&component_edge, current_best);
+    }
+  }
+};
+
+template <class ExecutionSpace, class BVH, class Labels, class Edges,
+          class Metric, class Radii>
+void findComponentNearestNeighbors(ExecutionSpace const &space, BVH const &bvh,
+                                   Labels const &labels, Edges const &edges,
+                                   Metric const &metric, Radii const &radii)
+{
+  FindComponentNearestNeighbors<BVH, Labels, Edges, Metric, Radii>(
+      space, bvh, labels, edges, metric, radii);
+}
+
+template <class Labels, class OutEdges, class Edges, class EdgesCount>
+struct UpdateComponentsAndEdges
+{
+  Labels _labels;
+  OutEdges _out_edges;
+  Edges _edges;
+  EdgesCount _num_edges;
+
+  template <class ExecutionSpace>
+  UpdateComponentsAndEdges(ExecutionSpace const &space, Labels const &labels,
+                           OutEdges const &out_edges, Edges const &edges,
+                           EdgesCount const &count)
+      : _labels(labels)
+      , _out_edges(out_edges)
+      , _edges(edges)
+      , _num_edges(count)
+  {
+    auto const n = out_edges.extent(0);
+    ARBORX_ASSERT(labels.extent(0) == 2 * n - 1);
+    ARBORX_ASSERT(edges.extent(0) == n - 1);
+
+    Kokkos::parallel_for(
+        "ArborX::MST::update_components_and_edges",
+        Kokkos::RangePolicy<ExecutionSpace>(space, n - 1, 2 * n - 1), *this);
+  }
+
+  KOKKOS_FUNCTION auto computeNextComponent(int component) const
+  {
+    auto const n = _out_edges.extent(0);
+
+    int next_component = _labels(_out_edges(component - n + 1).target);
+    int next_next_component =
+        _labels(_out_edges(next_component - n + 1).target);
+
+    if (next_next_component != component)
+    {
+      // The component's edge is unidirectional
+      return next_component;
+    }
+    // The component's edge is bidirectional, uniquely resolve the bidirectional
+    // edge
+    return KokkosExt::min(component, next_component);
+  }
+
+  KOKKOS_FUNCTION auto computeFinalComponent(int component) const
+  {
+    int prev_component = component;
+    int next_component;
+    while ((next_component = computeNextComponent(prev_component)) !=
+           prev_component)
+      prev_component = next_component;
+
+    return next_component;
+  }
+
+  KOKKOS_FUNCTION void operator()(int i) const
+  {
+    auto const component = _labels(i);
+    auto const final_component = computeFinalComponent(component);
+    _labels(i) = final_component;
+    if (i != component)
+    {
+      return;
+    }
+    auto const n = _out_edges.extent(0);
+    if (i != final_component)
+    {
+      auto const edge = _out_edges(i - n + 1);
+      // append new edge at the "end" of the array (akin to
+      // std::vector::push_back)
+      auto const back =
+          Kokkos::atomic_fetch_inc(&_num_edges()); // atomic post-increment
+      _edges(back) = edge;
+    }
+  }
+};
+
+// Merge components and append new edges
+template <class ExecutionSpace, class Labels, class ComponentOutEdges,
+          class Edges, class EdgesCount>
+void updateComponentsAndEdges(ExecutionSpace const &space,
+                              ComponentOutEdges const &component_out_edges,
+                              Labels const &labels, Edges const &edges,
+                              EdgesCount const &num_edges)
+{
+  UpdateComponentsAndEdges<Labels, ComponentOutEdges, Edges, EdgesCount>(
+      space, labels, component_out_edges, edges, num_edges);
+}
+
+// Reverse node leaf permutation order back to original indices
+template <class ExecutionSpace, class BVH, class Edges>
+void finalizeEdges(ExecutionSpace const &space, BVH const &bvh,
+                   Edges const &edges)
+{
+  auto const n = bvh.size();
+  ARBORX_ASSERT(edges.extent(0) == n - 1);
+  Kokkos::parallel_for(
+      "ArborX::MST::finalize_edges",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n - 1),
+      KOKKOS_LAMBDA(int i) {
+        edges(i).source =
+            HappyTreeFriends::getLeafPermutationIndex(bvh, edges(i).source);
+        edges(i).target =
+            HappyTreeFriends::getLeafPermutationIndex(bvh, edges(i).target);
+      });
+}
+
+template <class ExecutionSpace, class BVH, class Labels, class Metric,
+          class Radii>
+void resetSharedRadii(ExecutionSpace const &space, BVH const &bvh,
+                      Labels const &labels, Metric const &metric,
+                      Radii const &radii)
+{
+  //  We will search for the shortest outgoing edge of a component. The better
+  //  we initialize the upper bound on the distance (i.e., the smaller it is),
+  //  the less traversal we will do and the faster it will be.
+  //
+  // Here, we use the knowledge that it is a self-collision problem. In other
+  // words, we only have a single point cloud. We further use the fact that if
+  // we sort predicates based on the Morton codes, it will match the order of
+  // predicates (or be close enough, as some points with the same Morton codes
+  // may be in a different order due to the unstable sort that we use). Thus, if
+  // we take an index of a query, we assume that it matches corresponding
+  // primitive. If a label of that primitive is different from a label of its
+  // neighbor (which is in fact its Morton neighbor), we compute the distance
+  // between the two. The upper bound for a component is set to the minimum
+  // distance between all such pairs. Given that the Morton neighbors are
+  // typically close to each other, this should provide a reasonably low bound.
+  auto const n = bvh.size();
+  Kokkos::parallel_for(
+      "ArborX::MST::reset_shared_radii",
+      Kokkos::RangePolicy<ExecutionSpace>(space, n - 1, 2 * n - 2),
+      KOKKOS_LAMBDA(int i) {
+        int const j = i + 1;
+        auto const label_i = labels(i);
+        auto const label_j = labels(j);
+        if (label_i != label_j)
+        {
+          auto const r =
+              metric(HappyTreeFriends::getLeafPermutationIndex(bvh, i),
+                     HappyTreeFriends::getLeafPermutationIndex(bvh, j),
+                     distance(HappyTreeFriends::getBoundingVolume(bvh, i),
+                              HappyTreeFriends::getBoundingVolume(bvh, j)));
+          Kokkos::atomic_min(&radii(label_i - n + 1), r);
+          Kokkos::atomic_min(&radii(label_j - n + 1), r);
+        }
+      });
+}
+
+template <class MemorySpace>
+struct MinimumSpanningTree
+{
+  Kokkos::View<WeightedEdge *, MemorySpace> edges;
+
+  template <class ExecutionSpace, class Primitives>
+  MinimumSpanningTree(ExecutionSpace const &space, Primitives const &primitives,
+                      int k = 1)
+      : edges(Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                 "ArborX::MST::edges"),
+              AccessTraits<Primitives, PrimitivesTag>::size(primitives) - 1)
+  {
+    Kokkos::Profiling::pushRegion("ArborX::MST::MST");
+
+    BVH<MemorySpace> bvh(space, primitives);
+    auto const n = bvh.size();
+
+    if (k > 1)
+    {
+      Kokkos::Profiling::pushRegion("ArborX::MST::compute_core_distances");
+      Kokkos::View<float *, MemorySpace> core_distances(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                             "ArborX::MST::core_distances"),
+          n);
+      bvh.query(space, NearestK<Primitives>{primitives, k},
+                MaxDistance<Primitives, decltype(core_distances)>{
+                    primitives, core_distances});
+      Kokkos::Profiling::popRegion();
+
+      MutualReachability<decltype(core_distances)> mutual_reachability{
+          core_distances};
+      doBoruvka(space, bvh, mutual_reachability);
+    }
+    else
+    {
+      doBoruvka(space, bvh, Euclidean{});
+    }
+
+    finalizeEdges(space, bvh, edges);
+
+    Kokkos::Profiling::popRegion();
+  }
+
+private:
+  template <class ExecutionSpace, class BVH, class Metric>
+  void doBoruvka(ExecutionSpace const &space, BVH const &bvh,
+                 Metric const &metric)
+  {
+    auto const n = bvh.size();
+    Kokkos::View<int *, MemorySpace> parents(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "ArborX::MST::parents"),
+        2 * n - 1);
+    findParents(space, bvh, parents);
+
+    Kokkos::Profiling::pushRegion("ArborX::MST::initialize_node_labels");
+    Kokkos::View<int *, MemorySpace> labels(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "ArborX::MST::labels"),
+        2 * n - 1);
+    iota(space, Kokkos::subview(labels, std::make_pair(n - 1, 2 * n - 1)),
+         n - 1);
+    Kokkos::Profiling::popRegion();
+
+    Kokkos::View<WeightedEdge *, MemorySpace> component_out_edges(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                           "ArborX::MST::component_out_edges"),
+        n);
+
+    Kokkos::View<float *, MemorySpace> radii(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "ArborX::MST::radii"),
+        n);
+
+    Kokkos::Profiling::pushRegion("ArborX::MST::Boruvka_loop");
+    Kokkos::View<int, MemorySpace> num_edges(Kokkos::view_alloc(
+        Kokkos::WithoutInitializing, "ArborX::MST::num_edges"));
+    Kokkos::deep_copy(space, num_edges, 0);
+
+    // Boruvka iterations
+    int iterations = 0;
+    int num_components = n;
+    do
+    {
+      Kokkos::Profiling::pushRegion("ArborX::Boruvka_" +
+                                    std::to_string(++iterations) + "_" +
+                                    std::to_string(num_components));
+      reduceLabels(space, parents, labels);
+      constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
+      Kokkos::deep_copy(space, component_out_edges, {-1, -1, inf});
+      Kokkos::deep_copy(space, radii, inf);
+      resetSharedRadii(space, bvh, labels, metric, radii);
+      findComponentNearestNeighbors(space, bvh, labels, component_out_edges,
+                                    metric, radii);
+      // NOTE could perform the label tree reduction as part of the update
+      updateComponentsAndEdges(space, component_out_edges, labels, edges,
+                               num_edges);
+      num_components =
+          static_cast<int>(n) -
+          Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, num_edges)();
+      Kokkos::Profiling::popRegion();
+#if 0
+      printf("%d: %d\n", iterations, num_components);
+#endif
+    } while (num_components > 1);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+} // namespace Details
+} // namespace ArborX
+
+#endif

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -375,9 +375,9 @@ void resetSharedRadii(ExecutionSpace const &space, BVH const &bvh,
   // Here, we use the knowledge that it is a self-collision problem. In other
   // words, we only have a single point cloud. We further use the fact that if
   // we sort predicates based on the Morton codes, it will match the order of
-  // predicates (or be close enough, as some points with the same Morton codes
+  // primitives (or be close enough, as some points with the same Morton codes
   // may be in a different order due to the unstable sort that we use). Thus, if
-  // we take an index of a query, we assume that it matches corresponding
+  // we take an index of a query, we assume that it matches the corresponding
   // primitive. If a label of that primitive is different from a label of its
   // neighbor (which is in fact its Morton neighbor), we compute the distance
   // between the two. The upper bound for a component is set to the minimum

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -110,7 +110,8 @@ struct FindComponentNearestNeighbors
 
     WeightedEdge current_best{i, undetermined, inf};
     static_assert(WeightedEdge{undetermined, undetermined, inf} <
-                  WeightedEdge{0, undetermined, inf});
+                      WeightedEdge{0, undetermined, inf},
+                  "");
 
     auto const n = _bvh.size();
     auto &radius = _radii(component - n + 1);
@@ -492,7 +493,7 @@ private:
       constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
       constexpr WeightedEdge uninitialized_edge{-1, -1, inf};
       constexpr WeightedEdge partially_initialized_edge{0, -1, inf};
-      static_assert(uninitialized_edge < partially_initialized_edge);
+      static_assert(uninitialized_edge < partially_initialized_edge, "");
       Kokkos::deep_copy(space, component_out_edges, uninitialized_edge);
       Kokkos::deep_copy(space, radii, inf);
       resetSharedRadii(space, bvh, labels, metric, radii);

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -109,6 +109,8 @@ struct FindComponentNearestNeighbors
         HappyTreeFriends::getLeafPermutationIndex(_bvh, i);
 
     WeightedEdge current_best{i, undetermined, inf};
+    static_assert(WeightedEdge{undetermined, undetermined, inf} <
+                  WeightedEdge{0, undetermined, inf});
 
     auto const n = _bvh.size();
     auto &radius = _radii(component - n + 1);
@@ -488,7 +490,10 @@ private:
                                     std::to_string(num_components));
       reduceLabels(space, parents, labels);
       constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
-      Kokkos::deep_copy(space, component_out_edges, {-1, -1, inf});
+      constexpr WeightedEdge uninitialized_edge{-1, -1, inf};
+      constexpr WeightedEdge partially_initialized_edge{0, -1, inf};
+      static_assert(uninitialized_edge < partially_initialized_edge);
+      Kokkos::deep_copy(space, component_out_edges, uninitialized_edge);
       Kokkos::deep_copy(space, radii, inf);
       resetSharedRadii(space, bvh, labels, metric, radii);
       findComponentNearestNeighbors(space, bvh, labels, component_out_edges,

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -22,9 +22,7 @@
 
 #include <Kokkos_Core.hpp>
 
-#if KOKKOS_VERSION < 30500
-#error requiring atomic operations from Kokkos 3.5
-#endif
+#if KOKKOS_VERSION >= 30500
 
 namespace ArborX
 {
@@ -513,4 +511,5 @@ private:
 } // namespace Details
 } // namespace ArborX
 
+#endif
 #endif

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -499,8 +499,6 @@ private:
       reduceLabels(space, parents, labels);
       constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
       constexpr WeightedEdge uninitialized_edge{-1, -1, inf};
-      constexpr WeightedEdge partially_initialized_edge{0, -1, inf};
-      static_assert(uninitialized_edge < partially_initialized_edge, "");
       Kokkos::deep_copy(space, component_out_edges, uninitialized_edge);
       Kokkos::deep_copy(space, radii, inf);
       resetSharedRadii(space, bvh, labels, metric, radii);

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -505,9 +505,6 @@ private:
           static_cast<int>(n) -
           Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, num_edges)();
       Kokkos::Profiling::popRegion();
-#if 0
-      printf("%d: %d\n", iterations, num_components);
-#endif
     } while (num_components > 1);
     Kokkos::Profiling::popRegion();
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -161,7 +161,7 @@ target_compile_definitions(ArborX_Clustering.exe PRIVATE BOOST_TEST_DYN_LINK)
 target_include_directories(ArborX_Clustering.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/examples/dbscan)
 add_test(NAME ArborX_Clustering_Test COMMAND ./ArborX_Clustering.exe)
 
-if(Kokkos_VERSION VERSION_GREATER_EQUAL 3.5)
+if(Kokkos_VERSION VERSION_GREATER_EQUAL 3.5 AND NOT Kokkos_ENABLE_SYCL) # FIXME_SYCL
   set(MINIMUM_SPANNING_TREE_TESTS
     tstMinimumSpanningTree.cpp
   )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -161,9 +161,15 @@ target_compile_definitions(ArborX_Clustering.exe PRIVATE BOOST_TEST_DYN_LINK)
 target_include_directories(ArborX_Clustering.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/examples/dbscan)
 add_test(NAME ArborX_Clustering_Test COMMAND ./ArborX_Clustering.exe)
 
+if(Kokkos_VERSION VERSION_GREATER_EQUAL 3.5)
+  set(MINIMUM_SPANNING_TREE_TESTS
+    tstMinimumSpanningTree.cpp
+  )
+endif()
 add_executable(ArborX_DetailsClusteringHelpers.exe
   tstDetailsTreeNodeLabeling.cpp
   tstDetailsMutualReachabilityDistance.cpp
+  ${MINIMUM_SPANNING_TREE_TESTS}
   utf_main.cpp
 )
 target_link_libraries(ArborX_DetailsClusteringHelpers.exe PRIVATE ArborX Boost::unit_test_framework)

--- a/test/tstCompileOnlyCallbacks.cpp
+++ b/test/tstCompileOnlyCallbacks.cpp
@@ -106,7 +106,7 @@ void test_callbacks_compile_only()
   check_valid_callback(ArborX::Details::DefaultCallback{}, NearestPredicates{},
                        v);
 
-  // not required to tag inline callbacks any more
+  // not required to tag inline callbacks anymore
   check_valid_callback(CallbackMissingTag{}, SpatialPredicates{}, v);
   check_valid_callback(CallbackMissingTag{}, NearestPredicates{}, v);
 

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -15,8 +15,8 @@
 #define BOOST_TEST_MODULE Geometry
 #include <boost/test/unit_test.hpp>
 
-// NOTE: message is not required any more with C++17
-#define STATIC_ASSERT(cond) static_assert(cond, "");
+// NOTE: message is not required anymore with C++17
+#define STATIC_ASSERT(cond) static_assert(cond, "")
 
 using ArborX::Box;
 using ArborX::Point;

--- a/test/tstMinimumSpanningTree.cpp
+++ b/test/tstMinimumSpanningTree.cpp
@@ -1,0 +1,168 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborXTest_StdVectorToKokkosView.hpp"
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include "ArborX_EnableViewComparison.hpp"
+#include <ArborX_MinimumSpanningTree.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+// NOTE: message is not required anymore with C++17
+#define STATIC_ASSERT(cond) static_assert(cond, "")
+
+void test_compile_only()
+{
+  using ArborX::Details::WeightedEdge;
+  STATIC_ASSERT((WeightedEdge{1, 2, 3} < WeightedEdge{1, 2, 4}));
+  STATIC_ASSERT((WeightedEdge{1, 2, 3} < WeightedEdge{1, 4, 3}));
+}
+
+namespace ArborX
+{
+namespace Details
+{
+// NOTE not sure why but wasn't detected when defined in the global namespace
+inline constexpr bool operator==(WeightedEdge const &lhs,
+                                 WeightedEdge const &rhs)
+{
+  return !(lhs < rhs) && !(rhs < lhs);
+}
+} // namespace Details
+} // namespace ArborX
+
+void test_another_compile_only()
+{
+  using ArborX::Details::WeightedEdge;
+  STATIC_ASSERT((WeightedEdge{1, 2, 3} == WeightedEdge{1, 2, 3}));
+}
+
+template <>
+struct boost::test_tools::tt_detail::print_log_value<
+    ArborX::Details::WeightedEdge>
+{
+  void operator()(std::ostream &os, ArborX::Details::WeightedEdge const &e)
+  {
+    os << e.source << " -> " << e.target << " [weight=" << e.weight << "]";
+  }
+};
+
+namespace Test
+{
+using ArborXTest::toView;
+
+template <class ExecutionSpace>
+auto build_minimum_spanning_tree(ExecutionSpace const &exec_space,
+                                 std::vector<ArborX::Point> const &points_host,
+                                 int k)
+{
+  auto points = toView<ExecutionSpace>(points_host, "Test::points");
+
+  using MemorySpace = typename ExecutionSpace::memory_space;
+  ArborX::Details::MinimumSpanningTree<MemorySpace> mst{exec_space, points, k};
+
+  auto edges_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, mst.edges);
+  std::sort(edges_host.data(), edges_host.data() + edges_host.size());
+  return edges_host;
+}
+
+template <class T>
+std::vector<T> sorted(std::vector<T> v)
+{
+  std::sort(v.begin(), v.end());
+  return v;
+}
+
+#define ARBORX_TEST_MINIMUM_SPANNING_TREE(exec_space, points, k, ref)          \
+  BOOST_TEST(Test::build_minimum_spanning_tree(exec_space, points, k) ==       \
+                 Test::sorted(ref),                                            \
+             boost::test_tools::per_element());
+
+} // namespace Test
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(minimum_spanning_tree, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace exec_space;
+
+  { // equidistant points
+    // 0     1     2     3     4
+    //[0]   [1]   [2]   [3]   [4]
+    std::vector<ArborX::Point> points{
+        {0, 0, 0}, {1, 0, 0}, {2, 0, 0}, {3, 0, 0}, {4, 0, 0},
+    };
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, points, 1,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 1}, {1, 2, 1}, {2, 3, 1}, {3, 4, 1}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, points, 2,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 1}, {1, 2, 1}, {2, 3, 1}, {3, 4, 1}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, points, 3,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 2}, {1, 2, 1}, {2, 3, 1}, {2, 4, 2}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, points, 4,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 3}, {1, 2, 2}, {1, 3, 2}, {1, 4, 3}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, points, 5,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 4}, {1, 2, 3}, {1, 3, 3}, {0, 4, 4}}));
+  }
+  { // non-equidistant points
+    // 0   1   2   3   4   5   6   7   8   9   10
+    //[0] [1] [2] [3]         [4]             [5]
+    std::vector<ArborX::Point> non_equidistant_points{
+        {0, 0, 0}, {1, 0, 0}, {2, 0, 0}, {3, 0, 0}, {6, 0, 0}, {10, 0, 0},
+    };
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, non_equidistant_points, 1,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 1}, {1, 2, 1}, {2, 3, 1}, {3, 4, 3}, {4, 5, 4}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, non_equidistant_points, 2,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 1}, {1, 2, 1}, {2, 3, 1}, {3, 4, 3}, {4, 5, 4}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, non_equidistant_points, 3,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 2}, {1, 2, 1}, {1, 3, 2}, {2, 4, 4}, {3, 5, 7}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, non_equidistant_points, 4,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 3}, {1, 2, 2}, {0, 3, 3}, {2, 4, 4}, {2, 5, 8}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, non_equidistant_points, 5,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 6}, {1, 2, 5}, {2, 3, 4}, {1, 4, 5}, {1, 5, 9}}));
+
+    ARBORX_TEST_MINIMUM_SPANNING_TREE(
+        exec_space, non_equidistant_points, 6,
+        (std::vector<ArborX::Details::WeightedEdge>{
+            {0, 1, 10}, {1, 2, 9}, {2, 3, 8}, {3, 4, 7}, {0, 5, 10}}));
+  }
+}


### PR DESCRIPTION
Related to #557 
This version uses Andrey's kernels to compute the first neighbor (using a shared radius) and to update labels.
It was slightly changed to avoid allocating and deallocating arrays and do the computation with permuted indices with a finalization step to revert back to original indices.