### PR TITLE
Mark several AccessTraits::size functions as KOKKOS_FUNCTION

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -85,7 +85,7 @@ struct AccessTraits<Details::PrimitivesWithRadius<Primitives>, PredicatesTag>
   using memory_space = typename PrimitivesAccess::memory_space;
   using Predicates = Details::PrimitivesWithRadius<Primitives>;
 
-  static size_t size(Predicates const &w)
+  static KOKKOS_FUNCTION size_t size(Predicates const &w)
   {
     return PrimitivesAccess::size(w._primitives);
   }
@@ -109,7 +109,10 @@ struct AccessTraits<Details::PrimitivesWithRadiusReorderedAndFiltered<
       Details::PrimitivesWithRadiusReorderedAndFiltered<Primitives,
                                                         PermuteFilter>;
 
-  static size_t size(Predicates const &w) { return w._filter.extent(0); }
+  static KOKKOS_FUNCTION size_t size(Predicates const &w)
+  {
+    return w._filter.extent(0);
+  }
   static KOKKOS_FUNCTION auto get(Predicates const &w, size_t i)
   {
     int index = w._filter(i);

--- a/src/details/ArborX_DetailsPermutedData.hpp
+++ b/src/details/ArborX_DetailsPermutedData.hpp
@@ -38,7 +38,8 @@ struct AccessTraits<Details::PermutedData<Predicates, Permute, AttachIndices>,
       Details::PermutedData<Predicates, Permute, AttachIndices>;
   using NativeAccess = AccessTraits<Predicates, PredicatesTag>;
 
-  static std::size_t size(PermutedPredicates const &permuted_predicates)
+  KOKKOS_FUNCTION static std::size_t
+  size(PermutedPredicates const &permuted_predicates)
   {
     return NativeAccess::size(permuted_predicates._data);
   }


### PR DESCRIPTION
I was playing around with traversal algorithm, and tried using `Access::size()` within the traversal structure. When running DBSCAN, some `AccessTraits::size()` instantiations were not marked with `KOKKOS_FUNCTION` which lead to failures.