### PR TITLE
Couple perf improvements for MST and integration with the driver

### DIFF
--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -13,6 +13,7 @@
 #include <ArborX_DBSCANVerification.hpp>
 #include <ArborX_DetailsHeap.hpp>
 #include <ArborX_DetailsOperatorFunctionObjects.hpp> // Less
+#include <ArborX_MinimumSpanningTree.hpp>
 #include <ArborX_Version.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -305,6 +306,7 @@ int main(int argc, char *argv[])
   using ArborX::DBSCAN::Implementation;
 
   std::string filename;
+  std::string algorithm;
   bool binary;
   bool verify;
   bool print_dbscan_timers;
@@ -320,6 +322,7 @@ int main(int argc, char *argv[])
   // clang-format off
   desc.add_options()
       ( "help", "help message" )
+      ( "algorithm", bpo::value<std::string>(&algorithm)->default_value("dbscan"), "algorithm (dbscan | mst)" )
       ( "filename", bpo::value<std::string>(&filename), "filename containing data" )
       ( "binary", bpo::bool_switch(&binary)->default_value(false), "binary file indicator")
       ( "max-num-points", bpo::value<int>(&max_num_points)->default_value(-1), "max number of points to read in")
@@ -347,15 +350,20 @@ int main(int argc, char *argv[])
   ss << implementation;
 
   // Print out the runtime parameters
-  printf("eps               : %f\n", eps);
+  printf("algorithm         : %s\n", algorithm.c_str());
+  if (algorithm == "dbscan")
+  {
+    printf("eps               : %f\n", eps);
+    printf("cluster min size  : %d\n", cluster_min_size);
+    printf("implementation    : %s\n", ss.str().c_str());
+    printf("verify            : %s\n", (verify ? "true" : "false"));
+  }
   printf("minpts            : %d\n", core_min_size);
-  printf("cluster min size  : %d\n", cluster_min_size);
   printf("filename          : %s [%s, max_pts = %d]\n", filename.c_str(),
          (binary ? "binary" : "text"), max_num_points);
-  printf("filename [labels] : %s [binary]\n", filename_labels.c_str());
-  printf("implementation    : %s\n", ss.str().c_str());
+  if (filename_labels != "")
+    printf("filename [labels] : %s [binary]\n", filename_labels.c_str());
   printf("samples           : %d\n", num_samples);
-  printf("verify            : %s\n", (verify ? "true" : "false"));
   printf("print timers      : %s\n", (print_dbscan_timers ? "true" : "false"));
 
   // read in data
@@ -384,39 +392,48 @@ int main(int argc, char *argv[])
 
   timer_start(timer_total);
 
-  auto labels = ArborX::dbscan(exec_space, primitives, eps, core_min_size,
-                               ArborX::DBSCAN::Parameters()
-                                   .setPrintTimers(print_dbscan_timers)
-                                   .setImplementation(implementation));
-
-  timer_start(timer);
-  Kokkos::View<int *, MemorySpace> cluster_indices("Testing::cluster_indices",
-                                                   0);
-  Kokkos::View<int *, MemorySpace> cluster_offset("Testing::cluster_offset", 0);
-  sortAndFilterClusters(exec_space, labels, cluster_indices, cluster_offset,
-                        cluster_min_size);
-  elapsed["cluster"] = timer_seconds(timer);
-  elapsed["total"] = timer_seconds(timer_total);
-
-  printf("-- postprocess      : %10.3f\n", elapsed["cluster"]);
-  printf("total time          : %10.3f\n", elapsed["total"]);
-
-  int num_clusters = cluster_offset.size() - 1;
-  int num_cluster_points = cluster_indices.size();
-  printf("\n#clusters       : %d\n", num_clusters);
-  printf("#cluster points : %d [%.2f%%]\n", num_cluster_points,
-         (100.f * num_cluster_points / data.size()));
-
   bool success = true;
-  if (verify)
+  if (algorithm == "dbscan")
   {
-    success = ArborX::Details::verifyDBSCAN(exec_space, primitives, eps,
-                                            core_min_size, labels);
-    printf("Verification %s\n", (success ? "passed" : "failed"));
-  }
+    auto labels = ArborX::dbscan(exec_space, primitives, eps, core_min_size,
+                                 ArborX::DBSCAN::Parameters()
+                                     .setPrintTimers(print_dbscan_timers)
+                                     .setImplementation(implementation));
 
-  if (!filename_labels.empty())
-    writeLabelsData(filename_labels, labels);
+    timer_start(timer);
+    Kokkos::View<int *, MemorySpace> cluster_indices("Testing::cluster_indices",
+                                                     0);
+    Kokkos::View<int *, MemorySpace> cluster_offset("Testing::cluster_offset",
+                                                    0);
+    sortAndFilterClusters(exec_space, labels, cluster_indices, cluster_offset,
+                          cluster_min_size);
+    elapsed["cluster"] = timer_seconds(timer);
+    elapsed["total"] = timer_seconds(timer_total);
+
+    printf("-- postprocess      : %10.3f\n", elapsed["cluster"]);
+    printf("total time          : %10.3f\n", elapsed["total"]);
+
+    int num_clusters = cluster_offset.size() - 1;
+    int num_cluster_points = cluster_indices.size();
+    printf("\n#clusters       : %d\n", num_clusters);
+    printf("#cluster points : %d [%.2f%%]\n", num_cluster_points,
+           (100.f * num_cluster_points / data.size()));
+
+    if (verify)
+    {
+      success = ArborX::Details::verifyDBSCAN(exec_space, primitives, eps,
+                                              core_min_size, labels);
+      printf("Verification %s\n", (success ? "passed" : "failed"));
+    }
+
+    if (!filename_labels.empty())
+      writeLabelsData(filename_labels, labels);
+  }
+  else if (algorithm == "mst")
+  {
+    ArborX::Details::MinimumSpanningTree<MemorySpace> mst(
+        exec_space, primitives, core_min_size);
+  }
 
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -59,7 +59,8 @@ private:
   }
 };
 
-template <class BVH, class Labels, class Edges, class Metric, class Radii>
+template <class BVH, class Labels, class Edges, class Metric, class Radii,
+          class LowerBounds>
 struct FindComponentNearestNeighbors
 {
   BVH _bvh;
@@ -67,21 +68,25 @@ struct FindComponentNearestNeighbors
   Edges _edges;
   Metric _metric;
   Radii _radii;
+  LowerBounds _lower_bounds;
 
   template <class ExecutionSpace>
   FindComponentNearestNeighbors(ExecutionSpace const &space, BVH const &bvh,
                                 Labels const &labels, Edges const &edges,
-                                Metric const &metric, Radii const &radii)
+                                Metric const &metric, Radii const &radii,
+                                LowerBounds const &lower_bounds)
       : _bvh(bvh)
       , _labels(labels)
       , _edges(edges)
       , _metric{metric}
       , _radii(radii)
+      , _lower_bounds(lower_bounds)
   {
     auto const n = bvh.size();
     ARBORX_ASSERT(labels.extent(0) == 2 * n - 1);
     ARBORX_ASSERT(edges.extent(0) == n);
     ARBORX_ASSERT(radii.extent(0) == n);
+    ARBORX_ASSERT(lower_bounds.extent(0) == n);
 
     Kokkos::parallel_for(
         "ArborX::MST::find_component_nearest_neighbors",
@@ -90,6 +95,12 @@ struct FindComponentNearestNeighbors
 
   KOKKOS_FUNCTION void operator()(int i) const
   {
+    auto const n = _bvh.size();
+    auto const component = _labels(i);
+    auto &radius = _radii(component - n + 1);
+    if (radius < _lower_bounds(i - n + 1))
+      return;
+
     constexpr int undetermined = -1;
     constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
 
@@ -101,7 +112,6 @@ struct FindComponentNearestNeighbors
                       HappyTreeFriends::getBoundingVolume(bvh, j));
     };
 
-    auto const component = _labels(i);
     auto const predicate = [label_i = component, &labels = _labels](int j) {
       return label_i != labels(j);
     };
@@ -112,9 +122,6 @@ struct FindComponentNearestNeighbors
     static_assert(WeightedEdge{undetermined, undetermined, inf} <
                       WeightedEdge{0, undetermined, inf},
                   "");
-
-    auto const n = _bvh.size();
-    auto &radius = _radii(component - n + 1);
 
     constexpr int SENTINEL = -1;
     int stack[64];
@@ -250,13 +257,32 @@ struct FindComponentNearestNeighbors
 // For every component C, find the shortest edge (v, w) such that v is in C
 // and w is not in C. The found edge is stored in component_out_edges(C).
 template <class ExecutionSpace, class BVH, class Labels, class Edges,
-          class Metric, class Radii>
+          class Metric, class Radii, class LowerBounds>
 void findComponentNearestNeighbors(ExecutionSpace const &space, BVH const &bvh,
                                    Labels const &labels, Edges const &edges,
-                                   Metric const &metric, Radii const &radii)
+                                   Metric const &metric, Radii const &radii,
+                                   LowerBounds const &lower_bounds)
 {
-  FindComponentNearestNeighbors<BVH, Labels, Edges, Metric, Radii>(
-      space, bvh, labels, edges, metric, radii);
+  FindComponentNearestNeighbors<BVH, Labels, Edges, Metric, Radii, LowerBounds>(
+      space, bvh, labels, edges, metric, radii, lower_bounds);
+}
+
+template <class ExecutionSpace, class Labels, class ComponentOutEdges,
+          class LowerBounds>
+void updateLowerBounds(ExecutionSpace const &space, Labels const &labels,
+                       ComponentOutEdges const &component_out_edges,
+                       LowerBounds lower_bounds)
+{
+  auto const n = lower_bounds.extent(0);
+  Kokkos::parallel_for(
+      "ArborX::MST::update_lower_bounds",
+      Kokkos::RangePolicy<ExecutionSpace>(space, n - 1, 2 * n - 1),
+      KOKKOS_LAMBDA(int i) {
+        using KokkosExt::max;
+        auto component = labels(i);
+        auto const &edge = component_out_edges(component - n + 1);
+        lower_bounds(i - n + 1) = max(lower_bounds(i - n + 1), edge.weight);
+      });
 }
 
 template <class Labels, class OutEdges, class Edges, class EdgesCount>
@@ -486,6 +512,8 @@ private:
     Kokkos::View<float *, MemorySpace> radii(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "ArborX::MST::radii"),
         n);
+    Kokkos::View<float *, MemorySpace> lower_bounds("ArborX::MST::lower_bounds",
+                                                    n);
 
     Kokkos::Profiling::pushRegion("ArborX::MST::Boruvka_loop");
     Kokkos::View<int, MemorySpace> num_edges(Kokkos::view_alloc(
@@ -508,7 +536,8 @@ private:
       Kokkos::deep_copy(space, radii, inf);
       resetSharedRadii(space, bvh, labels, metric, radii);
       findComponentNearestNeighbors(space, bvh, labels, component_out_edges,
-                                    metric, radii);
+                                    metric, radii, lower_bounds);
+      updateLowerBounds(space, labels, component_out_edges, lower_bounds);
       // NOTE could perform the label tree reduction as part of the update
       updateComponentsAndEdges(space, component_out_edges, labels, edges,
                                num_edges);


### PR DESCRIPTION
Follow up to #624.

- Adds ability to run MST using DBSCAN driver
- Increases the number of neighbors used to set upper bound for a component to 2
  This gives about 5-10% improvement for HACC problem
- Uses lower bound
  This seems to only help in serial, not for GPU. For HACC problem, it is about 25% faster in serial (300 vs 225 on AMD EPYC). 