### PR TITLE
#745: Pass through execution space argument in sorting

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -113,11 +113,9 @@ sortObjects(ExecutionSpace const &space, ViewType &view)
   }
 
   Kokkos::BinSort<ViewType, CompType, typename ViewType::device_type, SizeType>
-      bin_sort(view, CompType(n / 2, min_val, max_val), true);
-  bin_sort.create_permute_vector();
-  bin_sort.sort(view);
-  // FIXME Kokkos::BinSort is currently missing overloads that an execution
-  // space as argument
+      bin_sort(space, view, CompType(n / 2, min_val, max_val), true);
+  bin_sort.create_permute_vector(space);
+  bin_sort.sort(space, view);
 
   return bin_sort.get_permute_vector();
 }

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -112,10 +112,17 @@ sortObjects(ExecutionSpace const &space, ViewType &view)
     return permute;
   }
 
+#if KOKKOS_VERSION >= 30700
   Kokkos::BinSort<ViewType, CompType, typename ViewType::device_type, SizeType>
       bin_sort(space, view, CompType(n / 2, min_val, max_val), true);
   bin_sort.create_permute_vector(space);
   bin_sort.sort(space, view);
+#else
+  Kokkos::BinSort<ViewType, CompType, typename ViewType::device_type, SizeType>
+      bin_sort(view, CompType(n / 2, min_val, max_val), true);
+  bin_sort.create_permute_vector();
+  bin_sort.sort(view);
+#endif
 
   return bin_sort.get_permute_vector();
 }


### PR DESCRIPTION
Fixes #745