### PR TITLE
Require C++17 standard

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-function-cognitive-complexity'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard,-modernize-concat-nested-namespaces,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-function-cognitive-complexity,-modernize-unary-static-assert'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -37,12 +37,12 @@ pipeline {
 
         stage('Build') {
             parallel {
-                stage('CUDA-11.0.3-NVCC-CUDA-AWARE-MPI') {
+                stage('CUDA-11.5.2-NVCC-CUDA-AWARE-MPI') {
                     agent {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.0.3-devel-ubuntu18.04 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON -DKokkos_ARCH_VOLTA70=ON" --build-arg CUDA_AWARE_MPI=1'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.5.2-devel-ubuntu20.04 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON -DKokkos_ARCH_VOLTA70=ON" --build-arg CUDA_AWARE_MPI=1'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -97,12 +97,12 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-11.1.1-NVCC') {
+                stage('CUDA-11.5.2-NVCC') {
                     agent {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.1.1-devel-ubuntu18.04 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON -DKokkos_ARCH_VOLTA70=ON"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.5.2-devel-ubuntu20.04 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON -DKokkos_ARCH_VOLTA70=ON"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 add_library(ArborX INTERFACE)
 target_link_libraries(ArborX INTERFACE Kokkos::kokkos)
-set_target_properties(ArborX PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_14)
+set_target_properties(ArborX PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
 # As all executables using ArborX depend on it, depending on record_hash allows
 # updating hash each time executable is rebuilt, including when called from
 # within a subdirectory.

--- a/examples/dbscan/CMakeLists.txt
+++ b/examples/dbscan/CMakeLists.txt
@@ -3,7 +3,7 @@ target_include_directories(ArborX_DBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 target_link_libraries(ArborX_DBSCAN.exe ArborX::ArborX Boost::program_options)
 
 add_executable(ArborX_DataConverter.exe converter.cpp)
-target_compile_features(ArborX_DataConverter.exe PRIVATE cxx_std_14)
+target_compile_features(ArborX_DataConverter.exe PRIVATE cxx_std_17)
 target_link_libraries(ArborX_DataConverter.exe Boost::program_options)
 
 set(input_file "input.txt")

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -103,20 +103,12 @@ inline void initializeSingleLeafNode(ExecutionSpace const &space,
       });
 }
 
-namespace
-{
-// Ideally, this would be
-//     static constexpr int UNTOUCHED_NODE = -1;
-// inside the GenerateHierarchyFunctor class. But prior to C++17, this would
-// require to also have a definition outside the class as it is odr-used.
-// This is a workaround.
-constexpr int UNTOUCHED_NODE = -1;
-} // namespace
-
 template <typename Primitives, typename MemorySpace, typename Node,
           typename LinearOrderingValueType>
 class GenerateHierarchy
 {
+  static constexpr int UNTOUCHED_NODE = -1;
+
 public:
   template <typename ExecutionSpace,
             typename... PermutationIndicesViewProperties,


### PR DESCRIPTION
I disabled several Clang-Tidy checks:

- modernize-use-no-discard
- modernize-use-concat-namespaces
- modernize-unary-static-assert