### PR TITLE
Do not bother with downloading GTest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,6 @@ stages:
   script:
     - git clone https://github.com/google/benchmark.git -b v1.4.1 &&
       cd benchmark &&
-      git clone https://github.com/google/googletest.git -b release-1.8.1 &&
       mkdir build && cd build &&
       cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/ccsopen/proj/csc333/benchmark.install .. &&
       make && make install


### PR DESCRIPTION
Fix https://github.com/arborx/ArborX/pull/799#discussion_r1058338594

It is only needed when building the Google benchmark unit tests which we don't do as we properly configure with `-DBENCHMARK_ENABLE_TESTING=OFF`