### PR TITLE
Use KOKKOS_CLASS_LAMBDA via ARBORX_CLASS_LAMBDA

### DIFF
--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -26,6 +26,7 @@
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Ray.hpp>
 #include <ArborX_Sphere.hpp>
+#include <kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 
 #include <Kokkos_Core.hpp>
 
@@ -447,13 +448,12 @@ struct CallbackWithDistance
     {
       int const leaf_nodes_shift = _tree.size() - 1;
       auto const &leaf_nodes = HappyTreeFriends::getLeafNodes(_tree);
-      auto const &rev_permute = _rev_permute; // avoid implicit capture of *this
       Kokkos::parallel_for(
           "ArborX::DistributedTree::query::nearest::"
           "compute_reverse_permutation",
           Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
-          KOKKOS_LAMBDA(int const i) {
-            rev_permute(leaf_nodes(i).getLeafPermutationIndex()) =
+          ARBORX_CLASS_LAMBDA(int const i) {
+            _rev_permute(leaf_nodes(i).getLeafPermutationIndex()) =
                 i + leaf_nodes_shift;
           });
     }

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -16,6 +16,7 @@
 #include <ArborX_Box.hpp>
 #include <ArborX_DetailsDistributor.hpp>
 #include <ArborX_DetailsHappyTreeFriends.hpp>
+#include <ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
 #include <ArborX_DetailsKokkosExtScopedProfileRegion.hpp>
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
@@ -26,7 +27,6 @@
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Ray.hpp>
 #include <ArborX_Sphere.hpp>
-#include <kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 
 #include <Kokkos_Core.hpp>
 

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -15,6 +15,7 @@
 #include <ArborX_DetailsAlgorithms.hpp>
 #include <ArborX_DetailsHappyTreeFriends.hpp>
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsNode.hpp> // ROPE_SENTINEL
 #include <ArborX_DetailsPriorityQueue.hpp>
@@ -22,7 +23,6 @@
 #include <ArborX_DetailsUtils.hpp>
 #include <ArborX_Exception.hpp>
 #include <ArborX_Predicates.hpp>
-#include <kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 
 namespace ArborX
 {

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp
@@ -14,8 +14,7 @@
 
 #include <Kokkos_Macros.hpp>
 
-#if defined(KOKKOS_VERSION_GREATER_EQUAL) &&                                   \
-    KOKKOS_VERSION_GREATER_EQUAL(4, 0, 0)
+#if KOKKOS_VERSION >= 40000
 #define ARBORX_CLASS_LAMBDA KOKKOS_CLASS_LAMBDA
 #elif defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 #define ARBORX_CLASS_LAMBDA [ =, *this ] __host__ __device__

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp
@@ -1,0 +1,26 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_CLASS_LAMBDA
+#define ARBORX_DETAILS_KOKKOS_EXT_CLASS_LAMBDA
+
+#include <Kokkos_Macros.hpp>
+
+#if defined(KOKKOS_VERSION_GREATER_EQUAL) &&                                   \
+    KOKKOS_VERSION_GREATER_EQUAL(4, 0, 0)
+#define ARBORX_CLASS_LAMBDA KOKKOS_CLASS_LAMBDA
+#elif defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#define ARBORX_CLASS_LAMBDA [ =, *this ] __host__ __device__
+#else
+#define ARBORX_CLASS_LAMBDA [ =, *this ]
+#endif
+
+#endif

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp
@@ -14,7 +14,8 @@
 
 #include <Kokkos_Macros.hpp>
 
-#if KOKKOS_VERSION >= 40000
+// Remove when we require Kokkos 4.0.00
+#ifdef KOKKOS_CLASS_LAMBDA
 #define ARBORX_CLASS_LAMBDA KOKKOS_CLASS_LAMBDA
 #elif defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 #define ARBORX_CLASS_LAMBDA [ =, *this ] __host__ __device__

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -13,6 +13,7 @@
 #include "ArborX_BoostRTreeHelpers.hpp"
 #include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
 #include <ArborX_DistributedTree.hpp>
+#include <kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 
 #include <boost/test/unit_test.hpp>
 
@@ -589,15 +590,12 @@ struct CustomPostCallbackWithAttachment
     using ArborX::Details::distance;
     auto const n = offset.extent(0) - 1;
     Kokkos::realloc(out, in.extent(0));
-    // NOTE workaround to avoid implicit capture of *this
-    auto const &points_ = points;
-    auto const &origin_ = origin;
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
+        Kokkos::RangePolicy<ExecutionSpace>(0, n), ARBORX_CLASS_LAMBDA(int i) {
           auto data = ArborX::getData(queries(i));
           for (int j = offset(i); j < offset(i + 1); ++j)
           {
-            out(j) = (float)distance(points_(in(j)), origin_) + data;
+            out(j) = (float)distance(points(in(j)), origin) + data;
           }
         });
   }

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -11,9 +11,9 @@
 
 #include "ArborXTest_StdVectorToKokkosView.hpp"
 #include "ArborX_BoostRTreeHelpers.hpp"
-#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include "ArborX_EnableDeviceTypes.hpp"           // ARBORX_DEVICE_TYPES
+#include <ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 #include <ArborX_DistributedTree.hpp>
-#include <kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -19,6 +19,8 @@
 #include "ArborXTest_TreeTypeTraits.hpp"
 // clang-format on
 
+#include <kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
+
 BOOST_AUTO_TEST_SUITE(Callbacks)
 
 namespace tt = boost::test_tools;
@@ -53,14 +55,11 @@ struct CustomPostCallback
     using ArborX::Details::distance;
     auto const n = offset.extent(0) - 1;
     Kokkos::realloc(out, in.extent(0));
-    // NOTE workaround to avoid implicit capture of *this
-    auto const &points_ = points;
-    auto const &origin_ = origin;
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
+        Kokkos::RangePolicy<ExecutionSpace>(0, n), ARBORX_CLASS_LAMBDA(int i) {
           for (int j = offset(i); j < offset(i + 1); ++j)
           {
-            out(j) = {in(j), (float)distance(points_(in(j)), origin_)};
+            out(j) = {in(j), (float)distance(points(in(j)), origin)};
           }
         });
   }
@@ -234,16 +233,13 @@ struct CustomPostCallbackWithAttachment
     using ArborX::Details::distance;
     auto const n = offset.extent(0) - 1;
     Kokkos::realloc(out, in.extent(0));
-    // NOTE workaround to avoid implicit capture of *this
-    auto const &points_ = points;
-    auto const &origin_ = origin;
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
+        Kokkos::RangePolicy<ExecutionSpace>(0, n), ARBORX_CLASS_LAMBDA(int i) {
           auto data_2 = ArborX::getData(queries(i));
           auto data = data_2[1];
           for (int j = offset(i); j < offset(i + 1); ++j)
           {
-            out(j) = {in(j), data + (float)distance(points_(in(j)), origin_)};
+            out(j) = {in(j), data + (float)distance(points(in(j)), origin)};
           }
         });
   }

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -19,7 +19,7 @@
 #include "ArborXTest_TreeTypeTraits.hpp"
 // clang-format on
 
-#include <kokkos_ext/ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
+#include <ArborX_DetailsKokkosExtClassLambda.hpp> // ARBORX_CLASS_LAMBDA
 
 BOOST_AUTO_TEST_SUITE(Callbacks)
 


### PR DESCRIPTION
Requiring C++17, we can now resolve the comments mentioning "capture *this". Also, this shows that we forgot to update the GitLab CI. I would propose to always just build `Kokkos` for clarity.

edit: This pull request now uses a newly defined `ARBORX_CLASS_LAMBDA` instead.