### PR TITLE
Switch host in HIP testing from Serial to OpenMP

### DIFF
--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -91,7 +91,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 # Install Kokkos
 ARG KOKKOS_VERSION=3.6.00
 ARG KOKKOS_ARCH=Kokkos_ARCH_VEGA906
-ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -D${KOKKOS_ARCH}=ON"
+ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_OPENMP=ON -D${KOKKOS_ARCH}=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
     KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \


### PR DESCRIPTION
While working on #788, an issue came up. `hipcc` does not follow OpenMP standard and does not define `_OPENMP` (see [here](https://github.com/ROCm-Developer-Tools/HIP/blob/develop/docs/markdown/hip_faq.md#why-_openmp-is-undefined-when-compiling-with--fopenmp)). So I think it would make sense to test OpenMP instead of Serial in the HIP build to catch related issues.

I chose to make the change inside the docker container and not inside of `.jenkins` as we only have one build running using that container, and I did not want to split Kokkos argument in two places.