### PR TITLE
Annotate fences

### DIFF
--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -156,7 +156,8 @@ DistributedTree<MemorySpace, Enable>::DistributedTree(
 #ifdef ARBORX_USE_CUDA_AWARE_MPI
   Kokkos::deep_copy(space, Kokkos::subview(boxes, comm_rank),
                     _bottom_tree.bounds());
-  space.fence();
+  space.fence("ArborX::DistributedTree::DistributedTree"
+              " (fill on device done before MPI_Allgather)");
 
   MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
                 static_cast<void *>(boxes.data()), sizeof(Box), MPI_BYTE,

--- a/src/details/ArborX_DetailsDendrogram.hpp
+++ b/src/details/ArborX_DetailsDendrogram.hpp
@@ -57,7 +57,8 @@ void dendrogramUnionFindHost(Edges sorted_edges_host, Parents &parents_host)
   Kokkos::deep_copy(host_space, set_edges_host, UNDEFINED);
 
   // Fence all execution spaces to make sure all the data is ready
-  Kokkos::fence();
+  Kokkos::fence("ArborX::Dendrogram::dendrogramUnionFindHost"
+                " (global fence before performing union-find on host)");
 
   Kokkos::Profiling::pushRegion(
       "ArborX::Dendrogram::dendrogram_union_find::union_find");

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -345,7 +345,8 @@ public:
 
     // make sure the data in dest_buffer has been copied before sending it.
     if (permutation_necessary)
-      space.fence();
+      space.fence("ArborX::Distributor::doPostsAndWaits"
+                  " (permute done before packing data into send buffer)");
 
     for (int i = 0; i < outdegrees; ++i)
     {

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtViewHelpers.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtViewHelpers.hpp
@@ -38,7 +38,7 @@ lastElement(ExecutionSpace const &space, Kokkos::View<T, P...> const &v)
   auto v_subview = Kokkos::subview(v, n - 1);
   auto v_host = Kokkos::create_mirror_view(v_subview); // FIXME
   Kokkos::deep_copy(space, v_host, v_subview);
-  space.fence();
+  space.fence("ArborX::KokkosExt::lastElement (copy to host)");
   return v_host();
 }
 


### PR DESCRIPTION
Just like we annotate kernels, we should annotate our fences.
The `std::string` label argument is available since Kokkos 3.5