### PR TITLE
Use std::sort for serial sorting

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -82,6 +82,98 @@ namespace ArborX
 namespace Details
 {
 
+// Helper functions and structs for applyPermutations
+namespace PermuteHelper
+{
+template <class DstViewType, class SrcViewType, int Rank = DstViewType::Rank>
+struct CopyOp;
+
+template <class DstViewType, class SrcViewType>
+struct CopyOp<DstViewType, SrcViewType, 1>
+{
+  KOKKOS_INLINE_FUNCTION
+  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
+                   size_t i_src)
+  {
+    dst(i_dst) = src(i_src);
+  }
+};
+
+template <class DstViewType, class SrcViewType>
+struct CopyOp<DstViewType, SrcViewType, 2>
+{
+  KOKKOS_INLINE_FUNCTION
+  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
+                   size_t i_src)
+  {
+    for (unsigned int j = 0; j < dst.extent(1); j++)
+      dst(i_dst, j) = src(i_src, j);
+  }
+};
+
+template <class DstViewType, class SrcViewType>
+struct CopyOp<DstViewType, SrcViewType, 3>
+{
+  KOKKOS_INLINE_FUNCTION
+  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
+                   size_t i_src)
+  {
+    for (unsigned int j = 0; j < dst.extent(1); j++)
+      for (unsigned int k = 0; k < dst.extent(2); k++)
+        dst(i_dst, j, k) = src(i_src, j, k);
+  }
+};
+} // namespace PermuteHelper
+
+template <typename ExecutionSpace, typename PermutationView, typename InputView,
+          typename OutputView>
+void applyInversePermutation(ExecutionSpace const &space,
+                             PermutationView const &permutation,
+                             InputView const &input_view,
+                             OutputView const &output_view)
+{
+  static_assert(std::is_integral<typename PermutationView::value_type>::value);
+  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
+  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
+
+  Kokkos::parallel_for(
+      "ArborX::Sorting::inverse_permute",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
+      KOKKOS_LAMBDA(int i) {
+        PermuteHelper::CopyOp<OutputView, InputView>::copy(
+            output_view, permutation(i), input_view, i);
+      });
+}
+
+template <typename ExecutionSpace, typename PermutationView, typename InputView,
+          typename OutputView>
+void applyPermutation(ExecutionSpace const &space,
+                      PermutationView const &permutation,
+                      InputView const &input_view,
+                      OutputView const &output_view)
+{
+  static_assert(std::is_integral<typename PermutationView::value_type>::value);
+  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
+  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
+
+  Kokkos::parallel_for(
+      "ArborX::Sorting::permute",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
+      KOKKOS_LAMBDA(int i) {
+        PermuteHelper::CopyOp<OutputView, InputView>::copy(
+            output_view, i, input_view, permutation(i));
+      });
+}
+
+template <typename ExecutionSpace, typename PermutationView, typename View>
+void applyPermutation(ExecutionSpace const &space,
+                      PermutationView const &permutation, View &view)
+{
+  static_assert(std::is_integral<typename PermutationView::value_type>::value);
+  auto scratch_view = KokkosExt::clone(space, view);
+  applyPermutation(space, permutation, scratch_view, view);
+}
+
 // NOTE returns the permutation indices **and** sorts the input view
 template <typename ExecutionSpace, typename ViewType,
           class SizeType = unsigned int>
@@ -190,98 +282,6 @@ sortObjects(Kokkos::Experimental::SYCL const &space, ViewType &view)
   return permute;
 }
 #endif
-
-// Helper functions and structs for applyPermutations
-namespace PermuteHelper
-{
-template <class DstViewType, class SrcViewType, int Rank = DstViewType::Rank>
-struct CopyOp;
-
-template <class DstViewType, class SrcViewType>
-struct CopyOp<DstViewType, SrcViewType, 1>
-{
-  KOKKOS_INLINE_FUNCTION
-  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
-                   size_t i_src)
-  {
-    dst(i_dst) = src(i_src);
-  }
-};
-
-template <class DstViewType, class SrcViewType>
-struct CopyOp<DstViewType, SrcViewType, 2>
-{
-  KOKKOS_INLINE_FUNCTION
-  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
-                   size_t i_src)
-  {
-    for (unsigned int j = 0; j < dst.extent(1); j++)
-      dst(i_dst, j) = src(i_src, j);
-  }
-};
-
-template <class DstViewType, class SrcViewType>
-struct CopyOp<DstViewType, SrcViewType, 3>
-{
-  KOKKOS_INLINE_FUNCTION
-  static void copy(DstViewType const &dst, size_t i_dst, SrcViewType const &src,
-                   size_t i_src)
-  {
-    for (unsigned int j = 0; j < dst.extent(1); j++)
-      for (unsigned int k = 0; k < dst.extent(2); k++)
-        dst(i_dst, j, k) = src(i_src, j, k);
-  }
-};
-} // namespace PermuteHelper
-
-template <typename ExecutionSpace, typename PermutationView, typename InputView,
-          typename OutputView>
-void applyInversePermutation(ExecutionSpace const &space,
-                             PermutationView const &permutation,
-                             InputView const &input_view,
-                             OutputView const &output_view)
-{
-  static_assert(std::is_integral<typename PermutationView::value_type>::value);
-  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
-  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
-
-  Kokkos::parallel_for(
-      "ArborX::Sorting::inverse_permute",
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
-      KOKKOS_LAMBDA(int i) {
-        PermuteHelper::CopyOp<OutputView, InputView>::copy(
-            output_view, permutation(i), input_view, i);
-      });
-}
-
-template <typename ExecutionSpace, typename PermutationView, typename InputView,
-          typename OutputView>
-void applyPermutation(ExecutionSpace const &space,
-                      PermutationView const &permutation,
-                      InputView const &input_view,
-                      OutputView const &output_view)
-{
-  static_assert(std::is_integral<typename PermutationView::value_type>::value);
-  ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
-  ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
-
-  Kokkos::parallel_for(
-      "ArborX::Sorting::permute",
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, input_view.extent(0)),
-      KOKKOS_LAMBDA(int i) {
-        PermuteHelper::CopyOp<OutputView, InputView>::copy(
-            output_view, i, input_view, permutation(i));
-      });
-}
-
-template <typename ExecutionSpace, typename PermutationView, typename View>
-void applyPermutation(ExecutionSpace const &space,
-                      PermutationView const &permutation, View &view)
-{
-  static_assert(std::is_integral<typename PermutationView::value_type>::value);
-  auto scratch_view = KokkosExt::clone(space, view);
-  applyPermutation(space, permutation, scratch_view, view);
-}
 
 } // namespace Details
 


### PR DESCRIPTION
I think we encounter problems with `Kokkos::BinSort` often enough. When running things for some of the 2D datasets, it's unusable (because of repeated Morton indices). I propose replacing it with `std::sort`. It may be slower for larger problem sizes compared to BinSort (when that works), but it is a) more robust, and b) sorting is a small fraction of the total.

The PR looks large only because I moved the permutation routines before sort ones, so that I could use `applyPermutation` inside the Serial specialization.

I would like to do something similar for OpenMP. But I am not sure what. Using `std::sort` there has more penalty. We could dispatch to Thrust if that's available.

Duplicate of #533.

Times we encountered issues with `BinSort` being extremely slow:
- NimbleSM/NimbleSM#244
- MST algorithm for certain 2D datasets (on top of my head, NGSIM and GeoLife)
- Compadre (https://github.com/arborx/ArborX/issues/145#issuecomment-926902908)

Another issue is that BinSort does not allow for custom comparison operators, which is useful.