### PR TITLE
Require benchmark 1.5.4, update nightly containers to Ubuntu 22.04

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
   extends: .LoadModules
   stage: buildDependencies
   script:
-    - git clone https://github.com/google/benchmark.git -b v1.4.1 &&
+    - git clone https://github.com/google/benchmark.git -b v1.6.0 &&
       cd benchmark &&
       git clone https://github.com/google/googletest.git -b release-1.8.1 &&
       mkdir build && cd build &&

--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -8,10 +8,10 @@ pipeline {
 
         stage('Build') {
             parallel {
-                stage('CUDA-11.4.2') {
+                stage('CUDA-11.7.1') {
                     agent {
                         docker {
-                            image 'nvidia/cuda:11.4.2-devel-ubuntu20.04'
+                            image 'nvidia/cuda:11.7.1-devel-ubuntu22.04'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
                     }
@@ -47,10 +47,10 @@ pipeline {
                         }
                     }
                 }
-                stage('ROCm-5.2') {
+                stage('ROCm-5.4') {
                     agent {
                         docker {
-                            image 'rocm/dev-ubuntu-20.04:5.2-complete'
+                            image 'rocm/dev-ubuntu-22.04:5.4-complete'
                             label 'AMD_Radeon_Instinct_MI100 && rocm-docker'
                             args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES}'
                         }

--- a/benchmarks/bvh_driver/CMakeLists.txt
+++ b/benchmarks/bvh_driver/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(POINT_CLOUDS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/benchmarks/point_clouds)
 set(UNIT_TESTS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/test)
 
-# We require version 1.4.0 or higher but the format used by Google benchmark is
-# wrong and thus, we cannot check the version during the configuration step.
-find_package(benchmark REQUIRED)
+find_package(benchmark 1.5.4 REQUIRED)
+message(STATUS "Found benchmark: ${benchmark_DIR} (version \"${benchmark_VERSION}\")")
 
 find_package(Threads REQUIRED)
 

--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -219,12 +219,8 @@ void BM_construction(benchmark::State &state, Spec const &spec)
     std::chrono::duration<double> elapsed_seconds = end - start;
     state.SetIterationTime(elapsed_seconds.count());
   }
-  // In Benchmark 1.5.0, it could be rewritten as
-  //   state.counters["rate"] = benchmark::Counter(
-  //     spec.n_values, benchmark::Counter::kIsIterationInvariantRate);
-  // Benchmark 1.4 does not support kIsIterationInvariantRate, however.
   state.counters["rate"] = benchmark::Counter(
-      spec.n_values * state.iterations(), benchmark::Counter::kIsRate);
+      spec.n_values, benchmark::Counter::kIsIterationInvariantRate);
 }
 
 template <typename ExecutionSpace, class TreeType>
@@ -260,7 +256,7 @@ void BM_radius_search(benchmark::State &state, Spec const &spec)
     state.SetIterationTime(elapsed_seconds.count());
   }
   state.counters["rate"] = benchmark::Counter(
-      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
+      spec.n_queries, benchmark::Counter::kIsIterationInvariantRate);
 }
 
 template <typename ExecutionSpace, class TreeType>
@@ -298,7 +294,7 @@ void BM_radius_callback_search(benchmark::State &state, Spec const &spec)
     state.SetIterationTime(elapsed_seconds.count());
   }
   state.counters["rate"] = benchmark::Counter(
-      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
+      spec.n_queries, benchmark::Counter::kIsIterationInvariantRate);
 }
 
 template <typename ExecutionSpace, class TreeType>
@@ -333,7 +329,7 @@ void BM_knn_search(benchmark::State &state, Spec const &spec)
     state.SetIterationTime(elapsed_seconds.count());
   }
   state.counters["rate"] = benchmark::Counter(
-      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
+      spec.n_queries, benchmark::Counter::kIsIterationInvariantRate);
 }
 
 template <typename ExecutionSpace, class TreeType>
@@ -370,7 +366,7 @@ void BM_knn_callback_search(benchmark::State &state, Spec const &spec)
     state.SetIterationTime(elapsed_seconds.count());
   }
   state.counters["rate"] = benchmark::Counter(
-      spec.n_queries * state.iterations(), benchmark::Counter::kIsRate);
+      spec.n_queries, benchmark::Counter::kIsIterationInvariantRate);
 }
 
 template <typename ExecutionSpace, typename TreeType>

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -110,7 +110,7 @@ RUN BOOST_VERSION=1.72.0 && \
 # Install Google Benchmark support library
 ENV BENCHMARK_DIR=/opt/benchmark
 RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
-    git clone https://github.com/google/benchmark.git -b v1.5.0 && \
+    git clone https://github.com/google/benchmark.git -b v1.5.4 && \
     cd benchmark && \
     mkdir build && cd build && \
     cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} -D BENCHMARK_ENABLE_TESTING=OFF .. && \


### PR DESCRIPTION
- Require benchmark 1.5.4
- Update our BVH benchmark to use new rate feature
- Update nightly containers to Ubuntu 22.04 

Still no way to require specific version of the benchmark in CMake, though. The main reason for the PR is to not propagate this rate issue to other benchmarks, such as union-find.