### PR TITLE
Move view helpers `ArborX:: -> KokkosExt::` and pass execution space instance

### DIFF
--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -206,7 +206,7 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
   auto &map_cluster_to_offset_position = cluster_sizes;
   constexpr int IGNORED_CLUSTER = -1;
   int num_clusters;
-  ArborX::reallocWithoutInitializing(cluster_offset, n + 1);
+  KokkosExt::reallocWithoutInitializing(exec_space, cluster_offset, n + 1);
   Kokkos::parallel_scan(
       "ArborX::DBSCAN::compute_cluster_offset_with_filter",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
@@ -232,8 +232,8 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
   ArborX::exclusivePrefixSum(exec_space, cluster_offset);
 
   auto cluster_starts = ArborX::clone(exec_space, cluster_offset);
-  ArborX::reallocWithoutInitializing(cluster_indices,
-                                     ArborX::lastElement(cluster_offset));
+  KokkosExt::reallocWithoutInitializing(exec_space, cluster_indices,
+                                        ArborX::lastElement(cluster_offset));
   Kokkos::parallel_for("ArborX::DBSCAN::compute_cluster_indices",
                        Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
                        KOKKOS_LAMBDA(int const i) {

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -231,7 +231,7 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
   Kokkos::resize(Kokkos::WithoutInitializing, cluster_offset, num_clusters + 1);
   ArborX::exclusivePrefixSum(exec_space, cluster_offset);
 
-  auto cluster_starts = ArborX::clone(exec_space, cluster_offset);
+  auto cluster_starts = KokkosExt::clone(exec_space, cluster_offset);
   KokkosExt::reallocWithoutInitializing(exec_space, cluster_indices,
                                         ArborX::lastElement(cluster_offset));
   Kokkos::parallel_for("ArborX::DBSCAN::compute_cluster_indices",

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -15,6 +15,7 @@
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsAlgorithms.hpp> // returnCentroid, translateAndScale
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsMortonCode.hpp> // morton32
 #include <ArborX_DetailsSortUtils.hpp>  // sortObjects
 #include <ArborX_DetailsUtils.hpp>      // exclusivePrefixSum, lastElement
@@ -110,7 +111,8 @@ public:
     auto const n = permute.extent(0);
     ARBORX_ASSERT(offset.extent(0) == n + 1);
 
-    auto tmp_offset = cloneWithoutInitializingNorCopying(offset);
+    auto tmp_offset =
+        KokkosExt::cloneWithoutInitializingNorCopying(space, offset);
     Kokkos::parallel_for(
         "ArborX::BatchedQueries::adjacent_difference_and_permutation",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n), KOKKOS_LAMBDA(int i) {
@@ -136,7 +138,8 @@ public:
     ARBORX_ASSERT(lastElement(offset) == indices.extent_int(0));
     ARBORX_ASSERT(lastElement(tmp_offset) == indices.extent_int(0));
 
-    auto tmp_indices = cloneWithoutInitializingNorCopying(indices);
+    auto tmp_indices =
+        KokkosExt::cloneWithoutInitializingNorCopying(space, indices);
     Kokkos::parallel_for(
         "ArborX::BatchedQueries::permute_indices",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n), KOKKOS_LAMBDA(int q) {

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -219,7 +219,7 @@ void queryImpl(ExecutionSpace const &space, Tree const &tree,
   if (underflow)
   {
     // Store a copy of the original offset. We'll need it for compression.
-    preallocated_offset = clone(space, offset);
+    preallocated_offset = KokkosExt::clone(space, offset);
   }
 
   Kokkos::parallel_for(

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -16,6 +16,7 @@
 #include <ArborX_DetailsDistributor.hpp>
 #include <ArborX_DetailsHappyTreeFriends.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsUtils.hpp>
 #include <ArborX_LinearBVH.hpp>
@@ -82,8 +83,8 @@ struct DistributedTreeImpl
         "ArborX::DistributedTree::query::spatial::pairs_index_rank", 0);
     queryDispatch(SpatialPredicateTag{}, tree, space, queries, out, offset);
     auto const n = out.extent(0);
-    reallocWithoutInitializing(indices, n);
-    reallocWithoutInitializing(ranks, n);
+    KokkosExt::reallocWithoutInitializing(space, indices, n);
+    KokkosExt::reallocWithoutInitializing(space, ranks, n);
     Kokkos::parallel_for("ArborX::DistributedTree::query::split_pairs",
                          Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),
                          KOKKOS_LAMBDA(int i) {
@@ -157,7 +158,7 @@ struct DistributedTreeImpl
         "ArborX::DistributedTree::query::nearest::ranks", 0);
     queryDispatchImpl(tag, tree, space, queries, indices, offset, ranks);
     auto const n = indices.extent(0);
-    reallocWithoutInitializing(values, n);
+    KokkosExt::reallocWithoutInitializing(space, values, n);
     Kokkos::parallel_for(
         "ArborX::DistributedTree::query::zip_indices_and_ranks",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n), KOKKOS_LAMBDA(int i) {
@@ -523,8 +524,8 @@ DistributedTreeImpl<DeviceType>::queryDispatchImpl(
 
       // Unzip
       auto const n = out.extent(0);
-      reallocWithoutInitializing(indices, n);
-      reallocWithoutInitializing(distances, n);
+      KokkosExt::reallocWithoutInitializing(space, indices, n);
+      KokkosExt::reallocWithoutInitializing(space, distances, n);
       Kokkos::parallel_for("ArborX::DistributedTree::query::nearest::split_"
                            "index_distance_pairs",
                            Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -13,6 +13,7 @@
 
 #include <ArborX_Config.hpp>
 
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsSortUtils.hpp>
 #include <ArborX_DetailsUtils.hpp> // max
 #include <ArborX_Exception.hpp>
@@ -233,7 +234,8 @@ public:
 
     // The next two function calls are the only difference to the other
     // overload.
-    reallocWithoutInitializing(_permute, destination_ranks.size());
+    KokkosExt::reallocWithoutInitializing(space, _permute,
+                                          destination_ranks.size());
     sortAndDetermineBufferLayout(space, destination_ranks, _permute,
                                  _destinations, _dest_counts, _dest_offsets);
 
@@ -293,7 +295,8 @@ public:
               "ArborX::Distributor::doPostsAndWaits::destination_buffer"),
           typename ExportView::array_layout{});
 
-      reallocWithoutInitializing(dest_buffer, exports.layout());
+      KokkosExt::reallocWithoutInitializing(space, dest_buffer,
+                                            exports.layout());
 
       // We need to create a local copy to avoid capturing a member variable
       // (via the 'this' pointer) which we can't do using a KOKKOS_LAMBDA.

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -14,6 +14,7 @@
 
 #include <ArborX_Callbacks.hpp>
 #include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsUnionFind.hpp>
 #include <ArborX_DetailsUtils.hpp>
 #include <ArborX_Predicates.hpp>
@@ -332,9 +333,10 @@ int reorderDenseAndSparseCells(ExecutionSpace const &exec_space,
   Kokkos::deep_copy(exec_space, dense_offset, 0);
   Kokkos::deep_copy(exec_space, sparse_offset, num_points_in_dense_cells);
 
-  auto reordered_permute = cloneWithoutInitializingNorCopying(permute);
-  auto reordered_cell_indices =
-      cloneWithoutInitializingNorCopying(sorted_cell_indices);
+  auto reordered_permute =
+      KokkosExt::cloneWithoutInitializingNorCopying(exec_space, permute);
+  auto reordered_cell_indices = KokkosExt::cloneWithoutInitializingNorCopying(
+      exec_space, sorted_cell_indices);
   Kokkos::parallel_for(
       "ArborX::DBSCAN::reorder_cell_indices_and_permutation",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, num_nonempty_cells),

--- a/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
+++ b/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_VIEW_HELPERS_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_VIEW_HELPERS_HPP
+
+#include <Kokkos_Core.hpp>
+
+namespace KokkosExt
+{
+
+template <class ExecutionSpace, class View>
+void reallocWithoutInitializing(ExecutionSpace const &space, View &v,
+                                size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                                size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                                size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                                size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                                size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                                size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                                size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                                size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
+{
+  static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+  static_assert(Kokkos::is_view<View>::value, "");
+  static_assert(View::is_managed, "Can only realloc managed views");
+
+  size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
+  bool has_requested_extents = true;
+  for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
+    if (new_extents[dim] != v.extent(dim))
+    {
+      has_requested_extents = false;
+      break;
+    }
+
+  if (!has_requested_extents)
+    v = View(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, v.label()),
+             n0, n1, n2, n3, n4, n5, n6, n7);
+}
+
+template <class ExecutionSpace, class View>
+void reallocWithoutInitializing(ExecutionSpace const &space, View &v,
+                                const typename View::array_layout &layout)
+{
+  static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+  static_assert(Kokkos::is_view<View>::value, "");
+  static_assert(View::is_managed, "Can only realloc managed views");
+  v = View(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, v.label()),
+           layout);
+}
+
+} // namespace KokkosExt
+
+#endif

--- a/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
+++ b/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
@@ -70,6 +70,17 @@ typename View::non_const_type clone(ExecutionSpace const &space, View &v)
   return w;
 }
 
+template <class ExecutionSpace, class View>
+typename View::non_const_type
+cloneWithoutInitializingNorCopying(ExecutionSpace const &space, View &v)
+{
+  static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+  static_assert(Kokkos::is_view<View>::value, "");
+  return typename View::non_const_type(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, v.label()),
+      v.layout());
+}
+
 } // namespace KokkosExt
 
 #endif

--- a/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
+++ b/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
@@ -57,6 +57,18 @@ void reallocWithoutInitializing(ExecutionSpace const &space, View &v,
            layout);
 }
 
+template <class ExecutionSpace, class View>
+typename View::non_const_type clone(ExecutionSpace const &space, View &v)
+{
+  static_assert(Kokkos::is_execution_space<ExecutionSpace>::value, "");
+  static_assert(Kokkos::is_view<View>::value, "");
+  typename View::non_const_type w(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, v.label()),
+      v.layout());
+  Kokkos::deep_copy(space, w, v);
+  return w;
+}
+
 } // namespace KokkosExt
 
 #endif

--- a/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
+++ b/src/details/ArborX_DetailsKokkosExtViewHelpers.hpp
@@ -17,6 +17,7 @@
 namespace KokkosExt
 {
 
+// FIXME it is not legal to use KOKKOS_IMPL_CTOR_DEFAULT_ARG
 template <class ExecutionSpace, class View>
 void reallocWithoutInitializing(ExecutionSpace const &space, View &v,
                                 size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -15,6 +15,7 @@
 #include <ArborX_Config.hpp> // ARBORX_ENABLE_ROCTHRUST
 
 #include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp> // is_accessible_from
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>         // clone
 #include <ArborX_DetailsUtils.hpp>                        // iota
 #include <ArborX_Exception.hpp>
 
@@ -274,7 +275,7 @@ void applyPermutation(ExecutionSpace const &space,
 {
   static_assert(std::is_integral<typename PermutationView::value_type>::value,
                 "");
-  auto scratch_view = clone(space, view);
+  auto scratch_view = KokkosExt::clone(space, view);
   applyPermutation(space, permutation, scratch_view, view);
 }
 

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -516,17 +516,6 @@ template <typename SrcViewType, typename DstViewType>
 // FIXME split this into one for STL-like algorithms and another one for view
 // utility helpers
 
-// FIXME get rid of this when Trilinos/Kokkos version is updated
-// clang-format off
-#ifndef KOKKOS_IMPL_CTOR_DEFAULT_ARG
-#  ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-#    define KOKKOS_IMPL_CTOR_DEFAULT_ARG 0
-#  else
-#    define KOKKOS_IMPL_CTOR_DEFAULT_ARG (~std::size_t(0))
-#  endif
-#endif
-// clang-format on
-
 // NOTE: not possible to avoid initialization with Kokkos::realloc()
 template <typename View>
 [[deprecated]] void

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -560,20 +560,17 @@ typename View::non_const_type cloneWithoutInitializingNorCopying(View &v)
 }
 
 template <typename ExecutionSpace, typename View>
-typename View::non_const_type clone(ExecutionSpace const &space, View &v)
+[[deprecated]] typename View::non_const_type clone(ExecutionSpace const &space,
+                                                   View &v)
 {
-  typename View::non_const_type w(
-      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, v.label()),
-      v.layout());
-  Kokkos::deep_copy(space, w, v);
-  return w;
+  return KokkosExt::clone(space, v);
 }
 
 template <typename View>
 [[deprecated]] inline typename View::non_const_type clone(View &v)
 {
   using ExecutionSpace = typename View::execution_space;
-  return clone(ExecutionSpace{}, v);
+  return KokkosExt::clone(ExecutionSpace{}, v);
 }
 
 } // namespace ArborX

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -12,6 +12,7 @@
 #ifndef ARBORX_DETAILS_UTILS_HPP
 #define ARBORX_DETAILS_UTILS_HPP
 
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_Exception.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -528,38 +529,27 @@ template <typename SrcViewType, typename DstViewType>
 
 // NOTE: not possible to avoid initialization with Kokkos::realloc()
 template <typename View>
-void reallocWithoutInitializing(View &v,
-                                size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                                size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                                size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                                size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                                size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                                size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                                size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                                size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
+[[deprecated]] void
+reallocWithoutInitializing(View &v, size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                           size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                           size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                           size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                           size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                           size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                           size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                           size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
 {
-  static_assert(View::is_managed, "Can only realloc managed views");
-
-  size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool has_requested_extents = true;
-  for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
-    if (new_extents[dim] != v.extent(dim))
-    {
-      has_requested_extents = false;
-      break;
-    }
-
-  if (!has_requested_extents)
-    v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), n0, n1,
-             n2, n3, n4, n5, n6, n7);
+  using ExecutionSpace = typename View::execution_space;
+  KokkosExt::reallocWithoutInitializing(ExecutionSpace{}, v, n0, n1, n2, n3, n4,
+                                        n5, n6, n7);
 }
 
 template <typename View>
-void reallocWithoutInitializing(View &v,
-                                const typename View::array_layout &layout)
+[[deprecated]] void
+reallocWithoutInitializing(View &v, const typename View::array_layout &layout)
 {
-  static_assert(View::is_managed, "Can only realloc managed views");
-  v = View(Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), layout);
+  using ExecutionSpace = typename View::execution_space;
+  KokkosExt::reallocWithoutInitializing(ExecutionSpace{}, v, layout);
 }
 
 template <typename View>

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -496,7 +496,7 @@ void adjacentDifference(ExecutionSpace &&space, SrcViewType const &src,
   ARBORX_ASSERT(src != dst);
   Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
-  Kokkos::parallel_for("ArbroX::Algorithms::adjacent_difference", policy,
+  Kokkos::parallel_for("ArborX::Algorithms::adjacent_difference", policy,
                        KOKKOS_LAMBDA(int i) {
                          if (i > 0)
                            dst(i) = src(i) - src(i - 1);

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -542,10 +542,11 @@ reallocWithoutInitializing(View &v, const typename View::array_layout &layout)
 }
 
 template <typename View>
-typename View::non_const_type cloneWithoutInitializingNorCopying(View &v)
+[[deprecated]] typename View::non_const_type
+cloneWithoutInitializingNorCopying(View &v)
 {
-  return typename View::non_const_type(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, v.label()), v.layout());
+  using ExecutionSpace = typename View::execution_space;
+  return KokkosExt::cloneWithoutInitializingNorCopying(ExecutionSpace{}, v);
 }
 
 template <typename ExecutionSpace, typename View>

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -15,6 +15,7 @@
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsMutualReachabilityDistance.hpp>
 #include <ArborX_DetailsTreeNodeLabeling.hpp>
 #include <ArborX_DetailsUtils.hpp>
@@ -550,7 +551,7 @@ private:
 #endif
     if (use_lower_bounds)
     {
-      reallocWithoutInitializing(lower_bounds, n);
+      KokkosExt::reallocWithoutInitializing(space, lower_bounds, n);
       Kokkos::deep_copy(space, lower_bounds, 0);
     }
 

--- a/test/tstDetailsCrsGraphWrapperImpl.cpp
+++ b/test/tstDetailsCrsGraphWrapperImpl.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(query_impl, DeviceType, ARBORX_DEVICE_TYPES)
 
   int const buffer_size = 2 * (n + 1);
 
-  ArborX::reallocWithoutInitializing(offset, n + 1);
+  Kokkos::realloc(offset, n + 1);
   Kokkos::deep_copy(offset, buffer_size);
 
   Kokkos::View<unsigned int *, DeviceType> permute(
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(query_impl, DeviceType, ARBORX_DEVICE_TYPES)
   ArborX::iota(ExecutionSpace{}, permute);
 
   ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);
-  ArborX::reallocWithoutInitializing(indices, ArborX::lastElement(offset));
+  Kokkos::realloc(indices, ArborX::lastElement(offset));
   ArborX::Details::CrsGraphWrapperImpl::queryImpl(
       ExecutionSpace{}, Test1{}, predicates, ArborX::Details::DefaultCallback{},
       indices, offset, permute,

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -464,7 +464,7 @@ struct CustomPostCallbackWithAttachment
     using ExecutionSpace = typename DeviceType::execution_space;
     using ArborX::Details::distance;
     auto const n = offset.extent(0) - 1;
-    ArborX::reallocWithoutInitializing(out, in.extent(0));
+    Kokkos::realloc(out, in.extent(0));
     // NOTE workaround to avoid implicit capture of *this
     auto const &points_ = points;
     auto const &origin_ = origin;

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -53,8 +53,8 @@ struct CustomPostCallback
     using ExecutionSpace = typename DeviceType::execution_space;
     using ArborX::Details::distance;
     auto const n = offset.extent(0) - 1;
-    ArborX::reallocWithoutInitializing(out, in.extent(0));
-    // NOTE woraround to avoid implicit capture of *this
+    Kokkos::realloc(out, in.extent(0));
+    // NOTE workaround to avoid implicit capture of *this
     auto const &points_ = points;
     auto const &origin_ = origin;
     Kokkos::parallel_for(
@@ -235,7 +235,7 @@ struct CustomPostCallbackWithAttachment
     using ExecutionSpace = typename DeviceType::execution_space;
     using ArborX::Details::distance;
     auto const n = offset.extent(0) - 1;
-    ArborX::reallocWithoutInitializing(out, in.extent(0));
+    Kokkos::realloc(out, in.extent(0));
     // NOTE workaround to avoid implicit capture of *this
     auto const &points_ = points;
     auto const &origin_ = origin;

--- a/test/tstQueryTreeTraversalPolicy.cpp
+++ b/test/tstQueryTreeTraversalPolicy.cpp
@@ -66,7 +66,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(buffer_optimization, DeviceType,
   checkResultsAreFine();
 
   // compute number of results per query
-  auto counts = ArborX::cloneWithoutInitializingNorCopying(offset);
+  auto counts =
+      KokkosExt::cloneWithoutInitializingNorCopying(ExecutionSpace{}, offset);
   ArborX::adjacentDifference(ExecutionSpace{}, offset, counts);
   // extract optimal buffer size
   auto const max_results_per_query = ArborX::max(ExecutionSpace{}, counts);


### PR DESCRIPTION
Partial fix for #641 