### PR TITLE
Attempt to get rid of `find_package(Threads)` in BVH benchmark

### DIFF
--- a/benchmarks/bvh_driver/CMakeLists.txt
+++ b/benchmarks/bvh_driver/CMakeLists.txt
@@ -4,10 +4,8 @@ set(UNIT_TESTS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/test)
 find_package(benchmark 1.5.4 REQUIRED)
 message(STATUS "Found benchmark: ${benchmark_DIR} (version \"${benchmark_VERSION}\")")
 
-find_package(Threads REQUIRED)
-
 add_executable(ArborX_Benchmark_BoundingVolumeHierarchy.exe bvh_driver.cpp)
-target_link_libraries(ArborX_Benchmark_BoundingVolumeHierarchy.exe ArborX::ArborX benchmark::benchmark Boost::program_options Threads::Threads)
+target_link_libraries(ArborX_Benchmark_BoundingVolumeHierarchy.exe ArborX::ArborX benchmark::benchmark Boost::program_options)
 target_include_directories(ArborX_Benchmark_BoundingVolumeHierarchy.exe PRIVATE ${POINT_CLOUDS_INCLUDE_DIR} ${UNIT_TESTS_INCLUDE_DIR})
 add_test(NAME ArborX_Benchmark_BoundingVolumeHierarchy COMMAND ./ArborX_Benchmark_BoundingVolumeHierarchy.exe --buffer=0 --benchmark_color=true)
 if(ARBORX_PERFORMANCE_TESTING)


### PR DESCRIPTION
See https://github.com/arborx/ArborX/pull/806#pullrequestreview-1232499529