### PR TITLE
Set timeout on Jenkins CI builds

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -1,6 +1,7 @@
 pipeline {
     options {
         disableConcurrentBuilds(abortPrevious: true)
+        timeout(time: 2, unit: 'HOURS')
     }
     triggers {
         issueCommentTrigger('.*test this please.*')


### PR DESCRIPTION
I observed recently a couple builds hanging for 10+ hrs and that I had to kill by hand.
Here I propose to set a limit at 2hrs.  The limit is for individual stages.  We could pick something shorter but I think that anything above 2hrs might as well get killed.
