### PR TITLE
Improve MST performance by prefering lock-free atomics

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -177,7 +177,7 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/mst_golden_test_edges.csv
   COPYONLY
 )
-if(Kokkos_VERSION VERSION_GREATER_EQUAL 3.5 AND NOT Kokkos_ENABLE_SYCL) # FIXME_SYCL
+if(Kokkos_VERSION VERSION_GREATER_EQUAL 3.5)
   set(MINIMUM_SPANNING_TREE_TESTS
     tstMinimumSpanningTree.cpp
     tstMinimumSpanningTreeGoldenTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(ArborX_CompileOnly.exe
   tstCompileOnlyAccessTraits.cpp
   tstCompileOnlyCallbacks.cpp
   tstCompileOnlyTypeRequirements.cpp
+  tstCompileOnlyWeightedEdges.cpp
   tstCompileOnlyMain.cpp
 )
 target_link_libraries(ArborX_CompileOnly.exe PRIVATE ArborX)

--- a/test/tstCompileOnlyWeightedEdges.cpp
+++ b/test/tstCompileOnlyWeightedEdges.cpp
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#if KOKKOS_VERSION >= 30500
+
+#include <ArborX_MinimumSpanningTree.hpp>
+
+namespace
+{
+
+// NOTE: message is not required anymore with C++17
+#define STATIC_ASSERT(cond) static_assert(cond, "")
+
+KOKKOS_FUNCTION constexpr bool test_directed_edges()
+{
+  using ArborX::Details::DirectedEdge;
+
+  STATIC_ASSERT((DirectedEdge{0, 1, 2.f}.weight == 2.f));
+  STATIC_ASSERT((DirectedEdge{0, 1, 2.f}.source() == 0));
+  STATIC_ASSERT((DirectedEdge{0, 1, 2.f}.target() == 1));
+
+  STATIC_ASSERT((DirectedEdge{6, 5, 4.f}.weight == 4.f));
+  STATIC_ASSERT((DirectedEdge{6, 5, 4.f}.source() == 6));
+  STATIC_ASSERT((DirectedEdge{6, 5, 4.f}.target() == 5));
+
+  constexpr auto inf = KokkosExt::ArithmeticTraits::infinity<float>::value;
+  STATIC_ASSERT((DirectedEdge{}.weight == inf));
+  STATIC_ASSERT((DirectedEdge{}.source() == INT_MAX));
+  STATIC_ASSERT((DirectedEdge{}.target() == INT_MAX));
+
+  STATIC_ASSERT((DirectedEdge{0, 1, 2.f} < DirectedEdge{0, 1, 3.f}));
+  STATIC_ASSERT((DirectedEdge{0, 1, 2.f} < DirectedEdge{1, 2, 2.f}));
+  STATIC_ASSERT((DirectedEdge{0, 1, 2.f} < DirectedEdge{2, 1, 2.f}));
+
+  constexpr DirectedEdge e12{1, 2, 3};
+  constexpr DirectedEdge e21{2, 1, 3};
+  STATIC_ASSERT(e12.weight == e21.weight);
+  STATIC_ASSERT((e12 < e21) ^ (e21 < e12));
+
+  return true;
+}
+STATIC_ASSERT(test_directed_edges()); // avoid warning unused function
+
+KOKKOS_FUNCTION constexpr bool test_weighted_edges()
+{
+  using ArborX::Details::WeightedEdge;
+
+  STATIC_ASSERT((WeightedEdge{1, 2, 3} < WeightedEdge{1, 2, 4}));
+
+  constexpr WeightedEdge e12{1, 2, 3};
+  constexpr WeightedEdge e21{2, 1, 3};
+  STATIC_ASSERT(e12.weight == e21.weight);
+  STATIC_ASSERT(!(e12 < e21));
+  STATIC_ASSERT(!(e21 < e12));
+
+  constexpr WeightedEdge e14{1, 4, 3};
+  STATIC_ASSERT(e12.weight == e14.weight);
+  STATIC_ASSERT(e12 < e14);
+
+  return true;
+}
+STATIC_ASSERT(test_weighted_edges()); // avoid warning unused function
+
+} // namespace
+
+#endif

--- a/test/tstMinimumSpanningTree.cpp
+++ b/test/tstMinimumSpanningTree.cpp
@@ -20,13 +20,6 @@
 // NOTE: message is not required anymore with C++17
 #define STATIC_ASSERT(cond) static_assert(cond, "")
 
-void test_compile_only()
-{
-  using ArborX::Details::WeightedEdge;
-  STATIC_ASSERT((WeightedEdge{1, 2, 3} < WeightedEdge{1, 2, 4}));
-  STATIC_ASSERT((WeightedEdge{1, 2, 3} < WeightedEdge{1, 4, 3}));
-}
-
 namespace ArborX
 {
 namespace Details
@@ -40,10 +33,11 @@ inline constexpr bool operator==(WeightedEdge const &lhs,
 } // namespace Details
 } // namespace ArborX
 
-void test_another_compile_only()
+void test_weighted_edges_comparison_compile_only()
 {
   using ArborX::Details::WeightedEdge;
   STATIC_ASSERT((WeightedEdge{1, 2, 3} == WeightedEdge{1, 2, 3}));
+  STATIC_ASSERT((WeightedEdge{1, 2, 3} == WeightedEdge{2, 1, 3}));
 }
 
 template <>


### PR DESCRIPTION
Variation on #660
As in the original PR by Andrey, the performance improvement comes from introducing an intermediate array that stores the weights, and taking advantage of lock-free atomics when searching for the component nearest neighbors.

Suggested improvements in this PR include
* smaller increase in memory footprint (allocate `View<float*>` instead of `View<WeightedEdge*>`)
* avoid allocating and deallocating at each iteration step
* one extra kernel  launch instead of three
* faster edge comparison through using `long`