### PR TITLE
Remove node with two children in favor of node with left child and rope

### DIFF
--- a/src/details/ArborX_DetailsHappyTreeFriends.hpp
+++ b/src/details/ArborX_DetailsHappyTreeFriends.hpp
@@ -26,17 +26,6 @@ namespace Details
 struct HappyTreeFriends
 {
   template <class BVH>
-  struct has_node_with_two_children
-      : std::is_same<typename BVH::node_type::Tag, NodeWithTwoChildrenTag>::type
-  {};
-
-  template <class BVH>
-  struct has_node_with_left_child_and_rope
-      : std::is_same<typename BVH::node_type::Tag,
-                     NodeWithLeftChildAndRopeTag>::type
-  {};
-
-  template <class BVH>
   static KOKKOS_FUNCTION int getRoot(BVH const &)
   {
     return 0;
@@ -76,41 +65,11 @@ struct HappyTreeFriends
   template <class BVH>
   static KOKKOS_FUNCTION auto getRightChild(BVH const &bvh, int i)
   {
-#ifndef KOKKOS_ENABLE_CXX17
-    return getRightChildImpl(bvh, i);
-#else
-    static_assert(has_node_with_two_children<BVH>::value ||
-                  has_node_with_left_child_and_rope<BVH>::value);
-    assert(!isLeaf(bvh, i));
-    if constexpr (has_node_with_left_child_and_rope<BVH>::value)
-      return bvh._internal_and_leaf_nodes(getLeftChild(bvh, i)).rope;
-    else
-      return bvh._internal_and_leaf_nodes(i).right_child;
-#endif
-  }
-
-#ifndef KOKKOS_ENABLE_CXX17
-  template <class BVH, std::enable_if_t<has_node_with_two_children<BVH>::value>
-                           * = nullptr>
-  static KOKKOS_FUNCTION auto getRightChildImpl(BVH const &bvh, int i)
-  {
-    assert(!isLeaf(bvh, i));
-    return bvh._internal_and_leaf_nodes(i).right_child;
-  }
-
-  template <class BVH,
-            std::enable_if_t<has_node_with_left_child_and_rope<BVH>::value> * =
-                nullptr>
-  static KOKKOS_FUNCTION auto getRightChildImpl(BVH const &bvh, int i)
-  {
     assert(!isLeaf(bvh, i));
     return bvh._internal_and_leaf_nodes(getLeftChild(bvh, i)).rope;
   }
-#endif
 
-  template <class BVH,
-            std::enable_if_t<has_node_with_left_child_and_rope<BVH>::value> * =
-                nullptr>
+  template <class BVH>
   static KOKKOS_FUNCTION auto getRope(BVH const &bvh, int i)
   {
     return bvh._internal_and_leaf_nodes(i).rope;

--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -25,51 +25,11 @@ namespace ArborX
 namespace Details
 {
 
-struct NodeWithTwoChildrenTag
-{};
-struct NodeWithLeftChildAndRopeTag
-{};
-
-template <class BoundingVolume>
-struct NodeWithTwoChildren
-{
-  using Tag = NodeWithTwoChildrenTag;
-  using bounding_volume_type = BoundingVolume;
-
-  KOKKOS_DEFAULTED_FUNCTION
-  constexpr NodeWithTwoChildren() = default;
-
-  KOKKOS_INLINE_FUNCTION constexpr bool isLeaf() const noexcept
-  {
-    return left_child == -1;
-  }
-
-  KOKKOS_INLINE_FUNCTION constexpr std::size_t
-  getLeafPermutationIndex() const noexcept
-  {
-    assert(isLeaf());
-    return right_child;
-  }
-
-  int left_child = -1;
-  int right_child = -1;
-  BoundingVolume bounding_volume;
-};
-
-template <class BoundingVolume>
-KOKKOS_INLINE_FUNCTION constexpr NodeWithTwoChildren<BoundingVolume>
-makeLeafNode(NodeWithTwoChildrenTag, std::size_t permutation_index,
-             BoundingVolume bounding_volume) noexcept
-{
-  return {-1, static_cast<int>(permutation_index), std::move(bounding_volume)};
-}
-
 constexpr int ROPE_SENTINEL = -1;
 
 template <class BoundingVolume>
 struct NodeWithLeftChildAndRope
 {
-  using Tag = NodeWithLeftChildAndRopeTag;
   using bounding_volume_type = BoundingVolume;
 
   KOKKOS_DEFAULTED_FUNCTION
@@ -105,7 +65,7 @@ struct NodeWithLeftChildAndRope
 
 template <class BoundingVolume>
 KOKKOS_INLINE_FUNCTION constexpr NodeWithLeftChildAndRope<BoundingVolume>
-makeLeafNode(NodeWithLeftChildAndRopeTag, std::size_t permutation_index,
+makeLeafNode(std::size_t permutation_index,
              BoundingVolume bounding_volume) noexcept
 {
   return {-static_cast<int>(permutation_index), ROPE_SENTINEL,

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -99,8 +99,7 @@ inline void initializeSingleLeafNode(ExecutionSpace const &space,
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, 1), KOKKOS_LAMBDA(int) {
         BoundingVolume bounding_volume{};
         expand(bounding_volume, Access::get(primitives, 0));
-        leaf_nodes(0) =
-            makeLeafNode(typename Node::Tag{}, 0, std::move(bounding_volume));
+        leaf_nodes(0) = makeLeafNode(0, std::move(bounding_volume));
       });
 }
 
@@ -202,32 +201,8 @@ public:
     return (i < n ? &(_internal_nodes(i)) : &(_leaf_nodes(i - n)));
   }
 
-  template <typename Tag = typename Node::Tag>
-  KOKKOS_FUNCTION std::enable_if_t<std::is_same<Tag, NodeWithTwoChildrenTag>{}>
-  setRightChild(Node *node, int child_right) const
-  {
-    assert(!node->isLeaf());
-    node->right_child = child_right;
-  }
-
-  template <typename Tag = typename Node::Tag>
   KOKKOS_FUNCTION
-      std::enable_if_t<std::is_same<Tag, NodeWithLeftChildAndRopeTag>{}>
-      setRightChild(Node *node, int) const
-  {
-    assert(!node->isLeaf());
-    (void)node;
-  }
-
-  template <typename Tag = typename Node::Tag>
-  KOKKOS_FUNCTION std::enable_if_t<std::is_same<Tag, NodeWithTwoChildrenTag>{}>
-  setRope(Node *, int, DeltaValueType) const
-  {}
-
-  template <typename Tag = typename Node::Tag>
-  KOKKOS_FUNCTION
-      std::enable_if_t<std::is_same<Tag, NodeWithLeftChildAndRopeTag>{}>
-      setRope(Node *node, int range_right, DeltaValueType delta_right) const
+  void setRope(Node *node, int range_right, DeltaValueType delta_right) const
   {
     int rope;
     if (range_right != _num_internal_nodes)
@@ -264,8 +239,7 @@ public:
 
     // Initialize leaf node
     auto *leaf_node = getNodePtr(i);
-    *leaf_node =
-        makeLeafNode(typename Node::Tag{}, original_index, bounding_volume);
+    *leaf_node = makeLeafNode(original_index, bounding_volume);
 
     // For a leaf node, the range is just one index
     int range_left = i - leaf_nodes_shift;
@@ -356,7 +330,6 @@ public:
 
       auto *parent_node = getNodePtr(karras_parent);
       parent_node->left_child = left_child;
-      setRightChild(parent_node, right_child);
       setRope(parent_node, range_right, delta_right);
       parent_node->bounding_volume = bounding_volume;
 

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -158,40 +158,8 @@ void generateHierarchy(Primitives primitives, MortonCodes sorted_morton_codes,
 }
 
 template <typename Node, typename LeafNodes, typename InternalNodes>
-std::enable_if_t<
-    std::is_same<typename Node::Tag, ArborX::Details::NodeWithTwoChildrenTag>{}>
-traverse(LeafNodes leaf_nodes, InternalNodes internal_nodes, Node const *root,
-         std::ostringstream &sol)
-{
-  int n = leaf_nodes.extent(0);
-  auto getNodePtr = [&leaf_nodes, &internal_nodes, &n](int i) {
-    return i < n - 1 ? &internal_nodes(i) : &leaf_nodes(i - n + 1);
-  };
-
-  std::function<void(Node const *, std::ostream &)> traverseRecursive;
-  traverseRecursive = [&leaf_nodes, &internal_nodes, &getNodePtr,
-                       &traverseRecursive](Node const *node, std::ostream &os) {
-    if (node->isLeaf())
-    {
-      os << "L" << node - leaf_nodes.data();
-    }
-    else
-    {
-      os << "I" << node - internal_nodes.data();
-      for (Node const *child :
-           {getNodePtr(node->left_child), getNodePtr(node->right_child)})
-        traverseRecursive(child, os);
-    }
-  };
-
-  traverseRecursive(root, sol);
-}
-
-template <typename Node, typename LeafNodes, typename InternalNodes>
-std::enable_if_t<std::is_same<typename Node::Tag,
-                              ArborX::Details::NodeWithLeftChildAndRopeTag>{}>
-traverse(LeafNodes leaf_nodes, InternalNodes internal_nodes, Node const *root,
-         std::ostringstream &sol)
+void traverse(LeafNodes leaf_nodes, InternalNodes internal_nodes,
+              Node const *root, std::ostringstream &sol)
 {
   int n = leaf_nodes.extent(0);
   auto getNodePtr = [&leaf_nodes, &internal_nodes, &n](int i) {
@@ -263,41 +231,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   // clang-format on
   BOOST_TEST_MESSAGE("ref = " << ref.str());
 
-  {
-    using Node = ArborX::Details::NodeWithTwoChildren<Test::FakeBoundingVolume>;
+  using Node =
+      ArborX::Details::NodeWithLeftChildAndRope<Test::FakeBoundingVolume>;
 
-    Kokkos::View<Node *, DeviceType> leaf_nodes("Testing::leaf_nodes", 0);
-    Kokkos::View<Node *, DeviceType> internal_nodes("Testing::internal_nodes",
-                                                    0);
-    generateHierarchy(primitives, sorted_morton_codes, leaf_nodes,
-                      internal_nodes);
+  Kokkos::View<Node *, DeviceType> leaf_nodes("Testing::leaf_nodes", 0);
+  Kokkos::View<Node *, DeviceType> internal_nodes("Testing::internal_nodes", 0);
+  generateHierarchy(primitives, sorted_morton_codes, leaf_nodes,
+                    internal_nodes);
 
-    auto const *root = internal_nodes.data();
+  auto const *root = internal_nodes.data();
 
-    std::ostringstream sol;
-    traverse(leaf_nodes, internal_nodes, root, sol);
+  std::ostringstream sol;
+  traverse(leaf_nodes, internal_nodes, root, sol);
 
-    BOOST_TEST_MESSAGE("sol(node_with_two_children) = " << sol.str());
+  BOOST_TEST_MESSAGE("sol(node_with_left_child_and_rope) = " << sol.str());
 
-    BOOST_TEST(sol.str() == ref.str());
-  }
-  {
-    using Node =
-        ArborX::Details::NodeWithLeftChildAndRope<Test::FakeBoundingVolume>;
-
-    Kokkos::View<Node *, DeviceType> leaf_nodes("Testing::leaf_nodes", 0);
-    Kokkos::View<Node *, DeviceType> internal_nodes("Testing::internal_nodes",
-                                                    0);
-    generateHierarchy(primitives, sorted_morton_codes, leaf_nodes,
-                      internal_nodes);
-
-    auto const *root = internal_nodes.data();
-
-    std::ostringstream sol;
-    traverse(leaf_nodes, internal_nodes, root, sol);
-
-    BOOST_TEST_MESSAGE("sol(node_with_left_child_and_rope) = " << sol.str());
-
-    BOOST_TEST(sol.str() == ref.str());
-  }
+  BOOST_TEST(sol.str() == ref.str());
 }


### PR DESCRIPTION
Following up on https://github.com/arborx/ArborX/pull/672#pullrequestreview-1011018003
Cleaning up and removing `Details::NodeWithTwoChildren`