### PR TITLE
Print on failure in kokkos tools annotations tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,6 +133,10 @@ add_executable(ArborX_Test_QueryTree.exe
   utf_main.cpp)
 target_link_libraries(ArborX_Test_QueryTree.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_Test_QueryTree.exe PRIVATE BOOST_TEST_DYN_LINK)
+# FIXME_SYCL oneDPL messes with namespace std, see https://github.com/oneapi-src/oneDPL/issues/576
+if(Kokkos_ENABLE_SYCL)
+  target_compile_definitions(ArborX_Test_QueryTree.exe PRIVATE NANORANGE_NO_STD_FORWARD_DECLARATIONS)
+endif()
 target_include_directories(ArborX_Test_QueryTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME ArborX_Test_QueryTree COMMAND ./ArborX_Test_QueryTree.exe)
 
@@ -197,6 +201,10 @@ if(ARBORX_ENABLE_MPI)
   add_executable(ArborX_Test_DistributedTree.exe tstDistributedTree.cpp tstKokkosToolsDistributedAnnotations.cpp utf_main.cpp)
   target_link_libraries(ArborX_Test_DistributedTree.exe PRIVATE ArborX Boost::unit_test_framework)
   target_compile_definitions(ArborX_Test_DistributedTree.exe PRIVATE BOOST_TEST_DYN_LINK ARBORX_MPI_UNIT_TEST)
+  # FIXME_SYCL oneDPL messes with namespace std, see https://github.com/oneapi-src/oneDPL/issues/576
+  if(Kokkos_ENABLE_SYCL)
+    target_compile_definitions(ArborX_Test_DistributedTree.exe PRIVATE NANORANGE_NO_STD_FORWARD_DECLARATIONS)
+  endif()
   target_include_directories(ArborX_Test_DistributedTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
   add_test(NAME ArborX_Test_DistributedTree COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ./ArborX_Test_DistributedTree.exe ${MPIEXEC_POSTFLAGS})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(ArborX_Test_QueryTree.exe
 target_link_libraries(ArborX_Test_QueryTree.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_Test_QueryTree.exe PRIVATE BOOST_TEST_DYN_LINK)
 # FIXME_SYCL oneDPL messes with namespace std, see https://github.com/oneapi-src/oneDPL/issues/576
+# only needed for the tools annotation test
 if(Kokkos_ENABLE_SYCL)
   target_compile_definitions(ArborX_Test_QueryTree.exe PRIVATE NANORANGE_NO_STD_FORWARD_DECLARATIONS)
 endif()
@@ -202,6 +203,7 @@ if(ARBORX_ENABLE_MPI)
   target_link_libraries(ArborX_Test_DistributedTree.exe PRIVATE ArborX Boost::unit_test_framework)
   target_compile_definitions(ArborX_Test_DistributedTree.exe PRIVATE BOOST_TEST_DYN_LINK ARBORX_MPI_UNIT_TEST)
   # FIXME_SYCL oneDPL messes with namespace std, see https://github.com/oneapi-src/oneDPL/issues/576
+  # only needed for the tools annotation test
   if(Kokkos_ENABLE_SYCL)
     target_compile_definitions(ArborX_Test_DistributedTree.exe PRIVATE NANORANGE_NO_STD_FORWARD_DECLARATIONS)
   endif()

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
                       "|Kokkos::Serial::" // unsure what's going on
                       ").*");
         BOOST_TEST(std::regex_match(label, re),
-                   "\"" << label << "\" matches the regular expression");
+                   "\"" << label << "\" does not match the regular expression");
       });
 
   { // default constructed
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_query_allocations_prefixed, DeviceType,
                       "|Kokkos::SortImpl::BinSortFunctor::"
                       ").*");
         BOOST_TEST(std::regex_match(label, re),
-                   "\"" << label << "\" matches the regular expression");
+                   "\"" << label << "\" does not match the regular expression");
       });
 
   // spatial predicates
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   auto const callback = [](char const *label, uint32_t, uint64_t *) {
     std::regex re("^(ArborX::|Kokkos::).*");
     BOOST_TEST(std::regex_match(label, re),
-               "\"" << label << "\" matches the regular expression");
+               "\"" << label << "\" does not match the regular expression");
   };
   Kokkos::Tools::Experimental::set_begin_parallel_for_callback(callback);
   Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(callback);
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
     std::regex re("^(ArborX::|Kokkos::).*");
     BOOST_TEST(std::regex_match(label, re),
-               "\"" << label << "\" matches the regular expression");
+               "\"" << label << "\" does not match the regular expression");
   });
 
   // BVH::BVH

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -15,7 +15,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <regex>
-#include <string>
 
 #include "Search_UnitTestHelpers.hpp"
 
@@ -23,16 +22,12 @@ BOOST_AUTO_TEST_SUITE(KokkosToolsAnnotations)
 
 namespace tt = boost::test_tools;
 
-bool isPrefixedWith(std::string const &s, std::string const &prefix)
-{
-  return s.find(prefix) == 0;
-}
-
 BOOST_AUTO_TEST_CASE(is_prefixed_with)
 {
-  BOOST_TEST(isPrefixedWith("ArborX::Whatever", "ArborX"));
-  BOOST_TEST(!isPrefixedWith("Nope", "ArborX"));
-  BOOST_TEST(!isPrefixedWith("Nope::ArborX", "ArborX"));
+  std::regex re("^ArborX::.*");
+  BOOST_TEST(std::regex_match("ArborX::Whatever", re));
+  BOOST_TEST(!std::regex_match("Nope", re));
+  BOOST_TEST(!std::regex_match("Nope::ArborX", re));
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -14,6 +14,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifdef KOKKOS_ENABLE_SYCL // FIXME_SYCL
+#define NANORANGE_NO_STD_FORWARD_DECLARATIONS
+#endif
 #include <regex>
 
 #include "Search_UnitTestHelpers.hpp"

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -14,9 +14,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef KOKKOS_ENABLE_SYCL // FIXME_SYCL
-#define NANORANGE_NO_STD_FORWARD_DECLARATIONS
-#endif
 #include <regex>
 
 #include "Search_UnitTestHelpers.hpp"

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <regex>
 #include <string>
 
 #include "Search_UnitTestHelpers.hpp"
@@ -43,15 +44,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, char const *label,
          void const * /*ptr*/, uint64_t /*size*/) {
-        BOOST_TEST_MESSAGE(label);
-        BOOST_TEST(
-            (isPrefixedWith(label, "ArborX::BVH::") || // data member
-             isPrefixedWith(label, "ArborX::BVH::BVH::") ||
-             isPrefixedWith(label, "ArborX::Sorting::") ||
-             isPrefixedWith(label, "Kokkos::SortImpl::BinSortFunctor::") ||
-             isPrefixedWith(label,
-                            "Kokkos::Serial::") || // unsure what's going on
-             isPrefixedWith(label, "Testing::")));
+        std::regex re("^(Testing::"
+                      "|ArborX::BVH::"
+                      "|ArborX::Sorting::"
+                      "|Kokkos::SortImpl::BinSortFunctor::"
+                      "|Kokkos::Serial::" // unsure what's going on
+                      ").*");
+        BOOST_TEST(std::regex_match(label, re),
+                   "\"" << label << "\" matches the regular expression");
       });
 
   { // default constructed
@@ -92,15 +92,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_query_allocations_prefixed, DeviceType,
   Kokkos::Tools::Experimental::set_allocate_data_callback(
       [](Kokkos::Profiling::SpaceHandle /*handle*/, char const *label,
          void const * /*ptr*/, uint64_t /*size*/) {
-        BOOST_TEST_MESSAGE(label);
-        BOOST_TEST(
-            (isPrefixedWith(label, "ArborX::BVH::query::") ||
-             isPrefixedWith(label, "ArborX::TreeTraversal::spatial::") ||
-             isPrefixedWith(label, "ArborX::TreeTraversal::nearest::") ||
-             isPrefixedWith(label, "ArborX::CrsGraphWrapper::") ||
-             isPrefixedWith(label, "ArborX::Sorting::") ||
-             isPrefixedWith(label, "Kokkos::SortImpl::BinSortFunctor::") ||
-             isPrefixedWith(label, "Testing::")));
+        std::regex re("^(Testing::"
+                      "|ArborX::BVH::query::"
+                      "|ArborX::TreeTraversal::spatial::"
+                      "|ArborX::TreeTraversal::nearest::"
+                      "|ArborX::CrsGraphWrapper::"
+                      "|ArborX::Sorting::"
+                      "|Kokkos::SortImpl::BinSortFunctor::"
+                      ").*");
+        BOOST_TEST(std::regex_match(label, re),
+                   "\"" << label << "\" matches the regular expression");
       });
 
   // spatial predicates
@@ -126,9 +127,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   auto const callback = [](char const *label, uint32_t, uint64_t *) {
-    BOOST_TEST_MESSAGE(label);
-    BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
-                isPrefixedWith(label, "Kokkos::")));
+    std::regex re("^(ArborX::|Kokkos::).*");
+    BOOST_TEST(std::regex_match(label, re),
+               "\"" << label << "\" matches the regular expression");
   };
   Kokkos::Tools::Experimental::set_begin_parallel_for_callback(callback);
   Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(callback);
@@ -189,9 +190,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   using ExecutionSpace = typename DeviceType::execution_space;
 
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
-    BOOST_TEST_MESSAGE(label);
-    BOOST_TEST((isPrefixedWith(label, "ArborX::") ||
-                isPrefixedWith(label, "Kokkos::")));
+    std::regex re("^(ArborX::|Kokkos::).*");
+    BOOST_TEST(std::regex_match(label, re),
+               "\"" << label << "\" matches the regular expression");
   });
 
   // BVH::BVH

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
                       "|ArborX::Sorting::"
                       ").*");
         BOOST_TEST(std::regex_match(label, re),
-                   "\"" << label << "\" matches the regular expression");
+                   "\"" << label << "\" does not match the regular expression");
       });
 
   { // one leaf per process
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
                       "|Kokkos::"
                       ").*");
         BOOST_TEST(std::regex_match(label, re),
-                   "\"" << label << "\" matches the regular expression");
+                   "\"" << label << "\" does not match the regular expression");
       });
 
   // spatial predicates
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(kernels_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   auto const callback = [](char const *label, uint32_t, uint64_t *) {
     std::regex re("^(ArborX::|Kokkos::).*");
     BOOST_TEST(std::regex_match(label, re),
-               "\"" << label << "\" matches the regular expression");
+               "\"" << label << "\" does not match the regular expression");
   };
   Kokkos::Tools::Experimental::set_begin_parallel_for_callback(callback);
   Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(callback);
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regions_prefixed, DeviceType, ARBORX_DEVICE_TYPES)
   Kokkos::Tools::Experimental::set_push_region_callback([](char const *label) {
     std::regex re("^(ArborX::|Kokkos::).*");
     BOOST_TEST(std::regex_match(label, re),
-               "\"" << label << "\" matches the regular expression");
+               "\"" << label << "\" does not match the regular expression");
   });
 
   // DistributedTree::DistriibutedSearchTree

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -14,6 +14,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifdef KOKKOS_ENABLE_SYCL // FIXME_SYCL
+#define NANORANGE_NO_STD_FORWARD_DECLARATIONS
+#endif
 #include <regex>
 
 #include "Search_UnitTestHelpers.hpp"

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -14,9 +14,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef KOKKOS_ENABLE_SYCL // FIXME_SYCL
-#define NANORANGE_NO_STD_FORWARD_DECLARATIONS
-#endif
 #include <regex>
 
 #include "Search_UnitTestHelpers.hpp"


### PR DESCRIPTION
Following up on https://github.com/arborx/ArborX/pull/749#discussion_r998190756

* Print the label on failure instead of unconditionally adding it as a comment
* Prefer regular expressions instead of `isPrefixedWith` helper test function