### PR TITLE
Fix View creation in do_posts_and_waits

### DIFF
--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -288,14 +288,11 @@ public:
     bool const permutation_necessary = _permute.size() != 0;
     if (permutation_necessary)
     {
-      auto dest_buffer = ExportViewWithoutMemoryTraits(
+      ExportViewWithoutMemoryTraits dest_buffer(
           Kokkos::view_alloc(
-              space,
+              space, Kokkos::WithoutInitializing,
               "ArborX::Distributor::doPostsAndWaits::destination_buffer"),
-          typename ExportView::array_layout{});
-
-      KokkosExt::reallocWithoutInitializing(space, dest_buffer,
-                                            exports.layout());
+          exports.layout());
 
       // We need to create a local copy to avoid capturing a member variable
       // (via the 'this' pointer) which we can't do using a KOKKOS_LAMBDA.

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
                     isPrefixedWith(label, "ArborX::TreeTraversal::nearest::") ||
                     isPrefixedWith(label, "ArborX::CrsGraphWrapper::") ||
                     isPrefixedWith(label, "ArborX::Sorting::") ||
-                    isPrefixedWith(label, "Kokkos::SortImpl::") ||
+                    isPrefixedWith(label, "Kokkos::") ||
                     isPrefixedWith(label, "Testing::")));
       });
 


### PR DESCRIPTION
Noticed while trying to use DTK with Trilinos 14/Kokkos 3.7, also see https://github.com/ORNL-CEES/DataTransferKit/pull/603.
Our intent here was to initialize `dest_buffer` as empty first for general layouts. The default layout, e.g., for `LayoutLeft`, represents is 0-dimensional, though, see https://github.com/kokkos/kokkos/blob/25e2302a61cd07c8a5f8c369bbbcd2f43fde542f/core/src/Kokkos_Layout.hpp#L91-L100, and we started checking for the passed layout to have correct rank in Kokkos 3.7.0.
Since we are resizing the `View` in the next line anyway, it's easy to fix the issue here and just initialize it with the correct layout in the first place.