### PR TITLE
Issue an error when using old Traits::Access

### DIFF
--- a/src/ArborX_CrsGraphWrapper.hpp
+++ b/src/ArborX_CrsGraphWrapper.hpp
@@ -30,7 +30,7 @@ inline void query(Tree const &tree, ExecutionSpace const &space,
       check_valid_callback_if_first_argument_is_not_a_view(callback_or_view,
                                                            predicates, view);
 
-  using Access = AccessTraits<Predicates, Traits::PredicatesTag>;
+  using Access = AccessTraits<Predicates, ArborX::PredicatesTag>;
   using Tag = typename Details::AccessTraitsHelper<Access>::tag;
 
   ArborX::Details::CrsGraphWrapperImpl::queryDispatch(

--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -191,10 +191,12 @@ void check_valid_access_traits(PrimitivesTag, Primitives const &)
 
 namespace Traits
 {
+#if !defined(KOKKOS_COMPILER_NVCC) || (__CUDACC_VER_MAJOR__ >= 11)
 using PredicatesTag [[deprecated("Use ArborX::PredicatesTag instead.")]] =
     ::ArborX::PredicatesTag;
 using PrimitivesTag [[deprecated("Use ArborX::PrimitivesTag instead.")]] =
     ::ArborX::PrimitivesTag;
+#endif
 template <typename T, typename Tag, typename Enable = void>
 struct Access
 {

--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -191,8 +191,10 @@ void check_valid_access_traits(PrimitivesTag, Primitives const &)
 
 namespace Traits
 {
-using ::ArborX::PredicatesTag;
-using ::ArborX::PrimitivesTag;
+using PredicatesTag [[deprecated("Use ArborX::PredicatesTag instead.")]] =
+    ::ArborX::PredicatesTag;
+using PrimitivesTag [[deprecated("Use ArborX::PrimitivesTag instead.")]] =
+    ::ArborX::PrimitivesTag;
 template <typename T, typename Tag, typename Enable = void>
 struct Access
 {
@@ -206,6 +208,11 @@ struct AccessTraits<
         AccessTraitsNotSpecializedArchetypeAlias, Traits::Access<T, Tag>>{}>>
     : Traits::Access<T, Tag>
 {
+  template <class U>
+  static constexpr bool always_false = std::is_void<U>::value;
+  static_assert(
+      always_false<T>,
+      "ArborX::Traits::Access was removed. Use ArborX::AccessTraits instead");
 };
 } // namespace ArborX
 

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -73,8 +73,6 @@ void test_access_traits_compile_only()
   Kokkos::View<NearestPredicate *> q;
   check_valid_access_traits(PredicatesTag{}, q);
 
-  check_valid_access_traits(PrimitivesTag{}, LegacyAccessTraits{});
-
   // Uncomment to see error messages
 
   // check_valid_access_traits(PrimitivesTag{}, NoAccessTraitsSpecialization{});
@@ -84,4 +82,6 @@ void test_access_traits_compile_only()
   // check_valid_access_traits(PrimitivesTag{}, InvalidMemorySpace{});
 
   // check_valid_access_traits(PrimitivesTag{}, SizeMemberFunctionNotStatic{});
+
+  // check_valid_access_traits(PrimitivesTag{}, LegacyAccessTraits{});
 }


### PR DESCRIPTION
Fix #399.

To be merged after releasing 1.2. Will affect platoanalyze if platoengine/platoanalyze#101 not merged there.