### PR TITLE
Check clang-tidy version in scripts/check_format_cpp.sh

### DIFF
--- a/scripts/check_format_cpp.sh
+++ b/scripts/check_format_cpp.sh
@@ -41,6 +41,16 @@ done
 # stop right here if clang-format does not exist in $PATH
 command -v $clang_format_executable >/dev/null 2>&1 || { echo >&2 "clang-format executable '$clang_format_executable' not found.  Aborting."; exit 1; }
 
+clang_format_version="$(${clang_format_executable} --version)"
+clang_format_major_version=$(echo "${clang_format_version}" | sed 's/^[^0-9]*\([0-9]*\).*$/\1/g')
+clang_format_minor_version=$(echo "${clang_format_version}" | sed 's/^[^0-9]*[0-9]*\.\([0-9]*\).*$/\1/g')
+
+if [ "${clang_format_major_version}" -ne 14 ] || [ "${clang_format_minor_version}" -ne 0 ]; then
+  echo "***   This indent script requires clang-format version 14.0,"
+  echo "***   but version ${clang_format_major_version}.${clang_format_minor_version} was found instead."
+  exit 1
+fi
+
 # shamelessy redirecting everything to /dev/null in quiet mode
 if [ $verbose -eq 0 ]; then
     exec &>/dev/null


### PR DESCRIPTION
This avoids using a wrong clang-format version for formatting and also documents which version we expect.
Before switching to clang-format 14.0, I accidentally used version 8.0 instead of 7.0 multiple times.