### PR TITLE
Use shared radii during MST traversal only for Serial

### DIFF
--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -715,7 +715,7 @@ private:
         SharedRadiiPolicy::NONE;
 #endif
 
-    if (use_lower_bounds)
+    if constexpr (use_lower_bounds)
     {
       KokkosExt::reallocWithoutInitializing(space, lower_bounds, n);
       Kokkos::deep_copy(space, lower_bounds, 0);
@@ -748,7 +748,7 @@ private:
                                                   component_out_edges, metric,
                                                   radii, lower_bounds);
       retrieveEdges(space, labels, weights, component_out_edges);
-      if (use_lower_bounds)
+      if constexpr (use_lower_bounds)
       {
         updateLowerBounds(space, labels, component_out_edges, lower_bounds);
       }

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -216,7 +216,7 @@ struct FindComponentNearestNeighbors
 
     auto const n = _bvh.size();
 
-    // Use a reference for shared radii, and a value otherwise.
+    // Use a reference for shared radii, and a copy otherwise.
     std::conditional_t<UseSharedRadii, float &, float> radius =
         _radii(component - n + 1);
 


### PR DESCRIPTION
I realized that we never updated the code with the final state of the experiments we did for the paper. What we ended up was using shared radii only in Serial. In parallel, they were inconsistent, sometimes slower, sometimes faster than not using them. We decided not to describe them because of the complexity.

I propose leaving them in, but hardcode to the ones used in the paper. We could consider enabling a command line argument for switching them in the future.