### PR TITLE
Add new facility to find "half" or "full" neighbor lists

### DIFF
--- a/src/details/ArborX_NeighborList.hpp
+++ b/src/details/ArborX_NeighborList.hpp
@@ -1,0 +1,149 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_NEIGHBOR_LIST_HPP
+#define ARBORX_NEIGHBOR_LIST_HPP
+
+#include <ArborX_DetailsHalfTraversal.hpp>
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp> // reallocWithoutInitializing
+#include <ArborX_DetailsUtils.hpp>                // exclusivePrefixSum
+#include <ArborX_LinearBVH.hpp>
+#include <ArborX_Sphere.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace ArborX::Experimental
+{
+
+struct NeighborListPredicateGetter
+{
+  float _radius;
+
+  KOKKOS_FUNCTION auto operator()(Box b) const
+  {
+    return intersects(Sphere{b.minCorner(), _radius});
+  }
+};
+
+template <class ExecutionSpace, class Primitives, class Offsets, class Indices>
+void findHalfNeighborList(ExecutionSpace const &space,
+                          Primitives const &primitives, float radius,
+                          Offsets &offsets, Indices &indices)
+{
+  Kokkos::Profiling::pushRegion("ArborX::Experimental::HalfNeighborList");
+
+  using Details::HalfTraversal;
+
+  using MemorySpace =
+      typename AccessTraits<Primitives, PrimitivesTag>::memory_space;
+  BVH<MemorySpace> bvh(space, primitives);
+  int const n = bvh.size();
+
+  Kokkos::Profiling::pushRegion(
+      "ArborX::Experimental::HalfNeighborList::Count");
+
+  KokkosExt::reallocWithoutInitializing(space, offsets, n + 1);
+  Kokkos::deep_copy(space, offsets, 0);
+  HalfTraversal(
+      space, bvh,
+      KOKKOS_LAMBDA(int, int j) { Kokkos::atomic_increment(&offsets(j)); },
+      NeighborListPredicateGetter{radius});
+  exclusivePrefixSum(space, offsets);
+  KokkosExt::reallocWithoutInitializing(space, indices,
+                                        KokkosExt::lastElement(space, offsets));
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::pushRegion("ArborX::Experimental::HalfNeighborList::Fill");
+
+  auto counts =
+      KokkosExt::clone(space, Kokkos::subview(offsets, std::make_pair(0, n)),
+                       "ArborX::Experimental::HalfNeighborList::counts");
+  HalfTraversal(
+      space, bvh,
+      KOKKOS_LAMBDA(int i, int j) {
+        indices(Kokkos::atomic_fetch_inc(&counts(j))) = i;
+      },
+      NeighborListPredicateGetter{radius});
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::popRegion();
+}
+
+template <class ExecutionSpace, class Primitives, class Offsets, class Indices>
+void findFullNeighborList(ExecutionSpace const &space,
+                          Primitives const &primitives, float radius,
+                          Offsets &offsets, Indices &indices)
+{
+  Kokkos::Profiling::pushRegion("ArborX::Experimental::FullNeighborList");
+
+  using Details::HalfTraversal;
+
+  using MemorySpace =
+      typename AccessTraits<Primitives, PrimitivesTag>::memory_space;
+  BVH<MemorySpace> bvh(space, primitives);
+  int const n = bvh.size();
+
+  Kokkos::Profiling::pushRegion(
+      "ArborX::Experimental::FullNeighborList::Count");
+
+  KokkosExt::reallocWithoutInitializing(space, offsets, n + 1);
+  Kokkos::deep_copy(space, offsets, 0);
+  HalfTraversal(
+      space, bvh,
+      KOKKOS_LAMBDA(int i, int j) {
+        Kokkos::atomic_increment(&offsets(i));
+        Kokkos::atomic_increment(&offsets(j));
+      },
+      NeighborListPredicateGetter{radius});
+  exclusivePrefixSum(space, offsets);
+  KokkosExt::reallocWithoutInitializing(space, indices,
+                                        KokkosExt::lastElement(space, offsets));
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::pushRegion("ArborX::Experimental::FullNeighborList::Fill");
+
+  auto counts =
+      KokkosExt::clone(space, Kokkos::subview(offsets, std::make_pair(0, n)),
+                       "ArborX::Experimental::FullNeighborList::counts");
+  HalfTraversal(
+      space, bvh,
+      KOKKOS_LAMBDA(int i, int j) {
+        indices(Kokkos::atomic_fetch_inc(&counts(j))) = i;
+      },
+      NeighborListPredicateGetter{radius});
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::pushRegion("ArborX::Experimental::FullNeighborList::Copy");
+
+  auto counts_copy = KokkosExt::clone(space, counts, counts.label() + "_copy");
+  Kokkos::parallel_for(
+      "ArborX::Experimental::FullNeighborList::Copy",
+      Kokkos::TeamPolicy<ExecutionSpace>(space, n, Kokkos::AUTO, 1),
+      KOKKOS_LAMBDA(
+          typename Kokkos::TeamPolicy<ExecutionSpace>::member_type const
+              &member) {
+        auto const i = member.league_rank();
+        auto const first = offsets(i);
+        auto const last = counts_copy(i);
+        Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(member, last - first), [&](int j) {
+              int const k = indices(first + j);
+              indices(Kokkos::atomic_fetch_inc(&counts(k))) = i;
+            });
+      });
+
+  Kokkos::Profiling::popRegion();
+  Kokkos::Profiling::popRegion();
+}
+
+} // namespace ArborX::Experimental
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -206,6 +206,7 @@ add_test(NAME ArborX_Test_DetailsClusteringHelpers COMMAND ./ArborX_Test_Details
 add_executable(ArborX_Test_SpecializedTraversals.exe
   tstDetailsHalfTraversal.cpp
   tstDetailsExpandHalfToFull.cpp
+  tstNeighborList.cpp
   utf_main.cpp
 )
 target_link_libraries(ArborX_Test_SpecializedTraversals.exe PRIVATE ArborX Boost::unit_test_framework)

--- a/test/tstNeighborList.cpp
+++ b/test/tstNeighborList.cpp
@@ -1,0 +1,250 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+// clang-format off
+#include "boost_ext/KokkosPairComparison.hpp"
+#include "boost_ext/TupleComparison.hpp"
+#include "boost_ext/CompressedStorageComparison.hpp"
+// clang-format on
+
+#include "ArborXTest_StdVectorToKokkosView.hpp"
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include "ArborX_EnableViewComparison.hpp"
+#include <ArborX_DetailsExpandHalfToFull.hpp>
+#include <ArborX_NeighborList.hpp>
+
+#include <Kokkos_Random.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+namespace Test
+{
+using ArborXTest::toView;
+
+template <class ExecutionSpace>
+Kokkos::View<ArborX::Point *, ExecutionSpace>
+make_random_cloud(ExecutionSpace const &space, int n)
+{
+  Kokkos::View<ArborX::Point *, ExecutionSpace> points(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, "Test::points"),
+      n);
+  using RandomPool = Kokkos::Random_XorShift64_Pool<ExecutionSpace>;
+  RandomPool random_pool(5374857);
+
+  Kokkos::parallel_for(
+      "Test::generate_random_points",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n), KOKKOS_LAMBDA(int i) {
+        typename RandomPool::generator_type generator = random_pool.get_state();
+        auto const x = generator.frand(0.f, 1.f);
+        auto const y = generator.frand(0.f, 1.f);
+        auto const z = generator.frand(0.f, 1.f);
+        points(i) = {x, y, z};
+        random_pool.free_state(generator);
+      });
+
+  return points;
+}
+
+struct Filter
+{
+  template <class Predicate, class OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Predicate const &predicate, int i,
+                                  OutputFunctor const &out) const
+  {
+    int const j = getData(predicate);
+    if (i < j)
+    {
+      out(i);
+    }
+  }
+};
+
+template <class Points>
+struct RadiusSearch
+{
+  Points points;
+  float radius;
+};
+
+template <class Predicates, class IndexType = int>
+struct AttachIndices
+{
+  Predicates predicates;
+};
+} // namespace Test
+
+template <class Points>
+struct ArborX::AccessTraits<Test::RadiusSearch<Points>, ArborX::PredicatesTag>
+{
+  using Access = AccessTraits<Points, PrimitivesTag>;
+  using Self = Test::RadiusSearch<Points>;
+  using memory_space = typename Access::memory_space;
+  using size_type = decltype(Access::size(std::declval<Points const &>()));
+  static KOKKOS_FUNCTION size_type size(Self const &x)
+  {
+    return Access::size(x.points);
+  }
+  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
+  {
+    return intersects(Sphere{Access::get(x.points, i), x.radius});
+  }
+};
+
+template <class Predicates, class IndexType>
+struct ArborX::AccessTraits<Test::AttachIndices<Predicates, IndexType>,
+                            ArborX::PredicatesTag>
+{
+  using Access = AccessTraits<Predicates, PredicatesTag>;
+  using Self = Test::AttachIndices<Predicates, IndexType>;
+  using memory_space = typename Access::memory_space;
+  using size_type = decltype(Access::size(std::declval<Predicates const &>()));
+  static KOKKOS_FUNCTION size_type size(Self const &x)
+  {
+    return Access::size(x.predicates);
+  }
+  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
+  {
+    return attach(Access::get(x.predicates, i), static_cast<IndexType>(i));
+  }
+};
+
+namespace Test
+{
+
+template <class MemorySpace, class ExecutionSpace, class Points>
+auto compute_reference(ExecutionSpace const &exec_space, Points const &points,
+                       float radius)
+{
+  Kokkos::View<int *, ExecutionSpace> offsets("Test::offsets", 0);
+  Kokkos::View<int *, ExecutionSpace> indices("Test::indices", 0);
+  ArborX::BoundingVolumeHierarchy<MemorySpace> bvh(exec_space, points);
+  RadiusSearch<Points> predicates{points, radius};
+  bvh.query(exec_space, AttachIndices<decltype(predicates)>{predicates},
+            Filter{}, indices, offsets);
+  ArborX::Details::expandHalfToFull(exec_space, offsets, indices);
+  return make_compressed_storage(
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, indices));
+}
+
+template <class ExecutionSpace, class Points>
+auto buildFullNeighborList(ExecutionSpace const &exec_space,
+                           Points const &points, float radius)
+{
+  Kokkos::View<int *, ExecutionSpace> offsets("Test::offsets", 0);
+  Kokkos::View<int *, ExecutionSpace> indices("Test::indices", 0);
+  ArborX::Experimental::findFullNeighborList(exec_space, points, radius,
+                                             offsets, indices);
+  return make_compressed_storage(
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, indices));
+}
+
+template <class ExecutionSpace, class Points>
+auto buildHalfNeighborListAndExpandToFull(ExecutionSpace const &exec_space,
+                                          Points const &points, float radius)
+{
+  Kokkos::View<int *, ExecutionSpace> offsets("Test::offsets", 0);
+  Kokkos::View<int *, ExecutionSpace> indices("Test::indices", 0);
+  ArborX::Experimental::findHalfNeighborList(exec_space, points, radius,
+                                             offsets, indices);
+  ArborX::Details::expandHalfToFull(exec_space, offsets, indices);
+  return make_compressed_storage(
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets),
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, indices));
+}
+
+#define ARBORX_TEST_NEIGHBOR_LIST(exec_space, points, radius, offsets_ref,     \
+                                  indices_ref)                                 \
+  BOOST_TEST(Test::buildFullNeighborList(exec_space, points, radius) ==        \
+                 make_compressed_storage(offsets_ref, indices_ref),            \
+             boost::test_tools::per_element());                                \
+  BOOST_TEST(Test::buildHalfNeighborListAndExpandToFull(exec_space, points,    \
+                                                        radius) ==             \
+                 make_compressed_storage(offsets_ref, indices_ref),            \
+             boost::test_tools::per_element())
+
+} // namespace Test
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(find_neighbor_list_degenerate, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace exec_space;
+
+  auto no_point = ArborXTest::toView<ExecutionSpace>(
+      std::vector<ArborX::Point>{}, "Test::no_point");
+
+  auto single_point = ArborXTest::toView<ExecutionSpace>(
+      std::vector<ArborX::Point>{{0.f, 0.f, 0.f}}, "Test::single_point");
+
+  constexpr auto radius = KokkosExt::ArithmeticTraits::infinity<float>::value;
+
+  ARBORX_TEST_NEIGHBOR_LIST(exec_space, no_point, radius, (std::vector<int>{0}),
+                            (std::vector<int>{}));
+
+  ARBORX_TEST_NEIGHBOR_LIST(exec_space, single_point, radius,
+                            (std::vector<int>{0, 0}), (std::vector<int>{}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(find_neighbor_list, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace exec_space;
+
+  auto points = ArborXTest::toView<ExecutionSpace>(
+      std::vector<ArborX::Point>{
+          {0.f, 0.f, 0.f},
+          {1.f, 1.f, 1.f},
+          {2.f, 2.f, 2.f},
+          {3.f, 3.f, 3.f},
+      },
+      "Test::four_points");
+
+  ARBORX_TEST_NEIGHBOR_LIST(exec_space, points, 1.f,
+                            (std::vector<int>{0, 0, 0, 0, 0}),
+                            (std::vector<int>{}));
+
+  ARBORX_TEST_NEIGHBOR_LIST(exec_space, points, 2.f,
+                            (std::vector<int>{0, 1, 3, 5, 6}),
+                            (std::vector<int>{1, 0, 2, 1, 3, 2}));
+
+  ARBORX_TEST_NEIGHBOR_LIST(exec_space, points, 4.f,
+                            (std::vector<int>{0, 2, 5, 8, 10}),
+                            (std::vector<int>{1, 2, 0, 2, 3, 0, 1, 3, 1, 2}));
+
+  ARBORX_TEST_NEIGHBOR_LIST(
+      exec_space, points, 6.f, (std::vector<int>{0, 3, 6, 9, 12}),
+      (std::vector<int>{1, 2, 3, 0, 2, 3, 0, 1, 3, 0, 1, 2}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    find_neighbor_list_compare_filtered_tree_traversal, DeviceType,
+    ARBORX_DEVICE_TYPES)
+{
+  using MemorySpace = typename DeviceType::memory_space;
+  using ExecutionSpace = typename DeviceType::execution_space;
+  ExecutionSpace exec_space;
+
+  auto points = Test::make_random_cloud(exec_space, 100);
+  auto radius = .3f;
+
+  BOOST_TEST(
+      Test::buildFullNeighborList(exec_space, points, radius) ==
+          Test::compute_reference<MemorySpace>(exec_space, points, radius),
+      boost::test_tools::per_element());
+  BOOST_TEST(
+      Test::buildHalfNeighborListAndExpandToFull(exec_space, points, radius) ==
+          Test::compute_reference<MemorySpace>(exec_space, points, radius),
+      boost::test_tools::per_element());
+}


### PR DESCRIPTION
Base on the new specialized "half" traversal from #808 

For reference, performance on AMD GPU for the MD example
```
BEGIN KOKKOS PROFILING REPORT:
TOTAL TIME: 0.814269 seconds
TOP-DOWN TIME TREE:
<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
===================
|-> 2.78e-01 sec 34.1% 98.1% 0.0% 0.0% 6.48e+01 1 classic [region]
|   |-> 2.72e-01 sec 33.4% 99.3% 0.0% 0.0% 4.04e+01 1 ArborX::query [region]
|   |   |-> 2.72e-01 sec 33.4% 99.3% 0.0% 0.0% 4.04e+01 1 ArborX::CrsGraphWrapper::query::spatial [region]
|   |       |-> 2.70e-01 sec 33.2% 100.0% 0.0% 0.0% 2.96e+01 1 ArborX::CrsGraphWrapper::two_pass [region]
|   |       |   |-> 2.06e-01 sec 25.2% 100.0% 0.0% 0.0% 9.73e+00 1 ArborX::CrsGraphWrapper::two_pass:second_pass [region]
|   |       |   |   |-> 2.05e-01 sec 25.2% 100.0% 0.0% 0.0% 4.87e+00 1 ArborX::BVH::query::spatial [region]
|   |       |   |   |   |-> 2.05e-01 sec 25.2% 100.0% 0.0% ------ 1 ArborX::TreeTraversal::spatial [for]
|   |       |   |-> 6.44e-02 sec 7.9% 100.0% 0.0% 0.0% 1.55e+01 1 ArborX::CrsGraphWrapper::two_pass::first_pass [region]
|   |       |   |   |-> 6.44e-02 sec 7.9% 100.0% 0.0% 0.0% 1.55e+01 1 ArborX::BVH::query::spatial [region]
|   |       |   |       |-> 6.44e-02 sec 7.9% 100.0% 0.0% ------ 1 ArborX::TreeTraversal::spatial [for]
|   |       |-> 1.83e-03 sec 0.2% 7.0% 0.0% 18.1% 1.09e+03 1 ArborX::CrsGraphWrapper::query::spatial::compute_permutation [region]
|   |       |   |-> 1.41e-03 sec 0.2% 3.0% 0.0% 97.0% 7.09e+02 1 ArborX::Sorting [region]
|   |-> 5.51e-03 sec 0.7% 39.5% 0.0% 1.3% 1.27e+03 1 ArborX::BVH::BVH [region]
|       |-> 3.15e-03 sec 0.4% 1.4% 0.0% 0.0% 3.18e+02 1 ArborX::BVH::BVH::sort_linearized_order [region]
|       |   |-> 3.15e-03 sec 0.4% 1.4% 0.0% 98.6% 3.18e+02 1 ArborX::Sorting [region]
|       |-> 2.00e-03 sec 0.2% 95.7% 0.0% 6.3% 2.00e+03 1 ArborX::BVH::BVH::generate_hierarchy [region]
|       |   |-> 1.82e-03 sec 0.2% 100.0% 0.0% ------ 1 ArborX::TreeConstruction::generate_hierarchy [for]
|-> 2.32e-01 sec 28.5% 98.1% 0.0% 0.1% 9.91e+01 1 half+expand [region]
|   |-> 1.66e-01 sec 20.4% 97.8% 0.0% 0.1% 9.01e+01 1 ArborX::Experimental::HalfNeighborList [region]
|   |   |-> 1.15e-01 sec 14.1% 100.0% 0.0% 0.0% 1.74e+01 1 ArborX::Experimental::HalfNeighborList::Fill [region]
|   |   |   |-> 1.15e-01 sec 14.1% 100.0% 0.0% ------ 1 ArborX::Experimental::HalfTraversal [for]
|   |   |-> 4.59e-02 sec 5.6% 99.3% 0.0% 0.7% 1.31e+02 1 ArborX::Experimental::HalfNeighborList::Count [region]
|   |   |   |-> 4.32e-02 sec 5.3% 100.0% 0.0% ------ 1 ArborX::Experimental::HalfTraversal [for]
|   |   |   |-> 2.29e-03 sec 0.3% 100.0% 0.0% ------ 1 ArborX::Algorithms::exclusive_scan [scan]
|   |   |-> 5.47e-03 sec 0.7% 40.1% 0.0% 1.3% 1.28e+03 1 ArborX::BVH::BVH [region]
|   |       |-> 3.09e-03 sec 0.4% 1.3% 0.0% 0.1% 3.24e+02 1 ArborX::BVH::BVH::sort_linearized_order [region]
|   |       |   |-> 3.09e-03 sec 0.4% 1.3% 0.0% 98.7% 3.24e+02 1 ArborX::Sorting [region]
|   |       |-> 2.01e-03 sec 0.2% 95.8% 0.0% 6.4% 1.99e+03 1 ArborX::BVH::BVH::generate_hierarchy [region]
|   |       |   |-> 1.82e-03 sec 0.2% 100.0% 0.0% ------ 1 ArborX::TreeConstruction::generate_hierarchy [for]
|   |-> 6.53e-02 sec 8.0% 99.5% 0.0% 0.5% 1.07e+02 1 ArborX::Experimental::HalfToFull [region]
|   |   |-> 4.33e-02 sec 5.3% 100.0% 0.0% ------ 1 ArborX::Experimental::HalfToFull::rewrite [for]
|   |   |-> 2.15e-02 sec 2.6% 100.0% 0.0% ------ 1 ArborX::Experimental::HalfToFull::count [for]
|-> 2.25e-01 sec 27.6% 98.4% 0.0% 0.1% 8.00e+01 1 full [region]
|   |-> 2.25e-01 sec 27.6% 98.4% 0.0% 0.0% 7.56e+01 1 ArborX::Experimental::FullNeighborList [region]
|   |   |-> 1.15e-01 sec 14.1% 100.0% 0.0% 0.0% 1.74e+01 1 ArborX::Experimental::FullNeighborList::Fill [region]
|   |   |   |-> 1.15e-01 sec 14.1% 100.0% 0.0% ------ 1 ArborX::Experimental::HalfTraversal [for]
|   |   |-> 7.32e-02 sec 9.0% 99.8% 0.0% 0.2% 9.56e+01 1 ArborX::Experimental::FullNeighborList::Count [region]
|   |   |   |-> 7.28e-02 sec 8.9% 100.0% 0.0% ------ 1 ArborX::Experimental::HalfTraversal [for]
|   |   |-> 3.12e-02 sec 3.8% 100.0% 0.0% ------ 1 ArborX::Experimental::FullNeighborList::Copy [for]
|   |   |-> 5.40e-03 sec 0.7% 40.0% 0.0% 1.3% 1.30e+03 1 ArborX::BVH::BVH [region]
|   |       |-> 3.07e-03 sec 0.4% 1.4% 0.0% 0.1% 3.25e+02 1 ArborX::BVH::BVH::sort_linearized_order [region]
|   |       |   |-> 3.07e-03 sec 0.4% 1.4% 0.0% 98.6% 3.26e+02 1 ArborX::Sorting [region]
|   |       |-> 1.96e-03 sec 0.2% 96.5% 0.0% 5.6% 2.04e+03 1 ArborX::BVH::BVH::generate_hierarchy [region]
|   |       |   |-> 1.80e-03 sec 0.2% 100.0% 0.0% ------ 1 ArborX::TreeConstruction::generate_hierarchy [for]
|-> 3.72e-02 sec 4.6% 100.0% 0.0% ------ 1 Example::compute_potential_energy [reduce]
|-> 3.38e-02 sec 4.2% 100.0% 0.0% ------ 1 Example::compute_forces [for]
|-> 7.53e-03 sec 0.9% 68.3% 0.0% 31.7% 7.97e+02 1 Example::setup [region]
|   |-> 4.16e-03 sec 0.5% 100.0% 0.0% ------ 1 Example::make_particles [for]