### PR TITLE
SYCL: Use device-code-split=per_kernel

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -351,7 +351,7 @@ pipeline {
                                     -D CMAKE_BUILD_TYPE=Release \
                                     -D CMAKE_CXX_COMPILER=clang++ \
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
-                                    -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra -Wno-unknown-cuda-version" \
+                                    -D CMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -Wpedantic -Wall -Wextra -Wno-unknown-cuda-version" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR;$ONE_DPL_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
                                     -D MPIEXEC_PREFLAGS="--allow-run-as-root" \


### PR DESCRIPTION
Comparing https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/ArborX/detail/PR-654/7/pipeline and https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/ArborX/detail/PR-654/6/pipeline, this seems to accelerate build and run time significantly:
build: 35m 39s -> 19m 23s
test: 6m 57s -> 1m 24s