### PR TITLE
Revert "Remove __SYCL_DEVICE_ONLY__ guards for ptintf"

### DIFF
--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -57,7 +57,9 @@ struct PrintfCallback
   KOKKOS_FUNCTION void operator()(Predicate, int primitive,
                                   OutputFunctor const &out) const
   {
+#ifndef __SYCL_DEVICE_ONLY__
     printf("Found %d from functor\n", primitive);
+#endif
     out(primitive);
   }
 };
@@ -92,7 +94,11 @@ int main(int argc, char *argv[])
     ArborX::query(bvh, ExecutionSpace{}, FirstOctant{},
                   KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                                 auto /*output_functor*/) {
+#ifndef __SYCL_DEVICE_ONLY__
                     printf("Found %d from generic lambda\n", primitive);
+#else
+                    (void)primitive;
+#endif
                   },
                   values, offsets);
 #endif
@@ -108,7 +114,11 @@ int main(int argc, char *argv[])
     ArborX::query(bvh, ExecutionSpace{}, NearestToOrigin{k},
                   KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                                 auto /*output_functor*/) {
+#ifndef __SYCL_DEVICE_ONLY__
                     printf("Found %d from generic lambda\n", primitive);
+#else
+                    (void)primitive;
+#endif
                   },
                   values, offsets);
 #endif
@@ -122,7 +132,11 @@ int main(int argc, char *argv[])
 #ifndef __NVCC__
     bvh.query(ExecutionSpace{}, FirstOctant{},
               KOKKOS_LAMBDA(auto /*predicate*/, int j) {
+#ifndef __SYCL_DEVICE_ONLY__
                 printf("%d %d %d\n", ++c(), -1, j);
+#else
+                (void)j;
+#endif
               });
 #endif
   }

--- a/examples/dbscan/ArborX_DBSCANVerification.hpp
+++ b/examples/dbscan/ArborX_DBSCANVerification.hpp
@@ -43,7 +43,9 @@ bool verifyCorePointsNonnegativeIndex(ExecutionSpace const &exec_space,
         bool self_is_core_point = (offset(i + 1) - offset(i) >= core_min_size);
         if (self_is_core_point && labels(i) < 0)
         {
+#ifndef __SYCL_DEVICE_ONLY__
           printf("Core point is marked as noise: %d [%d]\n", i, labels(i));
+#endif
           update++;
         }
       },
@@ -76,9 +78,11 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
 
             if (neigh_is_core_point && labels(i) != labels(j))
             {
+#ifndef __SYCL_DEVICE_ONLY__
               printf("Connected cores do not belong to the same cluster: "
                      "%d [%d] -> %d [%d]\n",
                      i, labels(i), j, labels(j));
+#endif
               update++;
             }
           }
@@ -128,15 +132,19 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
           // Border point must be connected to a core point
           if (is_border && !have_shared_core)
           {
+#ifndef __SYCL_DEVICE_ONLY__
             printf("Border point does not belong to a cluster: %d [%d]\n", i,
                    labels(i));
+#endif
             update++;
           }
           // Noise points must have index -1
           if (!is_border && labels(i) != -1)
           {
+#ifndef __SYCL_DEVICE_ONLY__
             printf("Noise point does not have index -1: %d [%d]\n", i,
                    labels(i));
+#endif
             update++;
           }
         }


### PR DESCRIPTION
This reverts commit d54e117fc0b7b6a6a36a4e1df0f66f58a244dc49 (part of #614). Corresponding to https://github.com/kokkos/kokkos/pull/4732.