### PR TITLE
Fixup for ordered spatial queries

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -283,10 +283,23 @@ void BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::query(
   Details::check_valid_callback(callback, predicates);
 
   using Tag = typename Details::AccessTraitsHelper<Access>::tag;
-  auto profiling_prefix =
-      std::string("ArborX::BVH::query::") +
-      (std::is_same<Tag, Details::SpatialPredicateTag>{} ? "spatial"
-                                                         : "nearest");
+  std::string profiling_prefix = "ArborX::BVH::query";
+  if (std::is_same<Tag, Details::SpatialPredicateTag>{})
+  {
+    profiling_prefix += "::spatial";
+  }
+  else if (std::is_same<Tag, Details::NearestPredicateTag>{})
+  {
+    profiling_prefix += "::nearest";
+  }
+  else if (std::is_same<Tag, Experimental::OrderedSpatialPredicateTag>{})
+  {
+    profiling_prefix += "::ordered_spatial;";
+  }
+  else
+  {
+    Kokkos::abort("implementation bug");
+  }
 
   Kokkos::Profiling::pushRegion(profiling_prefix);
 

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -305,7 +305,8 @@ struct Iota
 
 template <typename Tag, typename ExecutionSpace, typename Predicates,
           typename OffsetView, typename OutView>
-std::enable_if_t<std::is_same<Tag, SpatialPredicateTag>{}>
+std::enable_if_t<std::is_same<Tag, SpatialPredicateTag>{} ||
+                 std::is_same<Tag, Experimental::OrderedSpatialPredicateTag>{}>
 allocateAndInitializeStorage(Tag, ExecutionSpace const &space,
                              Predicates const &predicates, OffsetView &offset,
                              OutView &out, int buffer_size)

--- a/test/tstQueryTreeRay.cpp
+++ b/test/tstQueryTreeRay.cpp
@@ -36,10 +36,8 @@ struct BoxesIntersectedByRay
   Kokkos::View<ArborX::Experimental::Ray *, DeviceType> rays;
 };
 
-namespace ArborX
-{
 template <typename DeviceType>
-struct AccessTraits<NearestBoxToRay<DeviceType>, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<NearestBoxToRay<DeviceType>, ArborX::PredicatesTag>
 {
   using memory_space = typename DeviceType::memory_space;
   static KOKKOS_FUNCTION int
@@ -55,7 +53,8 @@ struct AccessTraits<NearestBoxToRay<DeviceType>, ArborX::PredicatesTag>
 };
 
 template <typename DeviceType>
-struct AccessTraits<BoxesIntersectedByRay<DeviceType>, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<BoxesIntersectedByRay<DeviceType>,
+                            ArborX::PredicatesTag>
 {
   using memory_space = typename DeviceType::memory_space;
   static KOKKOS_FUNCTION int
@@ -69,8 +68,6 @@ struct AccessTraits<BoxesIntersectedByRay<DeviceType>, ArborX::PredicatesTag>
     return intersects(nearest_boxes.rays(i));
   }
 };
-
-} // namespace ArborX
 
 BOOST_AUTO_TEST_SUITE(RayTraversals)
 


### PR DESCRIPTION
Fixup for #683

* Fix region name
* Fix query overloads that produce a graph
* Add a couple unit tests with degenerate trees