### PR TITLE
Refactor to avoid proliferation of access traits use

### DIFF
--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -287,6 +287,9 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
 {
   Kokkos::Profiling::pushRegion("ArborX::DBSCAN::verify");
 
+  Details::RangeAdaptor adapted_primitives(PrimitivesTag(), primitives);
+  using AdaptedPrimitives = decltype(adapted_primitives);
+
   static_assert(Kokkos::is_view<LabelsView>{});
 
   using Access = AccessTraits<Primitives, PrimitivesTag>;
@@ -301,11 +304,11 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   constexpr int dim = GeometryTraits::dimension<
       typename Details::AccessTraitsHelper<Access>::type>::value;
   using Box = ExperimentalHyperGeometry::Box<dim>;
-  ArborX::BasicBoundingVolumeHierarchy<MemorySpace, Box> bvh(exec_space,
-                                                             primitives);
+  ArborX::BasicBoundingVolumeHierarchy<MemorySpace, Box> bvh(
+      exec_space, adapted_primitives);
 
   auto const predicates =
-      Details::PrimitivesWithRadius<Primitives>{primitives, eps};
+      Details::PrimitivesWithRadius<AdaptedPrimitives>{adapted_primitives, eps};
 
   Kokkos::View<int *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
   Kokkos::View<int *, MemorySpace> offset("ArborX::DBSCAN::offset", 0);

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -8,10 +8,10 @@
  *                                                                          *
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
+
 #ifndef ARBORX_CALLBACKS_HPP
 #define ARBORX_CALLBACKS_HPP
 
-#include <ArborX_AccessTraits.hpp>
 #include <ArborX_Predicates.hpp> // is_valid_predicate_tag
 
 #include <Kokkos_DetectionIdiom.hpp>
@@ -97,9 +97,8 @@ void check_valid_callback(Callback const &callback, Predicates const &,
 {
   check_generic_lambda_support(callback);
 
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-  using PredicateTag = typename AccessTraitsHelper<Access>::tag;
-  using Predicate = typename AccessTraitsHelper<Access>::type;
+  using Predicate = typename Predicates::value_type;
+  using PredicateTag = typename Predicate::Tag;
 
   static_assert(!(std::is_same<PredicateTag, NearestPredicateTag>{} &&
                   Kokkos::is_detected<
@@ -175,9 +174,8 @@ void check_valid_callback(Callback const &callback, Predicates const &)
 {
   check_generic_lambda_support(callback);
 
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-  using PredicateTag = typename AccessTraitsHelper<Access>::tag;
-  using Predicate = typename AccessTraitsHelper<Access>::type;
+  using Predicate = typename Predicates::value_type;
+  using PredicateTag = typename Predicate::Tag;
 
   static_assert(is_valid_predicate_tag<PredicateTag>::value,
                 "The predicate tag is not valid");

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -371,7 +371,8 @@ queryDispatch(Tag, Tree const &tree, ExecutionSpace const &space,
   using MemorySpace = typename Tree::memory_space;
   using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
-  check_valid_callback(callback, predicates, out);
+  check_valid_callback(callback, RangeAdaptor(PredicatesTag(), predicates),
+                       out);
 
   auto profiling_prefix =
       std::string("ArborX::CrsGraphWrapper::query::") +
@@ -400,8 +401,9 @@ queryDispatch(Tag, Tree const &tree, ExecutionSpace const &space,
     using namespace Details;
     expand(scene_bounding_box, tree.bounds());
     auto permute = Details::BatchedQueries<DeviceType>::
-        sortPredicatesAlongSpaceFillingCurve(space, Experimental::Morton32(),
-                                             scene_bounding_box, predicates);
+        sortPredicatesAlongSpaceFillingCurve(
+            space, Experimental::Morton32(), scene_bounding_box,
+            RangeAdaptor(PredicatesTag(), predicates));
     Kokkos::Profiling::popRegion();
 
     queryImpl(space, tree, predicates, callback, out, offset, permute,
@@ -453,7 +455,8 @@ check_valid_callback_if_first_argument_is_not_a_view(
     Callback const &callback, Predicates const &predicates,
     OutputView const &out)
 {
-  check_valid_callback(callback, predicates, out);
+  check_valid_callback(callback, RangeAdaptor(PredicatesTag(), predicates),
+                       out);
 }
 
 template <typename Callback, typename Predicates, typename OutputView>

--- a/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
+++ b/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
@@ -28,22 +28,23 @@ struct MaxDistance
 {
   Primitives _primitives;
   Distances _distances;
-  using Access = AccessTraits<Primitives, PrimitivesTag>;
-  using memory_space = typename Access::memory_space;
-  using size_type = typename memory_space::size_type;
+  using size_type = typename Primitives::size_type;
   template <class Predicate>
   KOKKOS_FUNCTION void operator()(Predicate const &predicate, size_type i) const
   {
     size_type const j = getData(predicate);
     using KokkosExt::max;
-    auto const distance_ij =
-        distance(Access::get(_primitives, i), Access::get(_primitives, j));
+    auto const distance_ij = distance(_primitives(i), _primitives(j));
     // NOTE using knowledge that each nearest predicate traversal is performed
     // by a single thread.  The distance update below would need to be atomic
     // otherwise.
     _distances(j) = max(_distances(j), distance_ij);
   }
 };
+
+template <class Primitives, class Distances>
+MaxDistance(Primitives const &, Distances const &)
+    -> MaxDistance<Primitives, Distances>;
 
 template <class Primitives>
 struct NearestK

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -510,10 +510,13 @@ struct TreeTraversal<BVH, Predicates, Callback,
 
 template <typename ExecutionSpace, typename BVH, typename Predicates,
           typename Callback>
-TreeTraversal(ExecutionSpace const &, BVH const &, Predicates const &,
-              Callback const &)
-    -> TreeTraversal<BVH, Predicates, Callback,
-                     typename Predicates::value_type::Tag>;
+void traverse(ExecutionSpace const &space, BVH const &bvh,
+              Predicates const &predicates, Callback const &callback)
+{
+  using Tag = typename Predicates::value_type::Tag;
+  TreeTraversal<BVH, Predicates, Callback, Tag>(space, bvh, predicates,
+                                                callback);
+}
 
 } // namespace ArborX::Details
 

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -11,7 +11,6 @@
 #ifndef ARBORX_DETAILS_TREE_TRAVERSAL_HPP
 #define ARBORX_DETAILS_TREE_TRAVERSAL_HPP
 
-#include <ArborX_AccessTraits.hpp>
 #include <ArborX_DetailsAlgorithms.hpp>
 #include <ArborX_DetailsHappyTreeFriends.hpp>
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
@@ -23,9 +22,7 @@
 #include <ArborX_Exception.hpp>
 #include <ArborX_Predicates.hpp>
 
-namespace ArborX
-{
-namespace Details
+namespace ArborX::Details
 {
 
 template <typename BVH, typename Predicates, typename Callback, typename Tag>
@@ -38,8 +35,6 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
   BVH _bvh;
   Predicates _predicates;
   Callback _callback;
-
-  using Access = AccessTraits<Predicates, PredicatesTag>;
 
   template <typename ExecutionSpace>
   TreeTraversal(ExecutionSpace const &space, BVH const &bvh,
@@ -56,16 +51,16 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
     {
       Kokkos::parallel_for(
           "ArborX::TreeTraversal::spatial::degenerated_one_leaf_tree",
-          Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(
-              space, 0, Access::size(predicates)),
+          Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(space, 0,
+                                                           predicates.size()),
           *this);
     }
     else
     {
-      Kokkos::parallel_for("ArborX::TreeTraversal::spatial",
-                           Kokkos::RangePolicy<ExecutionSpace>(
-                               space, 0, Access::size(predicates)),
-                           *this);
+      Kokkos::parallel_for(
+          "ArborX::TreeTraversal::spatial",
+          Kokkos::RangePolicy<ExecutionSpace>(space, 0, predicates.size()),
+          *this);
     }
   }
 
@@ -74,7 +69,7 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
 
   KOKKOS_FUNCTION void operator()(OneLeafTree, int queryIndex) const
   {
-    auto const &predicate = Access::get(_predicates, queryIndex);
+    auto const &predicate = _predicates(queryIndex);
     auto const root = HappyTreeFriends::getRoot(_bvh);
     auto const &root_bounding_volume =
         HappyTreeFriends::getBoundingVolume(_bvh, root);
@@ -86,7 +81,7 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
 
   KOKKOS_FUNCTION void operator()(int queryIndex) const
   {
-    auto const &predicate = Access::get(_predicates, queryIndex);
+    auto const &predicate = _predicates(queryIndex);
 
     int node;
     int next = HappyTreeFriends::getRoot(_bvh); // start with root
@@ -126,8 +121,6 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
   Predicates _predicates;
   Callback _callback;
 
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-
   using Buffer = Kokkos::View<Kokkos::pair<int, float> *, MemorySpace>;
   using Offset = Kokkos::View<int *, MemorySpace>;
   struct BufferProvider
@@ -148,7 +141,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
   template <typename ExecutionSpace>
   void allocateBuffer(ExecutionSpace const &space)
   {
-    auto const n_queries = Access::size(_predicates);
+    auto const n_queries = _predicates.size();
 
     Offset offset(Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                                      "ArborX::TreeTraversal::nearest::offset"),
@@ -159,7 +152,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
         "ArborX::TreeTraversal::nearest::"
         "scan_queries_for_numbers_of_neighbors",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
-        KOKKOS_LAMBDA(int i) { offset(i) = getK(Access::get(predicates, i)); });
+        KOKKOS_LAMBDA(int i) { offset(i) = getK(predicates(i)); });
     exclusivePrefixSum(space, offset);
     int const buffer_size = KokkosExt::lastElement(space, offset);
     // Allocate buffer over which to perform heap operations in
@@ -188,18 +181,18 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
     {
       Kokkos::parallel_for(
           "ArborX::TreeTraversal::nearest::degenerated_one_leaf_tree",
-          Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(
-              space, 0, Access::size(predicates)),
+          Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(space, 0,
+                                                           predicates.size()),
           *this);
     }
     else
     {
       allocateBuffer(space);
 
-      Kokkos::parallel_for("ArborX::TreeTraversal::nearest",
-                           Kokkos::RangePolicy<ExecutionSpace>(
-                               space, 0, Access::size(predicates)),
-                           *this);
+      Kokkos::parallel_for(
+          "ArborX::TreeTraversal::nearest",
+          Kokkos::RangePolicy<ExecutionSpace>(space, 0, predicates.size()),
+          *this);
     }
   }
 
@@ -208,7 +201,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
 
   KOKKOS_FUNCTION void operator()(OneLeafTree, int queryIndex) const
   {
-    auto const &predicate = Access::get(_predicates, queryIndex);
+    auto const &predicate = _predicates(queryIndex);
     auto const k = getK(predicate);
 
     // NOTE thinking about making this a precondition
@@ -220,7 +213,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
 
   KOKKOS_FUNCTION void operator()(int queryIndex) const
   {
-    auto const &predicate = Access::get(_predicates, queryIndex);
+    auto const &predicate = _predicates(queryIndex);
     auto const k = getK(predicate);
     auto const buffer = _buffer(queryIndex);
 
@@ -388,8 +381,6 @@ struct TreeTraversal<BVH, Predicates, Callback,
   Predicates _predicates;
   Callback _callback;
 
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-
   template <class ExecutionSpace>
   TreeTraversal(ExecutionSpace const &space, BVH const &bvh,
                 Predicates const &predicates, Callback const &callback)
@@ -406,16 +397,15 @@ struct TreeTraversal<BVH, Predicates, Callback,
       Kokkos::parallel_for(
           "ArborX::Experimental::TreeTraversal::OrderedSpatialPredicate"
           "degenerated_one_leaf_tree",
-          Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(
-              space, 0, Access::size(predicates)),
+          Kokkos::RangePolicy<ExecutionSpace, OneLeafTree>(space, 0,
+                                                           predicates.size()),
           *this);
     }
     else
     {
       Kokkos::parallel_for(
           "ArborX::Experimental::TreeTraversal::OrderedSpatialPredicate",
-          Kokkos::RangePolicy<ExecutionSpace>(space, 0,
-                                              Access::size(predicates)),
+          Kokkos::RangePolicy<ExecutionSpace>(space, 0, predicates.size()),
           *this);
     }
   }
@@ -425,7 +415,7 @@ struct TreeTraversal<BVH, Predicates, Callback,
 
   KOKKOS_FUNCTION void operator()(OneLeafTree, int queryIndex) const
   {
-    auto const &predicate = Access::get(_predicates, queryIndex);
+    auto const &predicate = _predicates(queryIndex);
     auto const root = HappyTreeFriends::getRoot(_bvh);
     auto const &root_bounding_volume =
         HappyTreeFriends::getBoundingVolume(_bvh, root);
@@ -441,7 +431,7 @@ struct TreeTraversal<BVH, Predicates, Callback,
 
   KOKKOS_FUNCTION void operator()(int queryIndex) const
   {
-    auto const &predicate = Access::get(_predicates, queryIndex);
+    auto const &predicate = _predicates(queryIndex);
     using ArborX::Details::HappyTreeFriends;
 
     using distance_type = decltype(predicate.distance(
@@ -520,16 +510,11 @@ struct TreeTraversal<BVH, Predicates, Callback,
 
 template <typename ExecutionSpace, typename BVH, typename Predicates,
           typename Callback>
-void traverse(ExecutionSpace const &space, BVH const &bvh,
-              Predicates const &predicates, Callback const &callback)
-{
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-  using Tag = typename AccessTraitsHelper<Access>::tag;
-  TreeTraversal<BVH, Predicates, Callback, Tag>(space, bvh, predicates,
-                                                callback);
-}
+TreeTraversal(ExecutionSpace const &, BVH const &, Predicates const &,
+              Callback const &)
+    -> TreeTraversal<BVH, Predicates, Callback,
+                     typename Predicates::value_type::Tag>;
 
-} // namespace Details
-} // namespace ArborX
+} // namespace ArborX::Details
 
 #endif

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -602,8 +602,8 @@ struct MinimumSpanningTree
                              "ArborX::MST::core_distances"),
           n);
       bvh.query(space, NearestK<Primitives>{primitives, k},
-                MaxDistance<Primitives, decltype(core_distances)>{
-                    primitives, core_distances});
+                MaxDistance{RangeAdaptor(PrimitivesTag(), primitives),
+                            core_distances});
       Kokkos::Profiling::popRegion();
 
       MutualReachability<decltype(core_distances)> mutual_reachability{

--- a/test/tstCompileOnlyCallbacks.cpp
+++ b/test/tstCompileOnlyCallbacks.cpp
@@ -9,7 +9,6 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include <ArborX_AccessTraits.hpp>
 #include <ArborX_Callbacks.hpp>
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
@@ -17,26 +16,13 @@
 // NOTE Let's not bother with __host__ __device__ annotations here
 
 struct NearestPredicates
-{};
-template <>
-struct ArborX::AccessTraits<NearestPredicates, ArborX::PredicatesTag>
 {
-  using memory_space = Kokkos::HostSpace;
-  static int size(NearestPredicates const &) { return 1; }
-  static auto get(NearestPredicates const &, int) { return nearest(Point{}); }
+  using value_type = decltype(ArborX::nearest(ArborX::Point{}));
 };
 
 struct SpatialPredicates
-{};
-template <>
-struct ArborX::AccessTraits<SpatialPredicates, ArborX::PredicatesTag>
 {
-  using memory_space = Kokkos::HostSpace;
-  static int size(SpatialPredicates const &) { return 1; }
-  static auto get(SpatialPredicates const &, int)
-  {
-    return intersects(Point{});
-  }
+  using value_type = decltype(ArborX::intersects(ArborX::Point{}));
 };
 
 // Custom callbacks


### PR DESCRIPTION
This is a Work-In-Progress
Opening as a base for discussion
The intent of this refactor is to avoid propagating the use of access traits throughout the codebase by adapting the user provided primitives/predicates.