### PR TITLE
Move Google benchmark detection to the common CMakeLists.txt

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,8 @@
 find_package(Boost 1.56.0 REQUIRED COMPONENTS program_options)
 
+find_package(benchmark 1.5.4 REQUIRED)
+message(STATUS "Found benchmark: ${benchmark_DIR} (version \"${benchmark_VERSION}\")")
+
 add_subdirectory(brute_force_vs_bvh)
 add_subdirectory(bvh_driver)
 add_subdirectory(dbscan)

--- a/benchmarks/bvh_driver/CMakeLists.txt
+++ b/benchmarks/bvh_driver/CMakeLists.txt
@@ -1,9 +1,6 @@
 set(POINT_CLOUDS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/benchmarks/point_clouds)
 set(UNIT_TESTS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/test)
 
-find_package(benchmark 1.5.4 REQUIRED)
-message(STATUS "Found benchmark: ${benchmark_DIR} (version \"${benchmark_VERSION}\")")
-
 find_package(Threads REQUIRED)
 
 add_executable(ArborX_Benchmark_BoundingVolumeHierarchy.exe bvh_driver.cpp)


### PR DESCRIPTION
As we introduce more benchmarks that use Google Benchmark, it makes sense to move it to the common file.