### PR TITLE
Remove legacy deprecation for the old version of nearest callback

### DIFF
--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -52,12 +52,6 @@ using InlineCallbackArchetypeExpression =
     decltype(std::declval<Callback const &>()(std::declval<Predicate const &>(),
                                               0, std::declval<Out const &>()));
 
-// legacy nearest predicate archetypal expression for user callbacks
-template <typename Callback, typename Predicate, typename Out>
-using Legacy_NearestPredicateInlineCallbackArchetypeExpression = decltype(
-    std::declval<Callback const &>()(std::declval<Predicate const &>(), 0, 0.f,
-                                     std::declval<Out const &>()));
-
 // archetypal alias for a 'tag' type member in user callbacks
 template <typename Callback>
 using CallbackTagArchetypeAlias = typename Callback::tag;
@@ -99,14 +93,6 @@ void check_valid_callback(Callback const &callback, Predicates const &,
   using Access = AccessTraits<Predicates, PredicatesTag>;
   using PredicateTag = typename AccessTraitsHelper<Access>::tag;
   using Predicate = typename AccessTraitsHelper<Access>::type;
-
-  static_assert(!(std::is_same<PredicateTag, NearestPredicateTag>{} &&
-                  KokkosExt::is_detected<
-                      Legacy_NearestPredicateInlineCallbackArchetypeExpression,
-                      Callback, Predicate, OutputFunctorHelper<OutputView>>{}),
-                R"error(Callback signature has changed for nearest predicates.
-See https://github.com/arborx/ArborX/pull/366 for more details.
-Sorry!)error");
 
   static_assert(
       (std::is_same<PredicateTag, SpatialPredicateTag>{} ||


### PR DESCRIPTION
It's been 1.5 years now, should be safe to remove.