### PR TITLE
Fix warnings in release mode

### DIFF
--- a/src/details/ArborX_DetailsHeap.hpp
+++ b/src/details/ArborX_DetailsHeap.hpp
@@ -60,11 +60,12 @@ KOKKOS_INLINE_FUNCTION void pushHeap(RandomIterator first, RandomIterator last,
   using DistanceType =
       typename std::iterator_traits<RandomIterator>::difference_type;
   using ValueType = typename std::iterator_traits<RandomIterator>::value_type;
-  if (last - first > 1)
+  auto const n = last - first;
+  if (n > 1)
   {
-    ValueType value = std::move(*(last - 1));
-    bubbleUp(first, DistanceType((last - first) - 1), DistanceType(0),
-             std::move(value), comp);
+    ValueType value = std::move(*(first + n - 1));
+    bubbleUp(first, DistanceType(n - 1), DistanceType(0), std::move(value),
+             comp);
   }
 }
 
@@ -97,12 +98,13 @@ KOKKOS_INLINE_FUNCTION void popHeap(RandomIterator first, RandomIterator last,
   using DistanceType =
       typename std::iterator_traits<RandomIterator>::difference_type;
   using ValueType = typename std::iterator_traits<RandomIterator>::value_type;
-  if (last - first > 1)
+  auto const n = last - first;
+  if (n > 1)
   {
     ValueType value = std::move(*first);
-    bubbleDown(first, DistanceType(0), DistanceType((last - first) - 1),
-               std::move(*(last - 1)), comp);
-    *(last - 1) = std::move(value);
+    bubbleDown(first, DistanceType(0), DistanceType(n - 1),
+               std::move(*(first + n - 1)), comp);
+    *(first + n - 1) = std::move(value);
   }
 }
 

--- a/test/tstMinimumSpanningTreeGoldenTest.cpp
+++ b/test/tstMinimumSpanningTreeGoldenTest.cpp
@@ -62,14 +62,14 @@ auto parseEdgesFromCSVFile(std::string const &filename)
   std::fstream fin(filename, std::ios::in);
   using Tokenizer = boost::tokenizer<boost::escaped_list_separator<char>>;
   std::string line;
-  std::vector<ArborX::Details::WeightedEdge> edges;
+  std::vector<Test::UndirectedEdge> edges;
   assert(fin.is_open());
   while (std::getline(fin, line))
   {
     Tokenizer tok(line);
     auto first = tok.begin();
     auto const last = tok.end();
-    edges.emplace_back(ArborX::Details::WeightedEdge{
+    edges.emplace_back(Test::UndirectedEdge{
         std::stoi(*first++), std::stoi(*first++), std::stof(*first++)});
     assert(first == last);
   }
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(minimum_spanning_tree_golden_test, DeviceType,
   std::sort(edges.data(), edges.data() + edges.size());
 
   BOOST_TEST(
-      reinterpret_cast<std::vector<Test::UndirectedEdge> const &>(edges_ref) ==
+      edges_ref ==
           (Kokkos::View<Test::UndirectedEdge const *, Kokkos::HostSpace>(
               reinterpret_cast<Test::UndirectedEdge const *>(edges.data()),
               edges.size())),


### PR DESCRIPTION
I get warnings when compiling ArborX in release mode with g++ 11.2. I don't get any warnings in debug mode. The first commit is pretty uncontroversial, I am not sure if we want the second one. It looks like a false positive.