### PR TITLE
Restrict ViewComparison to non-strided Views

### DIFF
--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -32,8 +32,10 @@ struct is_forward_iterable<Kokkos::View<T, P...>> : public boost::mpl::true_
   // operator== for the operands is not as clear.
   static_assert(
       Kokkos::View<T, P...>::rank == 1 &&
+          !std::is_same<typename Kokkos::View<T, P...>::array_layout,
+                        Kokkos::LayoutStride>::value &&
           KokkosExt::is_accessible_from_host<Kokkos::View<T, P...>>::value,
-      "Restricted to rank-one host-accessible views");
+      "Restricted to contiguous rank-one host-accessible views");
 };
 
 template <typename T, typename... P>


### PR DESCRIPTION
[arborx/ArborX@`a4e33e3` (#683)](https://github.com/arborx/ArborX/pull/683/commits/a4e33e37045fdbdfd53695a7715f755e8c794b64) exposed that we can't use subviews in `BOOST_TEST` macros since they are strided and, thus, its elements are potentially not contiguous in memory.