### PR TITLE
Template BruteForce on BoundingVolume

### DIFF
--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -23,14 +23,14 @@
 namespace ArborX
 {
 
-template <typename MemorySpace>
+template <typename MemorySpace, typename BoundingVolume = Box>
 class BruteForce
 {
 public:
   using memory_space = MemorySpace;
   static_assert(Kokkos::is_memory_space<MemorySpace>::value, "");
   using size_type = typename MemorySpace::size_type;
-  using bounding_volume_type = Box;
+  using bounding_volume_type = BoundingVolume;
 
   BruteForce() = default;
 
@@ -68,10 +68,10 @@ private:
   Kokkos::View<bounding_volume_type *, memory_space> _bounding_volumes;
 };
 
-template <typename MemorySpace>
+template <typename MemorySpace, typename BoundingVolume>
 template <typename ExecutionSpace, typename Primitives>
-BruteForce<MemorySpace>::BruteForce(ExecutionSpace const &space,
-                                    Primitives const &primitives)
+BruteForce<MemorySpace, BoundingVolume>::BruteForce(
+    ExecutionSpace const &space, Primitives const &primitives)
     : _size(AccessTraits<Primitives, PrimitivesTag>::size(primitives))
     , _bounding_volumes(
           Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
@@ -94,12 +94,12 @@ BruteForce<MemorySpace>::BruteForce(ExecutionSpace const &space,
   Kokkos::Profiling::popRegion();
 }
 
-template <typename MemorySpace>
+template <typename MemorySpace, typename BoundingVolume>
 template <typename ExecutionSpace, typename Predicates, typename Callback,
           typename Ignore>
-void BruteForce<MemorySpace>::query(ExecutionSpace const &space,
-                                    Predicates const &predicates,
-                                    Callback const &callback, Ignore) const
+void BruteForce<MemorySpace, BoundingVolume>::query(
+    ExecutionSpace const &space, Predicates const &predicates,
+    Callback const &callback, Ignore) const
 {
   static_assert(
       KokkosExt::is_accessible_from<MemorySpace, ExecutionSpace>::value, "");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,7 +87,9 @@ foreach(_test Callbacks Degenerate ManufacturedSolution ComparisonWithBoost)
   list(APPEND ARBORX_TEST_QUERY_TREE_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp")
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BF.cpp.tmp"
     "#include <ArborX_BruteForce.hpp>\n"
-    "#define ARBORX_TEST_TREE_TYPES Tuple<ArborX::BruteForce>\n"
+    "#include <ArborX_Box.hpp>\n"
+    "template <class MemorySpace> using ArborX__BruteForce = ArborX::BruteForce<MemorySpace, ArborX::Box>;\n"
+    "#define ARBORX_TEST_TREE_TYPES Tuple<ArborX__BruteForce>\n"
     "#define ARBORX_TEST_DEVICE_TYPES std::tuple<${ARBORX_DEVICE_TYPES}>\n"
     "#define ARBORX_TEST_DISABLE_NEAREST_QUERY\n"
     "#define ARBORX_TEST_DISABLE_CALLBACK_EARLY_EXIT\n"


### PR DESCRIPTION
This is in preparation to using brute force for multi-dimensional data.

Realistically, it's not really `BoundingVolume`, but rather some `Value`. But that can be changed with APIv2.