### PR TITLE
Bump ROCm 4.5.2 -> 5.2 in nightly builds

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -47,10 +47,10 @@ pipeline {
                         }
                     }
                 }
-                stage('ROCm-4.5.2') {
+                stage('ROCm-5.2') {
                     agent {
                         docker {
-                            image 'rocm/dev-ubuntu-20.04:4.5.2-complete'
+                            image 'rocm/dev-ubuntu-20.04:5.2-complete'
                             label 'AMD_Radeon_Instinct_MI100 && rocm-docker'
                             args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES}'
                         }


### PR DESCRIPTION
Anticipating change in Kokkos minimum requirement on the `develop` branch

Testing here https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/rocm52/detail/rocm52/1/pipeline/10