### PR TITLE
Fix return type in PermutedData with no attachment

### DIFF
--- a/src/details/ArborX_DetailsPermutedData.hpp
+++ b/src/details/ArborX_DetailsPermutedData.hpp
@@ -54,8 +54,9 @@ struct AccessTraits<Details::PermutedData<Predicates, Permute, AttachIndices>,
   }
 
   template <bool _Attach = AttachIndices>
-  KOKKOS_FUNCTION static auto get(PermutedPredicates const &permuted_predicates,
-                                  std::enable_if_t<!_Attach, std::size_t> index)
+  KOKKOS_FUNCTION static decltype(auto)
+  get(PermutedPredicates const &permuted_predicates,
+      std::enable_if_t<!_Attach, std::size_t> index)
   {
     auto const permuted_index = permuted_predicates._permute(index);
     return NativeAccess::get(permuted_predicates._data, permuted_index);


### PR DESCRIPTION
Right now, we unconditionally create an unnecessary copy of a query when using `PermutedData`. If the queries don't require attachments (for example, when using a pure callback), this unnecessarily creates a copy.