### PR TITLE
Fix bugs in nearest search in DistributedTree

### DIFF
--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -72,7 +72,7 @@ struct AccessTraits<
                              std::is_same<Dummy, Point>::value> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
-    auto const &point = getGeometry(Access::get(x.predicates, i));
+    auto const point = getGeometry(Access::get(x.predicates, i));
     auto const distance = x.distances(i);
     return intersects(Sphere{point, distance});
   }
@@ -97,7 +97,7 @@ struct AccessTraits<
                              std::is_same<Dummy, Sphere>::value> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
-    auto const &sphere = getGeometry(Access::get(x.predicates, i));
+    auto const sphere = getGeometry(Access::get(x.predicates, i));
     auto const distance = x.distances(i);
     return intersects(Sphere{sphere.centroid(), distance + sphere.radius()});
   }

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -85,14 +85,12 @@ struct AccessTraits<
     auto &min_corner = box.minCorner();
     auto &max_corner = box.maxCorner();
     auto const distance = x.distances(i);
-    Point point;
-    Details::centroid(box, point);
-    Point const diag{max_corner[0] - min_corner[0],
-                     max_corner[1] - min_corner[1],
-                     max_corner[2] - min_corner[2]};
-    auto const hypot = KokkosExt::hypot(diag[0], diag[1], diag[2]);
-
-    return intersects(Sphere{point, distance + hypot / 2});
+    for (int d = 0; d < 3; ++d)
+    {
+      min_corner[d] -= distance;
+      max_corner[d] += distance;
+    }
+    return intersects(box);
   }
   template <class Dummy = Geometry,
             std::enable_if_t<std::is_same<Dummy, Geometry>::value &&

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -62,7 +62,7 @@ struct AccessTraits<
   using Self = Details::WithinDistanceFromPredicates<Predicates, Distances>;
 
   using memory_space = typename Access::memory_space;
-  using size_type = size_t;
+  using size_type = decltype(Access::size(std::declval<Predicates const &>()));
   static KOKKOS_FUNCTION size_type size(Self const &x)
   {
     return Access::size(x.predicates);

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -217,7 +217,7 @@ struct DistributedTreeImpl
                 ExecutionSpace const &space, Predicates const &queries,
                 IndicesAndRanks &values, Offset &offset)
   {
-    // FIXME avoid zipping when distributed nearest callbacks become availale
+    // FIXME avoid zipping when distributed nearest callbacks become available
     Kokkos::View<int *, ExecutionSpace> indices(
         "ArborX::DistributedTree::query::nearest::indices", 0);
     Kokkos::View<int *, ExecutionSpace> ranks(
@@ -536,13 +536,13 @@ DistributedTreeImpl<DeviceType>::queryDispatchImpl(
   // recompute everything instead of just searching for potential better
   // neighbors and updating the list.
 
-  // Right now, distance calcuations only work with BVH due to using functions
+  // Right now, distance calculations only work with BVH due to using functions
   // in DistributedTreeNearestUtils. So, there's no point in replacing this
   // with decltype.
   CallbackWithDistance<BVH<typename DeviceType::memory_space>>
       callback_with_distance(space, bottom_tree);
 
-  // NOTE: compiler would not deduce __range for the braced-init-list but I
+  // NOTE: compiler would not deduce __range for the braced-init-list, but I
   // got it to work with the static_cast to function pointers.
   using Strategy =
       void (*)(ExecutionSpace const &, Predicates const &,
@@ -833,7 +833,7 @@ void DistributedTreeImpl<DeviceType>::communicateResultsBack(
   Distributor<DeviceType> distributor(comm);
   // FIXME Distributor::createFromSends takes two views of the same type by
   // a const reference.  There were two easy ways out, either take the views by
-  // value or cast at the callsite.  I went with the latter.  Proper fix
+  // value or cast at the call site.  I went with the latter.  Proper fix
   // involves more code cleanup in ArborX_DetailsDistributor.hpp than I am
   // willing to do just now.
   int const n_imports =

--- a/src/details/ArborX_DetailsKokkosExtMathFunctions.hpp
+++ b/src/details/ArborX_DetailsKokkosExtMathFunctions.hpp
@@ -19,8 +19,18 @@ namespace KokkosExt
 
 #if KOKKOS_VERSION >= 30699
 using Kokkos::isfinite;
+
+KOKKOS_INLINE_FUNCTION float hypot(float x, float y, float z)
+{
+  return Kokkos::sqrt(x * x + y * y + z * z);
+}
 #else
 using Kokkos::Experimental::isfinite;
+
+KOKKOS_INLINE_FUNCTION float hypot(float x, float y, float z)
+{
+  return Kokkos::Experimental::sqrt(x * x + y * y + z * z);
+}
 #endif
 
 } // namespace KokkosExt

--- a/src/details/ArborX_DetailsKokkosExtMathFunctions.hpp
+++ b/src/details/ArborX_DetailsKokkosExtMathFunctions.hpp
@@ -19,18 +19,8 @@ namespace KokkosExt
 
 #if KOKKOS_VERSION >= 30699
 using Kokkos::isfinite;
-
-KOKKOS_INLINE_FUNCTION float hypot(float x, float y, float z)
-{
-  return Kokkos::sqrt(x * x + y * y + z * z);
-}
 #else
 using Kokkos::Experimental::isfinite;
-
-KOKKOS_INLINE_FUNCTION float hypot(float x, float y, float z)
-{
-  return Kokkos::Experimental::sqrt(x * x + y * y + z * z);
-}
 #endif
 
 } // namespace KokkosExt

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -235,6 +235,43 @@ auto makeNearestQueries(
   return queries;
 }
 
+template <typename DeviceType>
+auto makeBoxNearestQueries(
+    std::vector<std::tuple<ArborX::Point, ArborX::Point, int>> const &boxes)
+{
+  // NOTE: `boxes` is not a very descriptive name here. It stores both the
+  // corners of the boxe and the number k of neighbors to query for.
+  int const n = boxes.size();
+  Kokkos::View<ArborX::Nearest<ArborX::Box> *, DeviceType> queries(
+      "Testing::nearest_queries", n);
+  auto queries_host = Kokkos::create_mirror_view(queries);
+  for (int i = 0; i < n; ++i)
+    queries_host(i) = ArborX::nearest(
+        ArborX::Box{std::get<0>(boxes[i]), std::get<1>(boxes[i])},
+        std::get<2>(boxes[i]));
+  Kokkos::deep_copy(queries, queries_host);
+  return queries;
+}
+
+template <typename DeviceType>
+auto makeSphereNearestQueries(
+    std::vector<std::tuple<ArborX::Point, float, int>> const &spheres)
+{
+  // NOTE: `sphere` is not a very descriptive name here. It stores both the
+  // center and the radius of the sphere and the number k of neighbors to query
+  // for.
+  int const n = spheres.size();
+  Kokkos::View<ArborX::Nearest<ArborX::Sphere> *, DeviceType> queries(
+      "Testing::nearest_queries", n);
+  auto queries_host = Kokkos::create_mirror_view(queries);
+  for (int i = 0; i < n; ++i)
+    queries_host(i) = ArborX::nearest(
+        ArborX::Sphere{std::get<0>(spheres[i]), std::get<1>(spheres[i])},
+        std::get<2>(spheres[i]));
+  Kokkos::deep_copy(queries, queries_host);
+  return queries;
+}
+
 template <typename DeviceType, typename Data>
 auto makeNearestWithAttachmentQueries(
     std::vector<std::pair<ArborX::Point, int>> const &points,


### PR DESCRIPTION
Currently, ArborX does not compile if you want to use nearest neighbors on anything but `Point`. The problem is that we get the `Geometry` of the queries to build a sphere but we assume that the `Geometry` is a `Point` that we can use as the center of the sphere. This functions add three `buildSphere` functions that create a sphere if the `Geometry` is a `Point`, a `Box`, or a `Sphere`.