### PR TITLE
Fix a bug when using distributed tree with rays

### DIFF
--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -435,6 +435,11 @@ void DistributedTreeImpl<DeviceType>::reassessStrategy(
           farthest_distances(i) = max(farthest_distances(i), distances(j));
       });
 
+  Details::check_valid_access_traits(
+      PredicatesTag{},
+      WithinDistanceFromPredicates<Predicates, decltype(farthest_distances)>{
+          queries, farthest_distances});
+
   query(top_tree, space,
         WithinDistanceFromPredicates<Predicates, decltype(farthest_distances)>{
             queries, farthest_distances},

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -71,8 +71,8 @@ struct AccessTraits<
     return Access::size(x.predicates);
   }
   template <class Dummy = Geometry,
-            std::enable_if_t<std::is_same<Dummy, Geometry>::value &&
-                             std::is_same<Dummy, Point>::value> * = nullptr>
+            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                             std::is_same_v<Dummy, Point>> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
     auto const point = getGeometry(Access::get(x.predicates, i));
@@ -80,8 +80,8 @@ struct AccessTraits<
     return intersects(Sphere{point, distance});
   }
   template <class Dummy = Geometry,
-            std::enable_if_t<std::is_same<Dummy, Geometry>::value &&
-                             std::is_same<Dummy, Box>::value> * = nullptr>
+            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                             std::is_same_v<Dummy, Box>> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
     auto box = getGeometry(Access::get(x.predicates, i));
@@ -96,18 +96,18 @@ struct AccessTraits<
     return intersects(box);
   }
   template <class Dummy = Geometry,
-            std::enable_if_t<std::is_same<Dummy, Geometry>::value &&
-                             std::is_same<Dummy, Sphere>::value> * = nullptr>
+            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                             std::is_same_v<Dummy, Sphere>> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
     auto const sphere = getGeometry(Access::get(x.predicates, i));
     auto const distance = x.distances(i);
     return intersects(Sphere{sphere.centroid(), distance + sphere.radius()});
   }
-  template <class Dummy = Geometry,
-            std::enable_if_t<std::is_same<Dummy, Geometry>::value &&
-                             std::is_same<Dummy, Experimental::Ray>::value> * =
-                nullptr>
+  template <
+      class Dummy = Geometry,
+      std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                       std::is_same_v<Dummy, Experimental::Ray>> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
     auto const ray = getGeometry(Access::get(x.predicates, i));

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -22,6 +22,7 @@
 #include <ArborX_DetailsUtils.hpp>
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_Predicates.hpp>
+#include <ArborX_Ray.hpp>
 #include <ArborX_Sphere.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -102,6 +103,15 @@ struct AccessTraits<
     auto const sphere = getGeometry(Access::get(x.predicates, i));
     auto const distance = x.distances(i);
     return intersects(Sphere{sphere.centroid(), distance + sphere.radius()});
+  }
+  template <class Dummy = Geometry,
+            std::enable_if_t<std::is_same<Dummy, Geometry>::value &&
+                             std::is_same<Dummy, Experimental::Ray>::value> * =
+                nullptr>
+  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
+  {
+    auto const ray = getGeometry(Access::get(x.predicates, i));
+    return intersects(ray);
   }
 };
 

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -835,10 +835,9 @@ private:
   Kokkos::View<ArborX::Experimental::Ray *, MemorySpace> _rays;
 };
 
-namespace ArborX
-{
 template <typename MemorySpace>
-struct AccessTraits<RayNearestPredicate<MemorySpace>, PredicatesTag>
+struct ArborX::AccessTraits<RayNearestPredicate<MemorySpace>,
+                            ArborX::PredicatesTag>
 {
   using memory_space = MemorySpace;
 
@@ -854,7 +853,6 @@ struct AccessTraits<RayNearestPredicate<MemorySpace>, PredicatesTag>
     return nearest(ray_nearest.get(i), 1);
   }
 };
-} // namespace ArborX
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(distributed_ray, DeviceType, ARBORX_DEVICE_TYPES)
 {
@@ -904,16 +902,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(distributed_ray, DeviceType, ARBORX_DEVICE_TYPES)
         }
       });
 
-  if (comm_rank > 0)
-  {
-    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, RayNearestPredicate(rays),
-                           make_reference_solution<PairIndexRank>(
-                               {{0, comm_rank}, {0, 0}}, {0, 1, 2}));
-  }
-  else
-  {
-    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, RayNearestPredicate(rays),
-                           make_reference_solution<PairIndexRank>(
-                               {{0, comm_rank}, {0, comm_rank}}, {0, 1, 2}));
-  }
+  ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, RayNearestPredicate(rays),
+                         make_reference_solution<PairIndexRank>(
+                             {{0, comm_rank}, {0, 0}}, {0, 1, 2}));
 }


### PR DESCRIPTION
There is a problem when using `Ray` and `DistributedTree` together; we don't define a `get` function when the `Geometry` is a  `Ray`. This PR fixes the bug and add a test. I've also added a call to `Details::check_valid_access_traits` to make sure that  the `Predicate` we create make sense. Without it the error message is really obscure (you get an error about `Kokkos::nonesuch`...)