### PR TITLE
Fix warning on CUDA

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -60,10 +60,11 @@ struct WithinRadiusGetter
 {
   float _r;
 
-  template <typename Box,
-            typename Enable = std::enable_if_t<GeometryTraits::is_box<Box>{}>>
+  template <typename Box>
   KOKKOS_FUNCTION auto operator()(Box const &box) const
   {
+    static_assert(GeometryTraits::is_box<Box>::value);
+
     constexpr int dim = GeometryTraits::dimension_v<Box>;
     auto const &hyper_point =
         reinterpret_cast<ExperimentalHyperGeometry::Point<dim> const &>(

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -60,11 +60,10 @@ struct WithinRadiusGetter
 {
   float _r;
 
-  template <typename Box>
+  template <typename Box,
+            typename Enable = std::enable_if_t<GeometryTraits::is_box<Box>{}>>
   KOKKOS_FUNCTION auto operator()(Box const &box) const
   {
-    static_assert(GeometryTraits::is_box<Box>{});
-
     constexpr int dim = GeometryTraits::dimension_v<Box>;
     auto const &hyper_point =
         reinterpret_cast<ExperimentalHyperGeometry::Point<dim> const &>(


### PR DESCRIPTION
```
<snip>/arborx/src/ArborX_DBSCAN.hpp(66):
warning #20013-D: calling a constexpr __host__ function("operator __nv_bool") from a
__host__ __device__ function("operator()") is not allowed.
The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
```