### PR TITLE
Introduce dendrogram construction based on union-find

### DIFF
--- a/src/details/ArborX_Dendrogram.hpp
+++ b/src/details/ArborX_Dendrogram.hpp
@@ -28,7 +28,7 @@ struct Dendrogram
   Dendrogram(ExecutionSpace const &exec_space,
              Kokkos::View<Details::WeightedEdge *, MemorySpace> edges)
   {
-    Kokkos::Profiling::pushRegion("ArborX::Dendrogram::dendrogram");
+    Kokkos::Profiling::pushRegion("ArborX::Dendrogram::Dendrogram");
 
     _parents = Details::dendrogramUnionFind(exec_space, edges);
 

--- a/src/details/ArborX_Dendrogram.hpp
+++ b/src/details/ArborX_Dendrogram.hpp
@@ -33,7 +33,9 @@ struct Dendrogram
   {
     Kokkos::Profiling::pushRegion("ArborX::Dendrogram::Dendrogram");
 
-    Details::dendrogramUnionFind(exec_space, edges, _parents, _parent_heights);
+    using ConstEdges = Kokkos::View<Details::WeightedEdge const *, MemorySpace>;
+    Details::dendrogramUnionFind(exec_space, ConstEdges(edges), _parents,
+                                 _parent_heights);
 
     Kokkos::Profiling::popRegion();
   }

--- a/src/details/ArborX_Dendrogram.hpp
+++ b/src/details/ArborX_Dendrogram.hpp
@@ -23,14 +23,17 @@ template <typename MemorySpace>
 struct Dendrogram
 {
   Kokkos::View<int *, MemorySpace> _parents;
+  Kokkos::View<float *, MemorySpace> _parent_heights;
 
   template <typename ExecutionSpace>
   Dendrogram(ExecutionSpace const &exec_space,
              Kokkos::View<Details::WeightedEdge *, MemorySpace> edges)
+      : _parents("ArborX::Dendrogram::parents", 0)
+      , _parent_heights("ArborX::Dendrogram::parent_heights", 0)
   {
     Kokkos::Profiling::pushRegion("ArborX::Dendrogram::Dendrogram");
 
-    _parents = Details::dendrogramUnionFind(exec_space, edges);
+    Details::dendrogramUnionFind(exec_space, edges, _parents, _parent_heights);
 
     Kokkos::Profiling::popRegion();
   }

--- a/src/details/ArborX_Dendrogram.hpp
+++ b/src/details/ArborX_Dendrogram.hpp
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef ARBORX_DENDROGRAM_HPP
+#define ARBORX_DENDROGRAM_HPP
+
+#include <ArborX_DetailsDendrogram.hpp>
+#include <ArborX_DetailsWeightedEdge.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace ArborX::Experimental
+{
+
+template <typename MemorySpace>
+struct Dendrogram
+{
+  Kokkos::View<int *, MemorySpace> _parents;
+
+  template <typename ExecutionSpace>
+  Dendrogram(ExecutionSpace const &exec_space,
+             Kokkos::View<Details::WeightedEdge *, MemorySpace> edges)
+  {
+    Kokkos::Profiling::pushRegion("ArborX::Dendrogram::dendrogram");
+
+    _parents = Details::dendrogramUnionFind(exec_space, edges);
+
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+} // namespace ArborX::Experimental
+
+#endif

--- a/src/details/ArborX_DetailsDendrogram.hpp
+++ b/src/details/ArborX_DetailsDendrogram.hpp
@@ -56,7 +56,8 @@ void dendrogramUnionFindHost(
     UnionFind<Kokkos::Serial, Kokkos::HostSpace> union_find,
     Parents &parents_host)
 {
-  Kokkos::DefaultHostExecutionSpace exec_space;
+  using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
+  ExecutionSpace host_space;
 
   int const num_edges = edges_host.size();
   int const num_vertices = num_edges + 1;
@@ -65,10 +66,10 @@ void dendrogramUnionFindHost(
   constexpr int UNDEFINED = -1;
 
   Kokkos::View<int *, Kokkos::HostSpace> set_edges_host(
-      Kokkos::view_alloc(exec_space, Kokkos::WithoutInitializing,
+      Kokkos::view_alloc(host_space, Kokkos::WithoutInitializing,
                          "ArborX::Dendrogram::labels"),
       num_vertices + num_edges);
-  Kokkos::deep_copy(exec_space, set_edges_host, UNDEFINED);
+  Kokkos::deep_copy(host_space, set_edges_host, UNDEFINED);
 
   for (int k = 0; k < num_edges; ++k)
   {
@@ -108,9 +109,7 @@ dendrogramUnionFind(ExecutionSpace const &exec_space,
   Kokkos::Profiling::ProfilingSection profile_edge_sort(
       "ArborX::Dendrogram::edge_sort");
   profile_edge_sort.start();
-  Kokkos::Profiling::pushRegion("ArborX::Dendrogram::edge_sort");
   auto permute = computeEdgesPermutation(exec_space, edges);
-  Kokkos::Profiling::popRegion();
   profile_edge_sort.stop();
 
   auto const num_vertices = edges.size() + 1;

--- a/src/details/ArborX_DetailsDendrogram.hpp
+++ b/src/details/ArborX_DetailsDendrogram.hpp
@@ -1,0 +1,163 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_DENDROGRAM_HPP
+#define ARBORX_DETAILS_DENDROGRAM_HPP
+
+#include <ArborX_DetailsKokkosExtSwap.hpp>
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
+#include <ArborX_DetailsSortUtils.hpp>
+#include <ArborX_DetailsUnionFind.hpp>
+#include <ArborX_MinimumSpanningTree.hpp> // WeightedEdge
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Profiling_ProfileSection.hpp>
+
+namespace ArborX::Details
+{
+
+// Compute permutation that orders edges in increasing order
+template <typename ExecutionSpace, typename MemorySpace>
+Kokkos::View<unsigned int *, MemorySpace>
+computeEdgesPermutation(ExecutionSpace const &exec_space,
+                        Kokkos::View<WeightedEdge *, MemorySpace> &edges)
+{
+  Kokkos::Profiling::pushRegion("ArborX::Dendrogram::sort_edges");
+
+  int const num_edges = edges.size();
+
+  Kokkos::View<float *, MemorySpace> weights(
+      Kokkos::view_alloc(exec_space, Kokkos::WithoutInitializing,
+                         "ArborX::Dendrogram::weights"),
+      num_edges);
+  Kokkos::parallel_for(
+      "ArborX::Dendrogram::copy_weights",
+      Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, num_edges),
+      KOKKOS_LAMBDA(int const e) { weights(e) = edges(e).weight; });
+
+  auto permute = Details::sortObjects(exec_space, weights);
+
+  Kokkos::Profiling::popRegion();
+
+  return permute;
+}
+
+template <typename Edges, typename Permute, typename Parents>
+void dendrogramUnionFindHost(
+    Edges edges_host, Permute permute,
+    UnionFind<Kokkos::Serial, Kokkos::HostSpace> union_find,
+    Parents &parents_host)
+{
+  Kokkos::DefaultHostExecutionSpace exec_space;
+
+  int const num_edges = edges_host.size();
+  int const num_vertices = num_edges + 1;
+  auto const vertices_offset = num_edges;
+
+  constexpr int UNDEFINED = -1;
+
+  Kokkos::View<int *, Kokkos::HostSpace> set_edges_host(
+      Kokkos::view_alloc(exec_space, Kokkos::WithoutInitializing,
+                         "ArborX::Dendrogram::labels"),
+      num_vertices + num_edges);
+  Kokkos::deep_copy(exec_space, set_edges_host, UNDEFINED);
+
+  for (int k = 0; k < num_edges; ++k)
+  {
+    auto e = permute(k);
+
+    int i = edges_host(e).source;
+    int j = edges_host(e).target;
+
+    for (int s : {i, j})
+    {
+      auto child = set_edges_host(union_find.representative(s));
+      if (child == UNDEFINED)
+      {
+        // This will happen when a vertex has not been assigned a parent yet
+        parents_host(vertices_offset + s) = e;
+      }
+      else
+      {
+        parents_host(child) = e;
+      }
+    }
+
+    union_find.merge(i, j);
+
+    set_edges_host(union_find.representative(i)) = e;
+  }
+  parents_host(permute(num_edges - 1)) = UNDEFINED; // root
+}
+
+template <typename ExecutionSpace, typename MemorySpace>
+Kokkos::View<int *, MemorySpace>
+dendrogramUnionFind(ExecutionSpace const &exec_space,
+                    Kokkos::View<WeightedEdge *, MemorySpace> edges)
+{
+  Kokkos::Profiling::pushRegion("ArborX::Dendrogram::dendrogram_union_find");
+
+  Kokkos::Profiling::ProfilingSection profile_edge_sort(
+      "ArborX::Dendrogram::edge_sort");
+  profile_edge_sort.start();
+  Kokkos::Profiling::pushRegion("ArborX::Dendrogram::edge_sort");
+  auto permute = computeEdgesPermutation(exec_space, edges);
+  Kokkos::Profiling::popRegion();
+  profile_edge_sort.stop();
+
+  auto const num_vertices = edges.size() + 1;
+
+  Kokkos::View<int *, MemorySpace> parents(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                         "ArborX::Dendrogram::edge_parents"),
+      2 * num_vertices - 1);
+
+  Kokkos::View<int *, MemorySpace> vertex_labels(
+      Kokkos::view_alloc(
+          Kokkos::WithoutInitializing,
+          "ArborX::Dendrogram::dendrogram_union_find::vertex_labels"),
+      num_vertices);
+  iota(exec_space, vertex_labels);
+
+  Kokkos::Profiling::pushRegion(
+      "ArborX::Dendrogram::dendrogram_union_find::copy_to_host");
+
+  auto edges_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, edges);
+  auto permute_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, permute);
+  auto parents_host = Kokkos::create_mirror_view(parents);
+  auto vertex_labels_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, vertex_labels);
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::pushRegion(
+      "ArborX::Dendrogram::dendrogram_union_find::union_find");
+
+  UnionFind<Kokkos::Serial, Kokkos::HostSpace> union_find(vertex_labels_host);
+  dendrogramUnionFindHost(edges_host, permute_host, union_find, parents_host);
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::pushRegion(
+      "ArborX::Dendrogram::dendrogram_union_find::copy_to_device");
+
+  Kokkos::deep_copy(exec_space, parents, parents_host);
+
+  Kokkos::Profiling::popRegion();
+
+  Kokkos::Profiling::popRegion();
+
+  return parents;
+}
+
+} // namespace ArborX::Details
+
+#endif

--- a/src/details/ArborX_DetailsDendrogram.hpp
+++ b/src/details/ArborX_DetailsDendrogram.hpp
@@ -16,7 +16,7 @@
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsSortUtils.hpp>
 #include <ArborX_DetailsUnionFind.hpp>
-#include <ArborX_MinimumSpanningTree.hpp> // WeightedEdge
+#include <ArborX_DetailsWeightedEdge.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ProfileSection.hpp>

--- a/src/details/ArborX_DetailsWeightedEdge.hpp
+++ b/src/details/ArborX_DetailsWeightedEdge.hpp
@@ -12,18 +12,9 @@
 #ifndef ARBORX_DETAILS_WEIGHTED_EDGE_HPP
 #define ARBORX_DETAILS_WEIGHTED_EDGE_HPP
 
-#include <ArborX_AccessTraits.hpp>
-#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
-#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
-#include <ArborX_DetailsMutualReachabilityDistance.hpp>
-#include <ArborX_DetailsTreeNodeLabeling.hpp>
-#include <ArborX_DetailsUtils.hpp>
-#include <ArborX_HyperBox.hpp>
-#include <ArborX_LinearBVH.hpp>
 
-#include <Kokkos_Core.hpp>
-#include <Kokkos_Profiling_ProfileSection.hpp>
+#include <Kokkos_Macros.hpp>
 
 namespace ArborX::Details
 {

--- a/src/details/ArborX_DetailsWeightedEdge.hpp
+++ b/src/details/ArborX_DetailsWeightedEdge.hpp
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_WEIGHTED_EDGE_HPP
+#define ARBORX_DETAILS_WEIGHTED_EDGE_HPP
+
+#include <ArborX_AccessTraits.hpp>
+#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
+#include <ArborX_DetailsMutualReachabilityDistance.hpp>
+#include <ArborX_DetailsTreeNodeLabeling.hpp>
+#include <ArborX_DetailsUtils.hpp>
+#include <ArborX_HyperBox.hpp>
+#include <ArborX_LinearBVH.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Profiling_ProfileSection.hpp>
+
+namespace ArborX::Details
+{
+
+struct WeightedEdge
+{
+  int source;
+  int target;
+  float weight;
+
+private:
+  // performs lexicographical comparison by comparing first the weights and then
+  // the unordered pair of vertices
+  friend KOKKOS_FUNCTION constexpr bool operator<(WeightedEdge const &lhs,
+                                                  WeightedEdge const &rhs)
+  {
+    if (lhs.weight != rhs.weight)
+    {
+      return (lhs.weight < rhs.weight);
+    }
+    using KokkosExt::min;
+    auto const lhs_min = min(lhs.source, lhs.target);
+    auto const rhs_min = min(rhs.source, rhs.target);
+    if (lhs_min != rhs_min)
+    {
+      return (lhs_min < rhs_min);
+    }
+    using KokkosExt::max;
+    auto const lhs_max = max(lhs.source, lhs.target);
+    auto const rhs_max = max(rhs.source, rhs.target);
+    return (lhs_max < rhs_max);
+  }
+};
+
+} // namespace ArborX::Details
+
+#endif

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -19,46 +19,15 @@
 #include <ArborX_DetailsMutualReachabilityDistance.hpp>
 #include <ArborX_DetailsTreeNodeLabeling.hpp>
 #include <ArborX_DetailsUtils.hpp>
+#include <ArborX_DetailsWeightedEdge.hpp>
 #include <ArborX_HyperBox.hpp>
 #include <ArborX_LinearBVH.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ProfileSection.hpp>
 
-namespace ArborX
+namespace ArborX::Details
 {
-namespace Details
-{
-
-struct WeightedEdge
-{
-  int source;
-  int target;
-  float weight;
-
-private:
-  // performs lexicographical comparison by comparing first the weights and then
-  // the unordered pair of vertices
-  friend KOKKOS_FUNCTION constexpr bool operator<(WeightedEdge const &lhs,
-                                                  WeightedEdge const &rhs)
-  {
-    if (lhs.weight != rhs.weight)
-    {
-      return (lhs.weight < rhs.weight);
-    }
-    using KokkosExt::min;
-    auto const lhs_min = min(lhs.source, lhs.target);
-    auto const rhs_min = min(rhs.source, rhs.target);
-    if (lhs_min != rhs_min)
-    {
-      return (lhs_min < rhs_min);
-    }
-    using KokkosExt::max;
-    auto const lhs_max = max(lhs.source, lhs.target);
-    auto const rhs_max = max(rhs.source, rhs.target);
-    return (lhs_max < rhs_max);
-  }
-};
 
 class DirectedEdge
 {
@@ -751,7 +720,6 @@ private:
   }
 };
 
-} // namespace Details
-} // namespace ArborX
+} // namespace ArborX::Details
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,7 +169,7 @@ target_compile_definitions(ArborX_Test_DetailsCrsGraphWrapperImpl.exe PRIVATE BO
 target_include_directories(ArborX_Test_DetailsCrsGraphWrapperImpl.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME ArborX_Test_DetailsCrsGraphWrapperImpl COMMAND ./ArborX_Test_DetailsCrsGraphWrapperImpl.exe)
 
-add_executable(ArborX_Test_Clustering.exe tstDBSCAN.cpp utf_main.cpp)
+add_executable(ArborX_Test_Clustering.exe tstDBSCAN.cpp tstDendrogram.cpp utf_main.cpp)
 target_link_libraries(ArborX_Test_Clustering.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_Test_Clustering.exe PRIVATE BOOST_TEST_DYN_LINK)
 target_include_directories(ArborX_Test_Clustering.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/benchmarks/dbscan)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,7 +169,11 @@ target_compile_definitions(ArborX_Test_DetailsCrsGraphWrapperImpl.exe PRIVATE BO
 target_include_directories(ArborX_Test_DetailsCrsGraphWrapperImpl.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME ArborX_Test_DetailsCrsGraphWrapperImpl COMMAND ./ArborX_Test_DetailsCrsGraphWrapperImpl.exe)
 
-add_executable(ArborX_Test_Clustering.exe tstDBSCAN.cpp tstDendrogram.cpp utf_main.cpp)
+add_executable(ArborX_Test_Clustering.exe
+  tstDBSCAN.cpp
+  tstDendrogram.cpp
+  utf_main.cpp
+)
 target_link_libraries(ArborX_Test_Clustering.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_Test_Clustering.exe PRIVATE BOOST_TEST_DYN_LINK)
 target_include_directories(ArborX_Test_Clustering.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/benchmarks/dbscan)

--- a/test/tstDendrogram.cpp
+++ b/test/tstDendrogram.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_SUITE(Dendrogram)
 
 using ArborX::Details::WeightedEdge;
 
-namespace Test
+namespace
 {
 
 template <class ExecutionSpace>
@@ -39,10 +39,10 @@ auto build_dendrogram(ExecutionSpace const &exec_space,
   return parents_host;
 }
 
-} // namespace Test
+} // namespace
 
 #define ARBORX_TEST_DENDROGRAM(exec_space, edges, ref)                         \
-  BOOST_TEST(Test::build_dendrogram(exec_space, edges) == ref,                 \
+  BOOST_TEST(build_dendrogram(exec_space, edges) == ref,                       \
              boost::test_tools::per_element());
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(dendrogram_union_find, DeviceType,

--- a/test/tstDendrogram.cpp
+++ b/test/tstDendrogram.cpp
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#include "ArborXTest_StdVectorToKokkosView.hpp"
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include "ArborX_EnableViewComparison.hpp"
+#include <ArborX_Dendrogram.hpp>
+#include <ArborX_DetailsWeightedEdge.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(Dendrogram)
+
+using ArborX::Details::WeightedEdge;
+
+namespace Test
+{
+
+template <class ExecutionSpace>
+auto build_dendrogram(ExecutionSpace const &exec_space,
+                      std::vector<WeightedEdge> const &edges_host)
+{
+  using ArborXTest::toView;
+  auto edges = toView<ExecutionSpace>(edges_host, "Test::edges");
+
+  using MemorySpace = typename ExecutionSpace::memory_space;
+  ArborX::Experimental::Dendrogram<MemorySpace> dendrogram{exec_space, edges};
+
+  auto parents_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                          dendrogram._parents);
+  return parents_host;
+}
+
+} // namespace Test
+
+#define ARBORX_TEST_DENDROGRAM(exec_space, edges, ref)                         \
+  BOOST_TEST(Test::build_dendrogram(exec_space, edges) == ref,                 \
+             boost::test_tools::per_element());
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(dendrogram_union_find, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using ArborX::Details::WeightedEdge;
+
+  ExecutionSpace space;
+
+  // --0--
+  // |   |
+  // 0   1
+  ARBORX_TEST_DENDROGRAM(space, (std::vector<WeightedEdge>{{0, 1, 3.f}}),
+                         (std::vector<int>{-1, 0, 0}));
+
+  //      ----0---
+  //      |      |
+  //   ---1---   |
+  //   |     |   |
+  // --2--   |   |
+  // |   |   |   |
+  // 0   1   2   3
+  ARBORX_TEST_DENDROGRAM(
+      space, (std::vector<WeightedEdge>{{0, 3, 7.f}, {1, 2, 3.f}, {0, 1, 2.f}}),
+      (std::vector<int>{-1, 0, 1, 2, 2, 1, 0}));
+
+  //   ----1----
+  //   |       |
+  // --2--   --0--
+  // |   |   |   |
+  // 0   1   2   3
+  ARBORX_TEST_DENDROGRAM(
+      space, (std::vector<WeightedEdge>{{2, 3, 2.f}, {2, 0, 9.f}, {0, 1, 3.f}}),
+      (std::vector<int>{1, -1, 1, 2, 2, 0, 0}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR introduced dendrogram construction. Dendrogram is a binary tree on $n$ vertices. We store this tree as a set of parents of size $2n-1$, with the first $n-1$ corresponding to internal nodes, and last $n$ to the original vertices.

This PR also does two additional changes:
- Move out `WeightedEdge` out of the minimum spanning tree header