### PR TITLE
Fix Style check in CI

### DIFF
--- a/docker/Dockerfile.clang-format
+++ b/docker/Dockerfile.clang-format
@@ -2,6 +2,7 @@ ARG BASE=ubuntu:18.04
 FROM $BASE
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+        git \
         wget \
         xz-utils \
         && \

--- a/scripts/check_format_cpp.sh
+++ b/scripts/check_format_cpp.sh
@@ -57,6 +57,12 @@ if [ $verbose -eq 0 ]; then
     exec &>/dev/null
 fi
 
+if ! command -v git &> /dev/null
+then
+    echo "git not found"
+    exit 1
+fi
+
 cpp_source_files=$(git ls-files | grep -E "\.hpp$|\.cpp$|\.h$|\.c$" | grep -v -f .clang-format-ignore)
 
 unformatted_files=()

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -240,9 +240,9 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
   ARBORX_ASSERT(core_min_size >= 2);
 
 #ifdef KOKKOS_ENABLE_SERIAL
-  using UnionFind =
-      Details::UnionFind<MemorySpace,
-                         /*DoSerial=*/std::is_same_v<ExecutionSpace, Kokkos::Serial>>;
+  using UnionFind = Details::UnionFind<
+      MemorySpace,
+      /*DoSerial=*/std::is_same_v<ExecutionSpace, Kokkos::Serial>>;
 #else
   using UnionFind = Details::UnionFind<MemorySpace>;
 #endif
@@ -365,8 +365,8 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
              num_dense_cells + num_points_in_sparse_cells);
     }
 
-    Details::unionFindWithinEachDenseCell(
-        exec_space, dense_sorted_cell_indices, permute, UnionFind{labels});
+    Details::unionFindWithinEachDenseCell(exec_space, dense_sorted_cell_indices,
+                                          permute, UnionFind{labels});
 
     Kokkos::Profiling::popRegion();
 

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -185,11 +185,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
   }
   else
   {
-    ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree,
-                           makeIntersectsSphereQueries<DeviceType>({
-                               {{{(float)comm_rank, 0.f, 0.f}}, (float)comm_size},
-                           }),
-                           make_reference_solution<PairIndexRank>({}, {0, 0}));
+    ARBORX_TEST_QUERY_TREE(
+        ExecutionSpace{}, tree,
+        makeIntersectsSphereQueries<DeviceType>({
+            {{{(float)comm_rank, 0.f, 0.f}}, (float)comm_size},
+        }),
+        make_reference_solution<PairIndexRank>({}, {0, 0}));
   }
 
   // All ranks but rank 0 have a single query with a nearest predicate


### PR DESCRIPTION
The container for the Style did not have `git` installed. This resulted in the formatting script getting an empty set of cpp files, not performing any checks, and always passing.