### PR TITLE
Forward compatibility include `<Kokkos_ReductionIdentity.hpp>` header

### DIFF
--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -18,7 +18,7 @@
 #include <ArborX_Point.hpp>
 
 #include <Kokkos_Macros.hpp>
-#if __has_include(<Kokkos_ReductionIdentity.hpp>) // since Kokkos 4.0
+#if __has_include(<Kokkos_ReductionIdentity.hpp>) // FIXME requires Kokkos 4.0
 #include <Kokkos_ReductionIdentity.hpp>
 #endif
 

--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -18,6 +18,9 @@
 #include <ArborX_Point.hpp>
 
 #include <Kokkos_Macros.hpp>
+#if __has_include(<Kokkos_ReductionIdentity.hpp>) // since Kokkos 4.0
+#include <Kokkos_ReductionIdentity.hpp>
+#endif
 
 namespace ArborX
 {

--- a/src/geometry/ArborX_HyperBox.hpp
+++ b/src/geometry/ArborX_HyperBox.hpp
@@ -20,7 +20,7 @@
 #include <ArborX_HyperPoint.hpp>
 
 #include <Kokkos_Macros.hpp>
-#if __has_include(<Kokkos_ReductionIdentity.hpp>) // since Kokkos 4.0
+#if __has_include(<Kokkos_ReductionIdentity.hpp>) // FIXME requires Kokkos 4.0
 #include <Kokkos_ReductionIdentity.hpp>
 #endif
 

--- a/src/geometry/ArborX_HyperBox.hpp
+++ b/src/geometry/ArborX_HyperBox.hpp
@@ -20,6 +20,9 @@
 #include <ArborX_HyperPoint.hpp>
 
 #include <Kokkos_Macros.hpp>
+#if __has_include(<Kokkos_ReductionIdentity.hpp>) // since Kokkos 4.0
+#include <Kokkos_ReductionIdentity.hpp>
+#endif
 
 namespace ArborX::ExperimentalHyperGeometry
 {


### PR DESCRIPTION
... wherever appropriate

This is a draft.  We will need it if kokkos/kokkos#5450 gets merged