### PR TITLE
Take optional label argument in `KokkosExt::clone[WithoutInitializingNorCopying]`

### DIFF
--- a/src/details/ArborX_DetailsExpandHalfToFull.hpp
+++ b/src/details/ArborX_DetailsExpandHalfToFull.hpp
@@ -46,7 +46,8 @@ void expandHalfToFull(ExecutionSpace const &space, Offsets &offsets,
   auto const m = KokkosExt::lastElement(space, offsets);
   KokkosExt::reallocWithoutInitializing(space, indices, m);
 
-  auto counts = KokkosExt::clone(space, offsets);
+  auto counts = KokkosExt::clone(space, offsets,
+                                 "ArborX::Experimental::HalfToFull::counts");
   Kokkos::parallel_for(
       "ArborX::Experimental::HalfToFull::rewrite",
       Kokkos::TeamPolicy<ExecutionSpace>(space, n, Kokkos::AUTO, 1),

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtViewHelpers.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtViewHelpers.hpp
@@ -84,26 +84,41 @@ void reallocWithoutInitializing(ExecutionSpace const &space, View &v,
 }
 
 template <class ExecutionSpace, class View>
-typename View::non_const_type clone(ExecutionSpace const &space, View &v)
+typename View::non_const_type clone(ExecutionSpace const &space, View const &v,
+                                    std::string const &label)
 {
   static_assert(Kokkos::is_execution_space<ExecutionSpace>::value);
   static_assert(Kokkos::is_view<View>::value);
   typename View::non_const_type w(
-      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, v.label()),
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label),
       v.layout());
   Kokkos::deep_copy(space, w, v);
   return w;
 }
 
 template <class ExecutionSpace, class View>
+typename View::non_const_type clone(ExecutionSpace const &space, View const &v)
+{
+  return clone(space, v, v.label());
+}
+
+template <class ExecutionSpace, class View>
 typename View::non_const_type
-cloneWithoutInitializingNorCopying(ExecutionSpace const &space, View &v)
+cloneWithoutInitializingNorCopying(ExecutionSpace const &space, View const &v,
+                                   std::string const &label)
 {
   static_assert(Kokkos::is_execution_space<ExecutionSpace>::value);
   static_assert(Kokkos::is_view<View>::value);
   return typename View::non_const_type(
-      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, v.label()),
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label),
       v.layout());
+}
+
+template <class ExecutionSpace, class View>
+typename View::non_const_type
+cloneWithoutInitializingNorCopying(ExecutionSpace const &space, View const &v)
+{
+  return cloneWithoutInitializingNorCopying(space, v, v.label());
 }
 
 } // namespace KokkosExt


### PR DESCRIPTION
From #812 
Essentially avoid creating temp views that duplicate labels from user-provided view and prefer giving them a meaningful name with the proper `ArborX::` prefix.
There might be more places where we can use it.  I only applied where I knew on top of my head it was needed.