### PR TITLE
Add a faster implementation of the union-find for Serial

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -241,6 +241,8 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
   ARBORX_ASSERT(eps > 0);
   ARBORX_ASSERT(core_min_size >= 2);
 
+  using UnionFind = Details::UnionFind<ExecutionSpace, MemorySpace>;
+
   constexpr int dim = GeometryTraits::dimension_v<
       typename Details::AccessTraitsHelper<Access>::type>;
   using Box = ExperimentalHyperGeometry::Box<dim>;
@@ -283,9 +285,9 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
       using CorePoints = Details::CCSCorePoints;
       CorePoints core_points;
       Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters::query");
-      bvh.query(exec_space, predicates,
-                Details::FDBSCANCallback<MemorySpace, CorePoints>{labels,
-                                                                  core_points});
+      bvh.query(
+          exec_space, predicates,
+          Details::FDBSCANCallback<UnionFind, CorePoints>{labels, core_points});
       Kokkos::Profiling::popRegion();
     }
     else
@@ -309,7 +311,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
       profile_query.start();
       Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters:query");
       bvh.query(exec_space, predicates,
-                Details::FDBSCANCallback<MemorySpace, CorePoints>{
+                Details::FDBSCANCallback<UnionFind, CorePoints>{
                     labels, CorePoints{num_neigh, core_min_size}});
       Kokkos::Profiling::popRegion();
       profile_query.stop();
@@ -410,7 +412,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
           Details::PrimitivesWithRadius<Primitives>{primitives, eps};
       bvh.query(
           exec_space, predicates,
-          Details::FDBSCANDenseBoxCallback<MemorySpace, CorePoints, Primitives,
+          Details::FDBSCANDenseBoxCallback<UnionFind, CorePoints, Primitives,
                                            decltype(dense_cell_offsets),
                                            decltype(permute)>{
               labels, CorePoints{}, primitives, dense_cell_offsets, exec_space,
@@ -460,7 +462,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
           Details::PrimitivesWithRadius<Primitives>{primitives, eps};
       bvh.query(
           exec_space, predicates,
-          Details::FDBSCANDenseBoxCallback<MemorySpace, CorePoints, Primitives,
+          Details::FDBSCANDenseBoxCallback<UnionFind, CorePoints, Primitives,
                                            decltype(dense_cell_offsets),
                                            decltype(permute)>{
               labels, CorePoints{num_neigh, core_min_size}, primitives,

--- a/src/details/ArborX_DetailsFDBSCAN.hpp
+++ b/src/details/ArborX_DetailsFDBSCAN.hpp
@@ -43,17 +43,11 @@ struct CountUpToN
   }
 };
 
-template <typename MemorySpace, typename CorePointsType>
+template <typename UnionFind, typename CorePointsType>
 struct FDBSCANCallback
 {
-  UnionFind<MemorySpace> _union_find;
+  UnionFind _union_find;
   CorePointsType _is_core_point;
-
-  FDBSCANCallback(Kokkos::View<int *, MemorySpace> const &view,
-                  CorePointsType is_core_point)
-      : _union_find(view)
-      , _is_core_point(is_core_point)
-  {}
 
   template <typename Query>
   KOKKOS_FUNCTION auto operator()(Query const &query, int j) const

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -95,11 +95,11 @@ struct CountUpToN_DenseBox
   }
 };
 
-template <typename MemorySpace, typename CorePointsType, typename Primitives,
+template <typename UnionFind, typename CorePointsType, typename Primitives,
           typename DenseCellOffsets, typename Permutation>
 struct FDBSCANDenseBoxCallback
 {
-  UnionFind<MemorySpace> _union_find;
+  UnionFind _union_find;
   CorePointsType _is_core_point;
   Primitives _primitives;
   DenseCellOffsets _dense_cell_offsets;
@@ -109,13 +109,13 @@ struct FDBSCANDenseBoxCallback
   float eps;
 
   template <typename ExecutionSpace>
-  FDBSCANDenseBoxCallback(Kokkos::View<int *, MemorySpace> const &labels,
+  FDBSCANDenseBoxCallback(UnionFind const &union_find,
                           CorePointsType const &is_core_point,
                           Primitives const &primitives,
                           DenseCellOffsets const &dense_cell_offsets,
                           ExecutionSpace const &exec_space,
                           Permutation const &permute, float eps_in)
-      : _union_find(labels)
+      : _union_find(union_find)
       , _is_core_point(is_core_point)
       , _primitives(primitives)
       , _dense_cell_offsets(dense_cell_offsets)
@@ -283,7 +283,7 @@ void unionFindWithinEachDenseCell(ExecutionSpace const &exec_space,
 {
   using MemorySpace = typename Permutation::memory_space;
 
-  UnionFind<MemorySpace> union_find{labels};
+  UnionFind<ExecutionSpace, MemorySpace> union_find{labels};
 
   // The algorithm relies on the fact that the cell indices array only contains
   // dense cells. Thus, as long as two cell indices are the same, a) they


### PR DESCRIPTION
The patch tries to solve the problem of slow `Serial` atomics when Kokkos compiled with other backends. This patch is not strictly necessary right now, as one could compile Kokkos with just the `Serial` backend. However, it becomes necessary once I introduce a dendrogram construction algorithm using union-find, which will run MST construction on the device, but construct union-find on CPU using a single thread. In that context, it's not possible to fix it by just compiling Kokkos.

Drive-by change: `labels_` -> `_labels`