### PR TITLE
Mark one AccessTraits size() as KOKKOS_FUNCTION

### DIFF
--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -173,7 +173,7 @@ template <typename Queries>
 struct ArborX::AccessTraits<QueriesWithIndex<Queries>, ArborX::PredicatesTag>
 {
   using memory_space = typename Queries::memory_space;
-  static size_t size(QueriesWithIndex<Queries> const &q)
+  static KOKKOS_FUNCTION size_t size(QueriesWithIndex<Queries> const &q)
   {
     return q._queries.extent(0);
   }


### PR DESCRIPTION
Warning:
```
<arborx>/src/details/ArborX_DetailsPermutedData.hpp(44): warning:
	calling a __host__ function from a __host__ __device__ function is not allowed
```