### PR TITLE
Do not use size_t for permutation indices in Node

### DIFF
--- a/src/details/ArborX_DetailsNode.hpp
+++ b/src/details/ArborX_DetailsNode.hpp
@@ -44,7 +44,7 @@ struct NodeWithLeftChildAndRope
     return left_child <= 0;
   }
 
-  KOKKOS_INLINE_FUNCTION constexpr std::size_t
+  KOKKOS_INLINE_FUNCTION constexpr unsigned
   getLeafPermutationIndex() const noexcept
   {
     assert(isLeaf());
@@ -65,7 +65,7 @@ struct NodeWithLeftChildAndRope
 
 template <class BoundingVolume>
 KOKKOS_INLINE_FUNCTION constexpr NodeWithLeftChildAndRope<BoundingVolume>
-makeLeafNode(std::size_t permutation_index,
+makeLeafNode(unsigned permutation_index,
              BoundingVolume bounding_volume) noexcept
 {
   return {-static_cast<int>(permutation_index), ROPE_SENTINEL,


### PR DESCRIPTION
Lets not lie to ourselves that we support `size_t` here. We only support `unsigned`. 

I was hoping to also see some performance improvements for some backends, as `size_t` may be 8 bytes, but we already do an implicit case from `size_t` to `int` in the kNN when we define `PairIndexDistance` to be `Kokkos::pair<int, float>;`. The Ascent benchmark is [here](https://code.ornl.gov/ecpcitest/alexa/-/jobs/1462275).

So, realistically, this PR is mainly about making what's actually being done clearer, and avoid implicit conversion.

Note, that while it is possible to use `size_t` for the permutation indices in the `sortObjects`, it is still lying as we don't store `size_t` inside a `Node`, only `int`. In addition, recent patch hardcoded `unsigned` when using Kokkos in `sortByKey`, so it does not work anyways. I think we would want to remove that template argument.