### PR TITLE
Remove deprecated version of BVH templated on a device type

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -122,55 +122,6 @@ private:
   Kokkos::View<node_type *, MemorySpace> _internal_and_leaf_nodes;
 };
 
-template <typename DeviceType>
-class BasicBoundingVolumeHierarchy<
-    DeviceType, std::enable_if_t<Kokkos::is_device<DeviceType>::value>>
-    : public BasicBoundingVolumeHierarchy<typename DeviceType::memory_space>
-{
-  using base_type =
-      BasicBoundingVolumeHierarchy<typename DeviceType::memory_space>;
-
-public:
-  using device_type = DeviceType;
-
-  // clang-format off
-  [[deprecated("ArborX::BoundingVolumeHierarchy templated on a device type "
-               "is deprecated, use it templated on a memory space instead.")]]
-  BasicBoundingVolumeHierarchy() = default;
-  template <typename Primitives>
-  [[deprecated("ArborX::BoundingVolumeHierarchy templated on a device type "
-               "is deprecated, use it templated on a memory space instead.")]]
-  BasicBoundingVolumeHierarchy(Primitives const &primitives)
-      : base_type(
-            typename DeviceType::execution_space{}, primitives)
-  {
-  }
-  // clang-format on
-  template <typename FirstArgumentType, typename... Args>
-  std::enable_if_t<!Kokkos::is_execution_space<FirstArgumentType>::value>
-  query(FirstArgumentType &&arg1, Args &&...args) const
-  {
-    base_type::query(typename DeviceType::execution_space{},
-                     std::forward<FirstArgumentType>(arg1),
-                     std::forward<Args>(args)...);
-  }
-
-private:
-  template <typename Tree, typename ExecutionSpace, typename Predicates,
-            typename CallbackOrView, typename View, typename... Args>
-  friend void ArborX::query(Tree const &tree, ExecutionSpace const &space,
-                            Predicates const &predicates,
-                            CallbackOrView &&callback_or_view, View &&view,
-                            Args &&...args);
-
-  template <typename FirstArgumentType, typename... Args>
-  std::enable_if_t<Kokkos::is_execution_space<FirstArgumentType>::value>
-  query(FirstArgumentType const &space, Args &&...args) const
-  {
-    base_type::query(space, std::forward<Args>(args)...);
-  }
-};
-
 template <typename MemorySpace>
 using BoundingVolumeHierarchy = BasicBoundingVolumeHierarchy<MemorySpace>;
 


### PR DESCRIPTION
It has been broken for 1.5 years since 5355a8e. The introduction of the
BoundingVolume template argument in that pull request did not update the
device type specialization which led to no match when trying to use one. Given that, it should be safe to remove it.

I see two uses of `ArborX::BVH<DeviceType>` on GitHub.
- [lgrtk](https://github.com/sandialabs/lgrtk/blob/d969e670b9ba4371ae74b0cef023f7e887073fdd/otm_arborx_search_impl.cpp#L19)
  I'm not sure if it's even used, or updated with a recent ArborX version (last code 13 months ago)
- [platoengine](https://github.com/platoengine/platoengine/blob/a869510744e48d2003953a48a094c12c00147e6f/base/src/PlatoSubproblemLibrary/Geometry/PSL_TetMeshUtilities.hpp#L179) (proposed fix: platoengine/platoengine#338)
  The code in question is hidden behind `AMFILTER_ENABLED` CMake toggle. Not sure if it's tested, otherwise, how could it work?