### PR TITLE
Increase timeout in CI from 2h to 3h

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -1,7 +1,7 @@
 pipeline {
     options {
         disableConcurrentBuilds(abortPrevious: true)
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 3, unit: 'HOURS')
     }
     triggers {
         issueCommentTrigger('.*test this please.*')


### PR DESCRIPTION
I have seen multiple times that the CI timed out for SYCL when rebuilding the container. The overall run should run around 2h including building the compiler which is right on the limit for our current setting. Using 3h should provide a safe margin.