### PR TITLE
Include missing headers (works now due to transitive includes in DetailsGeometry)

### DIFF
--- a/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
+++ b/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include <ArborX_LinearBVH.hpp>
+#include <ArborX_Sphere.hpp>
 #include <ArborX_Version.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/examples/brute_force/brute_force.cpp
+++ b/examples/brute_force/brute_force.cpp
@@ -11,6 +11,7 @@
 
 #include <ArborX_BruteForce.hpp>
 #include <ArborX_LinearBVH.hpp>
+#include <ArborX_Sphere.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -17,6 +17,7 @@
 #include <ArborX_DetailsFDBSCANDenseBox.hpp>
 #include <ArborX_DetailsSortUtils.hpp>
 #include <ArborX_LinearBVH.hpp>
+#include <ArborX_Sphere.hpp>
 
 #include <map>
 

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -13,6 +13,7 @@
 
 #include <ArborX_Config.hpp>
 
+#include <ArborX_Box.hpp>
 #include <ArborX_DetailsDistributor.hpp>
 #include <ArborX_DetailsHappyTreeFriends.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -21,6 +21,7 @@
 #include <ArborX_DetailsUtils.hpp>
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_Predicates.hpp>
+#include <ArborX_Sphere.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -22,6 +22,7 @@
 #include <ArborX_DetailsUtils.hpp>                        // exclusivePrefixSum
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
+#include <ArborX_Sphere.hpp>
 
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/copy.hpp>

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -23,6 +23,9 @@
 #include "ArborX_BoostRTreeHelpers.hpp"
 #include <ArborX_DistributedTree.hpp>
 #endif
+#include <ArborX_Box.hpp>
+#include <ArborX_Point.hpp>
+#include <ArborX_Sphere.hpp>
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -10,7 +10,9 @@
  ****************************************************************************/
 
 #include "ArborX_BoostGeometryAdapters.hpp"
+#include <ArborX_Box.hpp>
 #include <ArborX_DetailsAlgorithms.hpp>
+#include <ArborX_Point.hpp>
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -9,8 +9,11 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+#include <ArborX_Box.hpp>
 #include <ArborX_DetailsAlgorithms.hpp>
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_Point.hpp>
+#include <ArborX_Sphere.hpp>
 
 #define BOOST_TEST_MODULE Geometry
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
Part of #708 that fixes missing includes.