### PR TITLE
Deduce point spatial dimension from view static extent

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -13,6 +13,7 @@
 #define ARBORX_ACCESS_TRAITS_HPP
 
 #include <ArborX_GeometryTraits.hpp>
+#include <ArborX_HyperPoint.hpp>
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
 
@@ -58,11 +59,30 @@ template <typename View, typename Tag>
 struct AccessTraits<
     View, Tag, std::enable_if_t<Kokkos::is_view<View>{} && View::rank == 2>>
 {
+#if KOKKOS_VERSION >= 30700
+  template <std::size_t... Is>
+  KOKKOS_FUNCTION static ExperimentalHyperGeometry::Point<sizeof...(Is)>
+  getPoint(std::index_sequence<Is...>, View const &v, int i)
+  {
+    return {v(i, Is)...};
+  }
+
+  // Returns by value
+  KOKKOS_FUNCTION static auto get(View const &v, int i)
+  {
+    constexpr int dim = View::static_extent(1);
+    if constexpr (dim > 0) // dimension known at compile time
+      return getPoint(std::make_index_sequence<dim>(), v, i);
+    else
+      return Point{{ v(i, 0), v(i, 1), v(i, 2) }};
+  }
+#else
   // Returns by value
   KOKKOS_FUNCTION static Point get(View const &v, int i)
   {
     return {{v(i, 0), v(i, 1), v(i, 2)}};
   }
+#endif
 
   KOKKOS_FUNCTION
   static typename View::size_type size(View const &v) { return v.extent(0); }

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -93,12 +93,15 @@ void test_deduce_point_type_from_view()
   using ArborX::ExperimentalHyperGeometry::Point;
   static_assert(
       std::is_same_v<deduce_point_t<Kokkos::View<float **>>, GoodOlePoint>);
+#if KOKKOS_VERSION >= 30700
   static_assert(
       std::is_same_v<deduce_point_t<Kokkos::View<float *[3]>>, Point<3>>);
-#if KOKKOS_VERSION >= 30700
   static_assert(
       std::is_same_v<deduce_point_t<Kokkos::View<float *[2]>>, Point<2>>);
   static_assert(
       std::is_same_v<deduce_point_t<Kokkos::View<float *[5]>>, Point<5>>);
+#else
+  static_assert(
+      std::is_same_v<deduce_point_t<Kokkos::View<float *[3]>>, GoodOlePoint>);
 #endif
 }

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include <ArborX_AccessTraits.hpp>
+#include <ArborX_HyperPoint.hpp>
 #include <ArborX_Point.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -79,4 +80,25 @@ void test_access_traits_compile_only()
   // check_valid_access_traits(PrimitivesTag{}, SizeMemberFunctionNotStatic{});
 
   // check_valid_access_traits(PrimitivesTag{}, LegacyAccessTraits{});
+}
+
+template <class V>
+using deduce_point_t =
+    decltype(ArborX::AccessTraits<V, ArborX::PrimitivesTag>::get(
+        std::declval<V>(), 0));
+
+void test_deduce_point_type_from_view()
+{
+  using GoodOlePoint = ArborX::Point;
+  using ArborX::ExperimentalHyperGeometry::Point;
+  static_assert(
+      std::is_same_v<deduce_point_t<Kokkos::View<float **>>, GoodOlePoint>);
+  static_assert(
+      std::is_same_v<deduce_point_t<Kokkos::View<float *[3]>>, Point<3>>);
+#if KOKKOS_VERSION >= 30700
+  static_assert(
+      std::is_same_v<deduce_point_t<Kokkos::View<float *[2]>>, Point<2>>);
+  static_assert(
+      std::is_same_v<deduce_point_t<Kokkos::View<float *[5]>>, Point<5>>);
+#endif
 }


### PR DESCRIPTION
Before that PR, the provided access traits for rank-2 views would always deduce `ArborX::Point`
```
Kokkos::View<float**> -> ArborX::Point
Kokkos::View<float*[3]> -> ArborX::Point // OK
Kokkos::View<float*[2]> -> ArborX::Point // Out of bound access at runtime
Kokkos::View<float*[5]> -> ArborX::Point // Last two dimensions discarded
```
In this PR I propose we deduce `ArborX::ExperimentalHyperGeometry::Point<DIM>` if the 2nd extent of the view (`DIM`) is known at compile time
```
Kokkos::View<float**> -> ArborX::Point // Unchanged
Kokkos::View<float*[3]> -> ArborX::ExperimentalHyperGeometry::Point<3>
Kokkos::View<float*[2]> -> ArborX::ExperimentalHyperGeometry::Point<2>
Kokkos::View<float*[5]> -> ArborX::ExperimentalHyperGeometry::Point<5>

```