### PR TITLE
Set a timeout for the nightly CI

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -1,4 +1,8 @@
 pipeline {
+    options {
+        disableConcurrentBuilds(abortPrevious: true)
+        timeout(time: 3, unit: 'HOURS')
+    }
     agent none
 
     stages {


### PR DESCRIPTION
These are the same options we set in .jenkins/continuous.groovy.
`disableConcurrentBuilds(abortPrevious: true)` probably isn't all that relevant here but it should also not hurt.