### PR TITLE
Use Kokkos::Sum for Kokkos::parallel_reduce using Box and hyper Box

### DIFF
--- a/src/details/ArborX_DetailsBruteForceImpl.hpp
+++ b/src/details/ArborX_DetailsBruteForceImpl.hpp
@@ -14,7 +14,6 @@
 
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_DetailsAlgorithms.hpp> // expand
-#include <ArborX_DetailsTreeConstruction.hpp> // Kokkos::reduction_identity<ArborX::Box>
 #include <ArborX_Exception.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -46,7 +45,7 @@ struct BruteForceImpl
           bounding_volumes(i) = bounding_volume;
           update += bounding_volume;
         },
-        bounds);
+        Kokkos::Sum<Bounds>{bounds});
   }
 
   template <class ExecutionSpace, class Primitives, class Predicates,

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -42,7 +42,7 @@ inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
       KOKKOS_LAMBDA(int i, Box &update) {
         update += Access::get(primitives, i);
       },
-      scene_bounding_box);
+      Kokkos::Sum<Box>{scene_bounding_box});
 }
 
 template <typename ExecutionSpace, typename Primitives,

--- a/src/geometry/ArborX_HyperBox.hpp
+++ b/src/geometry/ArborX_HyperBox.hpp
@@ -129,4 +129,16 @@ struct ArborX::GeometryTraits::tag<
   using type = BoxTag;
 };
 
+template <int DIM, typename FloatingPoint>
+struct Kokkos::reduction_identity<
+    ArborX::ExperimentalHyperGeometry::Box<DIM, FloatingPoint>>
+{
+  KOKKOS_FUNCTION static ArborX::ExperimentalHyperGeometry::Box<DIM,
+                                                                FloatingPoint>
+  sum()
+  {
+    return {};
+  }
+};
+
 #endif


### PR DESCRIPTION
Alternative to #727 making sure that `reduction_identity<ArborX::Box>` is actually used.