### PR TITLE
Fix incorrect profiling region naming in CrsGraph

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -238,22 +238,23 @@ void BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::query(
   Details::check_valid_callback(callback, predicates);
 
   using Tag = typename Details::AccessTraitsHelper<Access>::tag;
-  std::string profiling_prefix = "ArborX::BVH::query";
-  if (std::is_same<Tag, Details::SpatialPredicateTag>{})
+  std::string profiling_prefix = "ArborX::BVH::query::";
+  if constexpr (std::is_same_v<Tag, Details::SpatialPredicateTag>)
   {
-    profiling_prefix += "::spatial";
+    profiling_prefix += "spatial";
   }
-  else if (std::is_same<Tag, Details::NearestPredicateTag>{})
+  else if constexpr (std::is_same_v<Tag, Details::NearestPredicateTag>)
   {
-    profiling_prefix += "::nearest";
+    profiling_prefix += "nearest";
   }
-  else if (std::is_same<Tag, Experimental::OrderedSpatialPredicateTag>{})
+  else if constexpr (std::is_same_v<Tag,
+                                    Experimental::OrderedSpatialPredicateTag>)
   {
-    profiling_prefix += "::ordered_spatial";
+    profiling_prefix += "ordered_spatial";
   }
   else
   {
-    Kokkos::abort("ArborX: implementation bug");
+    static_assert(std::is_void_v<Tag>, "ArborX implementation bug");
   }
 
   Kokkos::Profiling::pushRegion(profiling_prefix);

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -373,9 +373,24 @@ queryDispatch(Tag, Tree const &tree, ExecutionSpace const &space,
 
   check_valid_callback(callback, predicates, out);
 
-  auto profiling_prefix =
-      std::string("ArborX::CrsGraphWrapper::query::") +
-      (std::is_same<Tag, SpatialPredicateTag>{} ? "spatial" : "nearest");
+  std::string profiling_prefix = "ArborX::CrsGraphWrapper::query::";
+  if constexpr (std::is_same_v<Tag, SpatialPredicateTag>)
+  {
+    profiling_prefix += "spatial";
+  }
+  else if constexpr (std::is_same_v<Tag,
+                                    Experimental::OrderedSpatialPredicateTag>)
+  {
+    profiling_prefix += "ordered_spatial";
+  }
+  else if constexpr (std::is_same_v<Tag, NearestPredicateTag>)
+  {
+    profiling_prefix += "nearest";
+  }
+  else
+  {
+    static_assert(std::is_void_v<Tag>, "ArborX implementation bug");
+  }
 
   Kokkos::Profiling::pushRegion(profiling_prefix);
 


### PR DESCRIPTION
When running ordered traversals with `CrsGraph`, it incorrectly printed `nearest` instead of `ordered_traversal` as a profiling region.

Drive-by change to use `constexpr` when labeling in `BVH`.