### PR TITLE
Add DistributedTree query only taking a callback

### DIFF
--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -200,6 +200,13 @@ public:
                      std::forward<OffsetView>(offset));
   }
 
+  template <typename ExecutionSpace, typename UserPredicates, typename Callback>
+  void query(ExecutionSpace const &space, UserPredicates const &user_predicates,
+             Callback &&callback) const
+  {
+    base_type::query(space, user_predicates, std::forward<Callback>(callback));
+  }
+
   template <typename ExecutionSpace, typename UserPredicates, typename Callback,
             typename Indices, typename Offset>
   void query(ExecutionSpace const &space, UserPredicates const &user_predicates,

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -40,6 +40,13 @@ struct DistributedTreeImpl
                 ExecutionSpace const &space, Predicates const &queries,
                 Callback const &callback, OutputView &out, OffsetView &offset);
 
+  template <typename DistributedTree, typename ExecutionSpace,
+            typename Predicates, typename Callback>
+  static void queryDispatch(SpatialPredicateTag, DistributedTree const &tree,
+                            ExecutionSpace const &space,
+                            Predicates const &predicates,
+                            Callback const &callback);
+
   // nearest neighbors queries
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename Callback, typename Indices,


### PR DESCRIPTION
This adds a
```
template <typename ExecutionSpace, typename Predicates, typename Callback>
void query(ExecutionSpace const& space,
           Predicates const& predicates,
           Callback const& callback) const;
```
overload for `DistributedTree` (and `SpatialTag) with the callback being executed on the MPI process storing the primitives. 