### PR TITLE
Move computing offsets in a sorted view to general utilities and add a test

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -311,8 +311,10 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
     int num_points_in_dense_cells;
     {
       // Reorder indices and permutation so that the dense cells go first
-      auto cell_offsets =
-          Details::computeOffsetsInOrderedView(exec_space, sorted_cell_indices);
+      Kokkos::View<int *, MemorySpace> cell_offsets(
+          "ArborX::DBSCAN::cell_offsets", 0);
+      Details::computeOffsetsInOrderedView(exec_space, sorted_cell_indices,
+                                           cell_offsets);
       num_nonempty_cells = cell_offsets.size() - 1;
 
       num_points_in_dense_cells = Details::reorderDenseAndSparseCells(
@@ -324,8 +326,10 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
     auto dense_sorted_cell_indices = Kokkos::subview(
         sorted_cell_indices, Kokkos::make_pair(0, num_points_in_dense_cells));
 
-    auto dense_cell_offsets = Details::computeOffsetsInOrderedView(
-        exec_space, dense_sorted_cell_indices);
+    Kokkos::View<int *, MemorySpace> dense_cell_offsets(
+        "ArborX::DBSCAN::dense_cell_offsets", 0);
+    Details::computeOffsetsInOrderedView(exec_space, dense_sorted_cell_indices,
+                                         dense_cell_offsets);
     int num_dense_cells = dense_cell_offsets.size() - 1;
     if (verbose)
     {

--- a/test/tstDetailsUtils.cpp
+++ b/test/tstDetailsUtils.cpp
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+#include "ArborXTest_StdVectorToKokkosView.hpp"
 #include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
 #include "ArborX_EnableViewComparison.hpp"
 #include <ArborX_DetailsSortUtils.hpp>
@@ -250,4 +251,46 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sort_objects, DeviceType, ARBORX_DEVICE_TYPES)
       values_copy[i] = values[host_permutation(i)];
     BOOST_TEST(host_view == values_copy, tt::per_element());
   }
+}
+
+namespace Test
+{
+using ArborXTest::toView;
+
+template <class ExecutionSpace>
+auto build_offsets(ExecutionSpace const &exec_space,
+                   std::vector<int> const &sorted_indices_host)
+{
+  auto sorted_indices =
+      toView<ExecutionSpace>(sorted_indices_host, "Test::sorted_indices");
+  Kokkos::View<int *, typename decltype(sorted_indices)::memory_space> offsets(
+      "Test::offsets", 0);
+  ArborX::Details::computeOffsetsInOrderedView(exec_space, sorted_indices,
+                                               offsets);
+  return Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets);
+}
+} // namespace Test
+
+#define ARBORX_TEST_OFFSETS_IN_SORTED_VIEW(exec_space, sorted_indices, ref)    \
+  BOOST_TEST(Test::build_offsets(exec_space, sorted_indices) == ref,           \
+             boost::test_tools::per_element());
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(compute_offsets_in_sorted_view, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace space{};
+
+  ARBORX_TEST_OFFSETS_IN_SORTED_VIEW(space, (std::vector<int>{}),
+                                     (std::vector<int>{0}));
+  ARBORX_TEST_OFFSETS_IN_SORTED_VIEW(space, (std::vector<int>{0}),
+                                     (std::vector<int>{0, 1}));
+  ARBORX_TEST_OFFSETS_IN_SORTED_VIEW(space, (std::vector<int>{0, 0, 1}),
+                                     (std::vector<int>{0, 2, 3}));
+  ARBORX_TEST_OFFSETS_IN_SORTED_VIEW(space,
+                                     (std::vector<int>{0, 1, 6, 6, 6, 6, 11}),
+                                     (std::vector<int>{0, 1, 2, 6, 7}));
+  ARBORX_TEST_OFFSETS_IN_SORTED_VIEW(space,
+                                     (std::vector<int>{14, 5, 5, 5, 3, 3}),
+                                     (std::vector<int>{0, 1, 4, 6}));
 }


### PR DESCRIPTION
This utility is general enough to be used beyond DBSCAN.