### PR TITLE
Fix `min` and `max` algorithms for element types other than `int`

### DIFF
--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -359,13 +359,14 @@ typename ViewType::non_const_value_type min(ExecutionSpace &&space,
   static_assert(ViewType::rank == 1, "min requires a View of rank 1");
   auto const n = v.extent(0);
   ARBORX_ASSERT(n > 0);
-  typename ViewType::non_const_value_type result;
+  using ValueType = typename ViewType::non_const_value_type;
+  ValueType result;
   Kokkos::Min<typename ViewType::non_const_value_type> reducer(result);
   Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(
       "ArborX::Algorithms::min", policy,
-      KOKKOS_LAMBDA(int i, int &update) {
+      KOKKOS_LAMBDA(int i, ValueType &update) {
         if (v(i) < update)
           update = v(i);
       },
@@ -393,13 +394,14 @@ typename ViewType::non_const_value_type max(ExecutionSpace &&space,
   static_assert(ViewType::rank == 1, "max requires a View of rank 1");
   auto const n = v.extent(0);
   ARBORX_ASSERT(n > 0);
-  typename ViewType::non_const_value_type result;
+  using ValueType = typename ViewType::non_const_value_type;
+  ValueType result;
   Kokkos::Max<typename ViewType::non_const_value_type> reducer(result);
   Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(
       "ArborX::Algorithms::max", policy,
-      KOKKOS_LAMBDA(int i, int &update) {
+      KOKKOS_LAMBDA(int i, ValueType &update) {
         if (v(i) > update)
           update = v(i);
       },

--- a/test/tstDetailsUtils.cpp
+++ b/test/tstDetailsUtils.cpp
@@ -221,6 +221,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(min_and_max, DeviceType, ARBORX_DEVICE_TYPES)
   ArborX::iota(space, w, 2);
   BOOST_TEST(ArborX::min(space, w) == 2);
   BOOST_TEST(ArborX::max(space, w) == 8);
+
+  Kokkos::View<float *, DeviceType> x("x", 3);
+  Kokkos::deep_copy(x, 3.14f);
+  BOOST_TEST(ArborX::min(space, x) == 3.14f);
+  BOOST_TEST(ArborX::max(space, x) == 3.14f);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(sort_objects, DeviceType, ARBORX_DEVICE_TYPES)


### PR DESCRIPTION
Kinda embarrassing especially considering that we still haven't moved it out of `ArborX::`