### PR TITLE
Add specialized "half" tree traversal for spatial predicates

### DIFF
--- a/src/details/ArborX_DetailsHalfTraversal.hpp
+++ b/src/details/ArborX_DetailsHalfTraversal.hpp
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_HALF_TRAVERSAL_HPP
+#define ARBORX_DETAILS_HALF_TRAVERSAL_HPP
+
+#include <ArborX_DetailsHappyTreeFriends.hpp>
+#include <ArborX_DetailsNode.hpp> // ROPE_SENTINEL
+
+namespace ArborX::Details
+{
+
+template <class BVH, class Callback, class PredicateGetter>
+struct HalfTraversal
+{
+  BVH _bvh;
+  PredicateGetter _get_predicate;
+  Callback _callback;
+
+  template <class ExecutionSpace>
+  HalfTraversal(ExecutionSpace const &space, BVH const &bvh,
+                Callback const &callback, PredicateGetter const &getter)
+      : _bvh{bvh}
+      , _get_predicate{getter}
+      , _callback{callback}
+  {
+    if (_bvh.empty())
+    {
+      // do nothing
+    }
+    else if (_bvh.size() == 1)
+    {
+      // do nothing either
+    }
+    else
+    {
+      auto const n = _bvh.size();
+      Kokkos::parallel_for(
+          "ArborX::Experimental::HalfTraversal",
+          Kokkos::RangePolicy<ExecutionSpace>(space, n - 1, 2 * n - 1), *this);
+    }
+  }
+
+  KOKKOS_FUNCTION void operator()(int i) const
+  {
+    auto const predicate =
+        _get_predicate(HappyTreeFriends::getBoundingVolume(_bvh, i));
+    auto const leaf_permutation_i =
+        HappyTreeFriends::getLeafPermutationIndex(_bvh, i);
+
+    int node = HappyTreeFriends::getRope(_bvh, i);
+    while (node != ROPE_SENTINEL)
+    {
+      if (predicate(HappyTreeFriends::getBoundingVolume(_bvh, node)))
+      {
+        if (!HappyTreeFriends::isLeaf(_bvh, node))
+        {
+          node = HappyTreeFriends::getLeftChild(_bvh, node);
+        }
+        else
+        {
+          _callback(leaf_permutation_i,
+                    HappyTreeFriends::getLeafPermutationIndex(_bvh, node));
+          node = HappyTreeFriends::getRope(_bvh, node);
+        }
+      }
+      else
+      {
+        node = HappyTreeFriends::getRope(_bvh, node);
+      }
+    }
+  }
+};
+
+} // namespace ArborX::Details
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -203,6 +203,15 @@ target_compile_definitions(ArborX_Test_DetailsClusteringHelpers.exe PRIVATE BOOS
 target_include_directories(ArborX_Test_DetailsClusteringHelpers.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME ArborX_Test_DetailsClusteringHelpers COMMAND ./ArborX_Test_DetailsClusteringHelpers.exe)
 
+add_executable(ArborX_Test_SpecializedTraversals.exe
+  tstDetailsHalfTraversal.cpp
+  utf_main.cpp
+)
+target_link_libraries(ArborX_Test_SpecializedTraversals.exe PRIVATE ArborX Boost::unit_test_framework)
+target_compile_definitions(ArborX_Test_SpecializedTraversals.exe PRIVATE BOOST_TEST_DYN_LINK)
+target_include_directories(ArborX_Test_SpecializedTraversals.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME ArborX_Test_SpecializedTraversals COMMAND ./ArborX_Test_SpecializedTraversals.exe)
+
 if(ARBORX_ENABLE_MPI)
   add_executable(ArborX_Test_DistributedTree.exe tstDistributedTree.cpp tstKokkosToolsDistributedAnnotations.cpp utf_main.cpp)
   target_link_libraries(ArborX_Test_DistributedTree.exe PRIVATE ArborX Boost::unit_test_framework)

--- a/test/tstDetailsHalfTraversal.cpp
+++ b/test/tstDetailsHalfTraversal.cpp
@@ -1,0 +1,105 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborXTest_StdVectorToKokkosView.hpp"
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include "ArborX_EnableViewComparison.hpp"
+#include <ArborX_DetailsHalfTraversal.hpp>
+#include <ArborX_LinearBVH.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+namespace Test
+{
+template <class ExecutionSpace>
+Kokkos::View<ArborX::Point *, ExecutionSpace>
+make_points(ExecutionSpace const &space, int n)
+{
+  Kokkos::View<ArborX::Point *, ExecutionSpace> points(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, "Test::points"),
+      n);
+
+  Kokkos::parallel_for(
+      "Test::make_points", Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),
+      KOKKOS_LAMBDA(int i) {
+        points(i) = {(float)i, (float)i, (float)i};
+      });
+
+  return points;
+}
+
+// Workaround NVCC's extended lambda restrictions
+struct AlwaysTrue
+{
+  template <class ValueType>
+  KOKKOS_FUNCTION bool operator()(ValueType const &) const
+  {
+    return true;
+  }
+};
+
+struct PredicateGetter
+{
+  template <class ValueType>
+  KOKKOS_FUNCTION AlwaysTrue operator()(ValueType) const
+  {
+    return {};
+  }
+};
+} // namespace Test
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(half_traversal, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using MemorySpace = typename DeviceType::memory_space;
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace exec_space;
+  int const n = 24;
+  auto points = Test::make_points(exec_space, n);
+  ArborX::BVH<MemorySpace> bvh(exec_space, points);
+
+  Kokkos::View<int *, MemorySpace> count("Test::count", n * (n + 1) / 2);
+
+  //    [0][1][2]...[j][i].........[n]
+  // [0] 0
+  // [1] 1  0
+  // [2] 1  1  0
+  // ... 1  1  1  0       i*(i+1)/2+i
+  // ... 1  1  1  1  0   /
+  // [i] 1  1  1  1  1  0
+  // ... 1  1  1    /
+  // ... 1  1  1   i*(i+1)/2+j
+  // ... 1  1  1
+  // [n] 1  1  1  1  1  1  1  1  1  0
+
+  using ArborX::Details::HalfTraversal;
+  HalfTraversal(
+      exec_space, bvh,
+      KOKKOS_LAMBDA(int i, int j) {
+#if KOKKOS_VERSION >= 30700
+        auto [min_ij, max_ij] = Kokkos::minmax(i, j);
+#else
+        auto [min_ij, max_ij] = Kokkos::Experimental::minmax(i, j);
+#endif
+        Kokkos::atomic_increment(&count(max_ij * (max_ij + 1) / 2 + min_ij));
+      },
+      Test::PredicateGetter{});
+
+  std::vector<int> count_ref(n * (n + 1) / 2, 1);
+  for (int i = 0; i < n; ++i)
+  {
+    count_ref[i * (i + 1) / 2 + i] = 0;
+  }
+
+  BOOST_TEST(count_ref == Kokkos::create_mirror_view_and_copy(
+                              Kokkos::HostSpace{}, count),
+             boost::test_tools::per_element());
+}


### PR DESCRIPTION
Per https://github.com/arborx/ArborX/pull/801#issuecomment-1368134410

Fix #409.