### PR TITLE
Use ropes for all backends

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -84,15 +84,18 @@ public:
 private:
   friend struct Details::HappyTreeFriends;
 
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) ||               \
+    defined(KOKKOS_ENABLE_SYCL)
   // Ropes based traversal is only used for CUDA, as it was found to be slower
   // than regular one for Power9 on Summit.  It is also used with HIP.
   using node_type = std::conditional_t<
       std::is_same<MemorySpace,
 #if defined(KOKKOS_ENABLE_CUDA)
                    Kokkos::CudaSpace
-#else
+#elif defined(KOKKOS_ENABLE_HIP)
                    Kokkos::Experimental::HIPSpace
+#else
+                   Kokkos::Experimental::SYCLDeviceUSMSpace
 #endif
                    >{},
       Details::NodeWithLeftChildAndRope<bounding_volume_type>,

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -84,25 +84,7 @@ public:
 private:
   friend struct Details::HappyTreeFriends;
 
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) ||               \
-    defined(KOKKOS_ENABLE_SYCL)
-  // Ropes based traversal is only used for CUDA, as it was found to be slower
-  // than regular one for Power9 on Summit.  It is also used with HIP.
-  using node_type = std::conditional_t<
-      std::is_same<MemorySpace,
-#if defined(KOKKOS_ENABLE_CUDA)
-                   Kokkos::CudaSpace
-#elif defined(KOKKOS_ENABLE_HIP)
-                   Kokkos::Experimental::HIPSpace
-#else
-                   Kokkos::Experimental::SYCLDeviceUSMSpace
-#endif
-                   >{},
-      Details::NodeWithLeftChildAndRope<bounding_volume_type>,
-      Details::NodeWithTwoChildren<bounding_volume_type>>;
-#else
-  using node_type = Details::NodeWithTwoChildren<bounding_volume_type>;
-#endif
+  using node_type = Details::NodeWithLeftChildAndRope<bounding_volume_type>;
 
   Kokkos::View<node_type *, MemorySpace> getInternalNodes()
   {


### PR DESCRIPTION
I see up to 10% faster results for our performance benchmark and around 17% for DBScan.