### PR TITLE
Remove unused node labeling utility

### DIFF
--- a/src/details/ArborX_DetailsTreeNodeLabeling.hpp
+++ b/src/details/ArborX_DetailsTreeNodeLabeling.hpp
@@ -35,8 +35,8 @@ void findParents(ExecutionSpace const &exec_space, BVH const &bvh,
       "ArborX::recompute_internal_and_leaf_node_parents",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n - 1),
       KOKKOS_LAMBDA(int i) {
-        parents(Details::HappyTreeFriends::getLeftChild(bvh, i)) = i;
-        parents(Details::HappyTreeFriends::getRightChild(bvh, i)) = i;
+        parents(HappyTreeFriends::getLeftChild(bvh, i)) = i;
+        parents(HappyTreeFriends::getRightChild(bvh, i)) = i;
       });
 }
 

--- a/src/details/ArborX_DetailsTreeNodeLabeling.hpp
+++ b/src/details/ArborX_DetailsTreeNodeLabeling.hpp
@@ -22,24 +22,6 @@ namespace ArborX
 namespace Details
 {
 
-template <class ExecutionSpace, class BVH, class LabelsIn, class LabelsOut>
-void initLabels(ExecutionSpace const &exec_space, BVH const &bvh,
-                LabelsIn const &in, LabelsOut &out)
-{
-  int const n = bvh.size();
-
-  ARBORX_ASSERT(n >= 2);
-  ARBORX_ASSERT((int)in.size() == n);
-  ARBORX_ASSERT((int)out.size() == 2 * n - 1);
-
-  Kokkos::parallel_for(
-      "ArborX::initialize_leaf_node_labels",
-      Kokkos::RangePolicy<ExecutionSpace>(exec_space, n - 1, 2 * n - 1),
-      KOKKOS_LAMBDA(int i) {
-        out(i) = in(Details::HappyTreeFriends::getLeafPermutationIndex(bvh, i));
-      });
-}
-
 template <class ExecutionSpace, class BVH, class Parents>
 void findParents(ExecutionSpace const &exec_space, BVH const &bvh,
                  Parents const &parents)


### PR DESCRIPTION
`Details::initLabels` was used in earlier versions of our computing minimum spanning trees but we don't use it any more and there is no plan to do so.