### PR TITLE
Fix generation of the hollow sphere point cloud to be u.a.r.

### DIFF
--- a/benchmarks/point_clouds/point_clouds.hpp
+++ b/benchmarks/point_clouds/point_clouds.hpp
@@ -169,7 +169,7 @@ void hollowSphereCloud(
       "The View should be accessible on the Host");
   std::default_random_engine generator;
 
-  std::uniform_real_distribution<double> distribution(-1., 1.);
+  std::normal_distribution<float> distribution(0.f, 1.f);
   auto random = [&distribution, &generator]() {
     return distribution(generator);
   };


### PR DESCRIPTION
The original code normalized a uniformly distributed point to produce a
point on a sphere. However, this does not result in the uniformly
distributed points on the sphere itself. The density of the regions
point to the box corners would be higher than that towards centers of
the box faces.

Using standard normal distribution, however, will. To see this,
$$f(x) = \frac{1}{\sqrt{2\pi}} e^{-\frac12 x^2}$$
which results in
$$f(x,y,z) = \frac{1}{(2\pi)^{\frac32}} e^{-\frac12(x^2+y^2+z^2)}$$
which only depends on the magnitude but not any direction.