### PR TITLE
Initialize core distances in MST to zero to be used in Max functor

### DIFF
--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -614,9 +614,7 @@ struct MinimumSpanningTree
       profile_core_distances.start();
       Kokkos::Profiling::pushRegion("ArborX::MST::compute_core_distances");
       Kokkos::View<float *, MemorySpace> core_distances(
-          Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
-                             "ArborX::MST::core_distances"),
-          n);
+          "ArborX::MST::core_distances", n);
       bvh.query(space, NearestK<Primitives>{primitives, k},
                 MaxDistance<Primitives, decltype(core_distances)>{
                     primitives, core_distances});


### PR DESCRIPTION
A major oops! This made us use unitialized values in computing core distances, that sometimes affected results for `minPts > 1`.

This was originally caught by dumping MST and seeing some edge weights becomes things like `1e+25` or `1e+31`. Running `-fsanitize=undefined -fsanitize=memory` did not produce any leads. `valgrind` was also unhelpful pointing at places much later during execution. Tracked it by using early returns in the `MinimumSpanningTree` constructor.

@dalg24 We may need to create a golden test for `minPts > 1` so as not to repeat this. But I currently don't have time to do that. I'll just file an issue.