### PR TITLE
Make sure default-initialized BVH or BF do not give undefined behavior

### DIFF
--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -63,7 +63,7 @@ public:
   }
 
 private:
-  size_type _size;
+  size_type _size{0};
   bounding_volume_type _bounds;
   Kokkos::View<bounding_volume_type *, memory_space> _bounding_volumes;
 };

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -117,7 +117,7 @@ private:
     return &_internal_and_leaf_nodes.data()->bounding_volume;
   }
 
-  size_t _size{0};
+  size_type _size{0};
   bounding_volume_type _bounds;
   Kokkos::View<node_type *, MemorySpace> _internal_and_leaf_nodes;
 };

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -117,7 +117,7 @@ private:
     return &_internal_and_leaf_nodes.data()->bounding_volume;
   }
 
-  size_t _size;
+  size_t _size{0};
   bounding_volume_type _bounds;
   Kokkos::View<node_type *, MemorySpace> _internal_and_leaf_nodes;
 };

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -30,8 +30,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree_spatial_predicate, TreeTypeTraits,
   using DeviceType = typename TreeTypeTraits::device_type;
 
   // tree is empty, it has no leaves.
+  Tree default_initialized;
+  Tree value_initialized{};
   for (auto const &tree : {
-           Tree{}, // default constructed
+           default_initialized, value_initialized,
            make<Tree>(ExecutionSpace{},
                       {}), // constructed with empty view of boxes
        })


### PR DESCRIPTION
Default initialization was leading to uninitialized `_size` data members