### PR TITLE
Move `{ArborX -> KokkosExt}::lastElement` and use provided executions space

### DIFF
--- a/examples/dbscan/ArborX_DBSCANVerification.hpp
+++ b/examples/dbscan/ArborX_DBSCANVerification.hpp
@@ -263,7 +263,7 @@ bool verifyClusters(ExecutionSpace const &exec_space, IndicesView indices,
 {
   int n = labels.size();
   if ((int)offset.size() != n + 1 ||
-      ArborX::lastElement(offset) != (int)indices.size())
+      KokkosExt::lastElement(exec_space, offset) != (int)indices.size())
     return false;
 
   using Verify = bool (*)(ExecutionSpace const &, IndicesView, OffsetView,

--- a/examples/dbscan/dbscan.cpp
+++ b/examples/dbscan/dbscan.cpp
@@ -232,8 +232,9 @@ void sortAndFilterClusters(ExecutionSpace const &exec_space,
   ArborX::exclusivePrefixSum(exec_space, cluster_offset);
 
   auto cluster_starts = KokkosExt::clone(exec_space, cluster_offset);
-  KokkosExt::reallocWithoutInitializing(exec_space, cluster_indices,
-                                        ArborX::lastElement(cluster_offset));
+  KokkosExt::reallocWithoutInitializing(
+      exec_space, cluster_indices,
+      KokkosExt::lastElement(exec_space, cluster_offset));
   Kokkos::parallel_for("ArborX::DBSCAN::compute_cluster_indices",
                        Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
                        KOKKOS_LAMBDA(int const i) {

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -374,7 +374,8 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
           Details::FDBSCANDenseBoxCallback<MemorySpace, CorePoints, Primitives,
                                            decltype(dense_cell_offsets),
                                            decltype(permute)>{
-              labels, CorePoints{}, primitives, dense_cell_offsets, permute,
+              labels, CorePoints{}, primitives, dense_cell_offsets,
+              KokkosExt::lastElement(exec_space, dense_cell_offsets), permute,
               eps});
       Kokkos::Profiling::popRegion();
     }
@@ -422,7 +423,9 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
                                            decltype(dense_cell_offsets),
                                            decltype(permute)>{
               labels, CorePoints{num_neigh, core_min_size}, primitives,
-              dense_cell_offsets, permute, eps});
+              dense_cell_offsets,
+              KokkosExt::lastElement(exec_space, dense_cell_offsets), permute,
+              eps});
       Kokkos::Profiling::popRegion();
       elapsed["query"] = timer_seconds(timer_local);
     }

--- a/src/details/ArborX_DetailsBatchedQueries.hpp
+++ b/src/details/ArborX_DetailsBatchedQueries.hpp
@@ -18,7 +18,7 @@
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsMortonCode.hpp> // morton32
 #include <ArborX_DetailsSortUtils.hpp>  // sortObjects
-#include <ArborX_DetailsUtils.hpp>      // exclusivePrefixSum, lastElement
+#include <ArborX_DetailsUtils.hpp>      // exclusivePrefixSum
 
 #include <Kokkos_Core.hpp>
 
@@ -137,8 +137,9 @@ public:
 
     ARBORX_ASSERT(offset.extent(0) == n + 1);
     ARBORX_ASSERT(tmp_offset.extent(0) == n + 1);
-    ARBORX_ASSERT(lastElement(offset) == indices.extent_int(0));
-    ARBORX_ASSERT(lastElement(tmp_offset) == indices.extent_int(0));
+    using KokkosExt::lastElement;
+    ARBORX_ASSERT(lastElement(space, offset) == indices.extent_int(0));
+    ARBORX_ASSERT(lastElement(space, tmp_offset) == indices.extent_int(0));
 
     auto tmp_indices =
         KokkosExt::cloneWithoutInitializingNorCopying(space, indices);

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -228,7 +228,7 @@ void queryImpl(ExecutionSpace const &space, Tree const &tree,
       KOKKOS_LAMBDA(int const i) { permuted_offset(i) = counts(i); });
   exclusivePrefixSum(space, offset);
 
-  int const n_results = lastElement(offset);
+  int const n_results = KokkosExt::lastElement(space, offset);
 
   Kokkos::Profiling::popRegion();
 
@@ -326,8 +326,8 @@ allocateAndInitializeStorage(Tag, ExecutionSpace const &space,
   {
     exclusivePrefixSum(space, offset);
 
-    // Use calculation for the size to avoid calling lastElement(offset) as it
-    // will launch an extra kernel to copy to host.
+    // Use calculation for the size to avoid calling lastElement(space, offset)
+    // as it will launch an extra kernel to copy to host.
     KokkosExt::reallocWithoutInitializing(space, out, n_queries * buffer_size);
   }
 }
@@ -351,7 +351,8 @@ allocateAndInitializeStorage(Tag, ExecutionSpace const &space,
       KOKKOS_LAMBDA(int i) { offset(i) = getK(Access::get(predicates, i)); });
   exclusivePrefixSum(space, offset);
 
-  KokkosExt::reallocWithoutInitializing(space, out, lastElement(offset));
+  KokkosExt::reallocWithoutInitializing(space, out,
+                                        KokkosExt::lastElement(space, offset));
 }
 
 // Views are passed by reference here because internally Kokkos::realloc()

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -58,7 +58,8 @@ determineBufferLayout(ExecutionSpace const &space, InputView batched_ranks,
   offsets.push_back(0);
 
   auto const n_batched_ranks = batched_ranks.size();
-  if (n_batched_ranks == 0 || lastElement(batched_offsets) == 0)
+  if (n_batched_ranks == 0 ||
+      KokkosExt::lastElement(space, batched_offsets) == 0)
     return;
 
   using DeviceType = typename InputView::traits::device_type;

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -163,13 +163,14 @@ struct FDBSCANDenseBoxCallback
                           CorePointsType const &is_core_point,
                           Primitives const &primitives,
                           DenseCellOffsets const &dense_cell_offsets,
+                          int num_points_in_dense_cells,
                           Permutation const &permute, float eps_in)
       : _union_find(labels)
       , _is_core_point(is_core_point)
       , _primitives(primitives)
       , _dense_cell_offsets(dense_cell_offsets)
       , _num_dense_cells(dense_cell_offsets.size() - 1)
-      , _num_points_in_dense_cells(lastElement(dense_cell_offsets))
+      , _num_points_in_dense_cells(num_points_in_dense_cells)
       , _permute(permute)
       , eps(eps_in)
   {

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -15,6 +15,7 @@
 #include <ArborX_DetailsAlgorithms.hpp>
 #include <ArborX_DetailsHappyTreeFriends.hpp>
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsNode.hpp> // ROPE_SENTINEL
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsStack.hpp>
@@ -231,7 +232,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
         KOKKOS_LAMBDA(int i) { offset(i) = getK(Access::get(predicates, i)); });
     exclusivePrefixSum(space, offset);
-    int const buffer_size = lastElement(offset);
+    int const buffer_size = KokkosExt::lastElement(space, offset);
     // Allocate buffer over which to perform heap operations in
     // TreeTraversal::nearestQuery() to store nearest leaf nodes found so far.
     // It is not possible to anticipate how much memory to allocate since the

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -252,17 +252,11 @@ template <typename T, typename... P>
  *  \pre \c v is of rank 1 and not empty.
  */
 template <typename T, typename... P>
-typename Kokkos::ViewTraits<T, P...>::non_const_value_type
+[[deprecated]] typename Kokkos::ViewTraits<T, P...>::non_const_value_type
 lastElement(Kokkos::View<T, P...> const &v)
 {
-  static_assert((unsigned(Kokkos::ViewTraits<T, P...>::rank) == unsigned(1)),
-                "lastElement requires Views of rank 1");
-  auto const n = v.extent(0);
-  ARBORX_ASSERT(n > 0);
-  auto v_subview = Kokkos::subview(v, n - 1);
-  auto v_host = Kokkos::create_mirror_view(v_subview);
-  Kokkos::deep_copy(v_host, v_subview);
-  return v_host();
+  using ExecutionSpace = typename Kokkos::View<T, P...>::execution_space;
+  return KokkosExt::lastElement(ExecutionSpace{}, v);
 }
 
 /** \brief Fills the view with a sequence of numbers

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -18,7 +18,8 @@
 #include "ArborX_BoostRangeAdapters.hpp"
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp> // is_accessible_from_host
-#include <ArborX_DetailsUtils.hpp> // exclusivePrefixSum, lastElement
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>         // lastElement
+#include <ArborX_DetailsUtils.hpp>                        // exclusivePrefixSum
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
 
@@ -195,8 +196,9 @@ performQueries(RTree<Indexable> const &rtree, InputView const &queries)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
   using ExecutionSpace = typename InputView::execution_space;
-  ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);
-  auto const n_results = ArborX::lastElement(offset);
+  ExecutionSpace space;
+  ArborX::exclusivePrefixSum(space, offset);
+  auto const n_results = KokkosExt::lastElement(space, offset);
   OutputView indices("indices", n_results);
   for (int i = 0; i < n_queries; ++i)
     for (int j = offset(i); j < offset(i + 1); ++j)
@@ -221,8 +223,9 @@ performQueries(ParallelRTree<Indexable> const &rtree, InputView const &queries)
     offset(i) = rtree.query(translate<Value>(queries(i)),
                             std::back_inserter(returned_values));
   using ExecutionSpace = typename InputView::execution_space;
-  ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);
-  auto const n_results = ArborX::lastElement(offset);
+  ExecutionSpace space;
+  ArborX::exclusivePrefixSum(space, offset);
+  auto const n_results = KokkosExt::lastElement(space, offset);
   OutputView1 values("values", n_results);
   for (int i = 0; i < n_queries; ++i)
     for (int j = offset(i); j < offset(i + 1); ++j)

--- a/test/tstDetailsCrsGraphWrapperImpl.cpp
+++ b/test/tstDetailsCrsGraphWrapperImpl.cpp
@@ -66,14 +66,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(query_impl, DeviceType, ARBORX_DEVICE_TYPES)
 
   Kokkos::View<unsigned int *, DeviceType> permute(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::permute"), n);
-  ArborX::iota(ExecutionSpace{}, permute);
+  ExecutionSpace space;
+  ArborX::iota(space, permute);
 
-  ArborX::exclusivePrefixSum(ExecutionSpace{}, offset);
-  Kokkos::realloc(indices, ArborX::lastElement(offset));
+  ArborX::exclusivePrefixSum(space, offset);
+  Kokkos::realloc(indices, KokkosExt::lastElement(space, offset));
   ArborX::Details::CrsGraphWrapperImpl::queryImpl(
-      ExecutionSpace{}, Test1{}, predicates, ArborX::Details::DefaultCallback{},
-      indices, offset, permute,
-      ArborX::Details::BufferStatus::PreallocationHard);
+      space, Test1{}, predicates, ArborX::Details::DefaultCallback{}, indices,
+      offset, permute, ArborX::Details::BufferStatus::PreallocationHard);
 
   auto indices_host =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, indices);

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -352,19 +352,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_spatial_predicate,
     double const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
-  auto const bvh = make<ArborX::BVH<typename DeviceType::memory_space>>(
-      ExecutionSpace{}, boxes);
+  ExecutionSpace space;
+  auto const bvh =
+      make<ArborX::BVH<typename DeviceType::memory_space>>(space, boxes);
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> offset("offset", 0);
   // spatial query that is satisfied by all leaves in the tree
-  BOOST_CHECK_NO_THROW(ArborX::query(bvh, ExecutionSpace{},
+  BOOST_CHECK_NO_THROW(ArborX::query(bvh, space,
                                      makeIntersectsBoxQueries<DeviceType>({
                                          {},
                                          {{{0., 0., 0.}}, {{n, n, n}}},
                                      }),
                                      indices, offset));
-  BOOST_TEST(ArborX::lastElement(offset) == n);
+  BOOST_TEST(KokkosExt::lastElement(space, offset) == n);
 }
 
 #ifndef ARBORX_TEST_DISABLE_NEAREST_QUERY
@@ -385,18 +386,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_nearest_predicate,
     double const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
-  auto const bvh = make<ArborX::BVH<typename DeviceType::memory_space>>(
-      ExecutionSpace{}, boxes);
+  ExecutionSpace space;
+  auto const bvh =
+      make<ArborX::BVH<typename DeviceType::memory_space>>(space, boxes);
 
   Kokkos::View<int *, DeviceType> indices("indices", 0);
   Kokkos::View<int *, DeviceType> offset("offset", 0);
   // nearest query asking for as many neighbors as they are leaves in the tree
-  BOOST_CHECK_NO_THROW(ArborX::query(bvh, ExecutionSpace{},
+  BOOST_CHECK_NO_THROW(ArborX::query(bvh, space,
                                      makeNearestQueries<DeviceType>({
                                          {{{0., 0., 0.}}, n},
                                      }),
                                      indices, offset));
-  BOOST_TEST(ArborX::lastElement(offset) == n);
+  BOOST_TEST(KokkosExt::lastElement(space, offset) == n);
 }
 #endif
 


### PR DESCRIPTION
Partial fix for #641 