### PR TITLE
Introduce ArborX::PairIndexRank

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -423,12 +423,11 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   if (comm_rank == 0)
     os << "construction done\n";
 
-  using PairIndexRank = Kokkos::pair<int, int>;
-
   if (perform_knn_search)
   {
     Kokkos::View<int *, DeviceType> offsets("Testing::offsets", 0);
-    Kokkos::View<PairIndexRank *, DeviceType> values("Testing::values", 0);
+    Kokkos::View<ArborX::PairIndexRank *, DeviceType> values("Testing::values",
+                                                             0);
 
     auto knn = time_monitor.getNewTimer("knn");
     MPI_Barrier(comm);
@@ -473,7 +472,8 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     }
 
     Kokkos::View<int *, DeviceType> offsets("Testing::offsets", 0);
-    Kokkos::View<PairIndexRank *, DeviceType> values("Testing::values", 0);
+    Kokkos::View<ArborX::PairIndexRank *, DeviceType> values("Testing::values",
+                                                             0);
 
     auto radius = time_monitor.getNewTimer("radius");
     MPI_Barrier(comm);

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -32,8 +32,30 @@
 namespace ArborX
 {
 
+struct PairIndexRank
+{
+  int index;
+  int rank;
+  friend bool operator==(ArborX::PairIndexRank lhs, ArborX::PairIndexRank rhs)
+  {
+    return lhs.index == rhs.index && lhs.rank == rhs.rank;
+  }
+  friend bool operator<(ArborX::PairIndexRank lhs, ArborX::PairIndexRank rhs)
+  {
+    return lhs.index < rhs.index ||
+           (lhs.index == rhs.index && lhs.rank < rhs.rank);
+  }
+  friend std::ostream &operator<<(std::ostream &stream,
+                                  ArborX::PairIndexRank const &pair)
+  {
+    return stream << '[' << pair.index << ',' << pair.rank << ']';
+  }
+};
+
 namespace Details
 {
+using TupleIndexRankDistance = Kokkos::pair<PairIndexRank, float>;
+
 struct DefaultCallbackWithRank
 {
   int _rank;

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -21,6 +21,7 @@
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsUtils.hpp>
 #include <ArborX_LinearBVH.hpp>
+#include <ArborX_PairIndexRank.hpp>
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Ray.hpp>
 #include <ArborX_Sphere.hpp>
@@ -31,22 +32,6 @@
 
 namespace ArborX
 {
-
-struct PairIndexRank
-{
-  int index;
-  int rank;
-  friend bool operator==(PairIndexRank lhs, PairIndexRank rhs)
-  {
-    return lhs.index == rhs.index && lhs.rank == rhs.rank;
-  }
-  friend bool operator<(PairIndexRank lhs, PairIndexRank rhs)
-  {
-    return lhs.index < rhs.index ||
-           (lhs.index == rhs.index && lhs.rank < rhs.rank);
-  }
-};
-
 namespace Details
 {
 using TupleIndexRankDistance = Kokkos::pair<PairIndexRank, float>;

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -36,19 +36,14 @@ struct PairIndexRank
 {
   int index;
   int rank;
-  friend bool operator==(ArborX::PairIndexRank lhs, ArborX::PairIndexRank rhs)
+  friend bool operator==(PairIndexRank lhs, PairIndexRank rhs)
   {
     return lhs.index == rhs.index && lhs.rank == rhs.rank;
   }
-  friend bool operator<(ArborX::PairIndexRank lhs, ArborX::PairIndexRank rhs)
+  friend bool operator<(PairIndexRank lhs, PairIndexRank rhs)
   {
     return lhs.index < rhs.index ||
            (lhs.index == rhs.index && lhs.rank < rhs.rank);
-  }
-  friend std::ostream &operator<<(std::ostream &stream,
-                                  ArborX::PairIndexRank const &pair)
-  {
-    return stream << '[' << pair.index << ',' << pair.rank << ']';
   }
 };
 

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -34,7 +34,7 @@ namespace ArborX
 {
 namespace Details
 {
-using TupleIndexRankDistance = Kokkos::pair<PairIndexRank, float>;
+using PairIndexRankAndDistance = Kokkos::pair<PairIndexRank, float>;
 
 struct DefaultCallbackWithRank
 {

--- a/src/details/ArborX_PairIndexRank.hpp
+++ b/src/details/ArborX_PairIndexRank.hpp
@@ -31,8 +31,8 @@ private:
   friend KOKKOS_FUNCTION constexpr bool operator<(PairIndexRank lhs,
                                                   PairIndexRank rhs)
   {
-    return lhs.index < rhs.index ||
-           (lhs.index == rhs.index && lhs.rank < rhs.rank);
+    return lhs.rank < rhs.rank ||
+           (lhs.rank == rhs.rank && lhs.index < rhs.index);
   }
 };
 

--- a/src/details/ArborX_PairIndexRank.hpp
+++ b/src/details/ArborX_PairIndexRank.hpp
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_PAIR_INDEX_RANK_HPP
+#define ARBORX_PAIR_INDEX_RANK_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace ArborX
+{
+
+struct PairIndexRank
+{
+  int index;
+  int rank;
+
+private:
+  friend KOKKOS_FUNCTION constexpr bool operator==(PairIndexRank lhs,
+                                                   PairIndexRank rhs)
+  {
+    return lhs.index == rhs.index && lhs.rank == rhs.rank;
+  }
+  friend KOKKOS_FUNCTION constexpr bool operator<(PairIndexRank lhs,
+                                                  PairIndexRank rhs)
+  {
+    return lhs.index < rhs.index ||
+           (lhs.index == rhs.index && lhs.rank < rhs.rank);
+  }
+};
+
+} // namespace ArborX
+
+#endif

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -24,7 +24,7 @@
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Sphere.hpp>
 #ifdef ARBORX_ENABLE_MPI
-#include <ArborX_DistributedTree.hpp> // PairIndexRank
+#include <ArborX_PairIndexRank.hpp>
 #endif
 
 #include <boost/range/adaptors.hpp>
@@ -34,16 +34,6 @@
 
 #ifdef ARBORX_ENABLE_MPI
 #include <mpi.h>
-#endif
-
-#ifdef ARBORX_ENABLE_MPI
-namespace ArborX
-{
-inline std::ostream &operator<<(std::ostream &stream, PairIndexRank const &pair)
-{
-  return stream << '[' << pair.index << ',' << pair.rank << ']';
-}
-} // namespace ArborX
 #endif
 
 namespace BoostRTreeHelpers

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -23,6 +23,9 @@
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Sphere.hpp>
+#ifdef ARBORX_ENABLE_MPI
+#include <ArborX_DistributedTree.hpp> // PairIndexRank
+#endif
 
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/copy.hpp>
@@ -34,7 +37,13 @@
 #endif
 
 #ifdef ARBORX_ENABLE_MPI
-#include <ArborX_DistributedTree.hpp> // PairIndexRank
+namespace ArborX
+{
+inline std::ostream &operator<<(std::ostream &stream, PairIndexRank const &pair)
+{
+  return stream << '[' << pair.index << ',' << pair.rank << ']';
+}
+} // namespace ArborX
 #endif
 
 namespace BoostRTreeHelpers

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -33,6 +33,10 @@
 #include <mpi.h>
 #endif
 
+#ifdef ARBORX_ENABLE_MPI
+#include <ArborX_DistributedTree.hpp> // PairIndexRank
+#endif
+
 namespace BoostRTreeHelpers
 {
 // NOTE: The balancing algorithm does not really matter since the tree is
@@ -208,7 +212,7 @@ performQueries(RTree<Indexable> const &rtree, InputView const &queries)
 #ifdef ARBORX_ENABLE_MPI
 template <typename Indexable, typename InputView,
           typename OutputView1 =
-              Kokkos::View<Kokkos::pair<int, int> *, Kokkos::HostSpace>,
+              Kokkos::View<ArborX::PairIndexRank *, Kokkos::HostSpace>,
           typename OutputView2 = Kokkos::View<int *, Kokkos::HostSpace>>
 static std::tuple<OutputView2, OutputView1>
 performQueries(ParallelRTree<Indexable> const &rtree, InputView const &queries)

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -13,6 +13,7 @@
 #define ARBORX_SEARCH_TEST_HELPERS_HPP
 
 // clang-format off
+#include "boost_ext/ArborXPairIndexRankComparison.hpp"
 #include "boost_ext/KokkosPairComparison.hpp"
 #include "boost_ext/TupleComparison.hpp"
 #include "boost_ext/CompressedStorageComparison.hpp"

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -72,8 +72,12 @@ auto query(ExecutionSpace const &exec_space, Tree const &tree,
            Queries const &queries)
 {
   using memory_space = typename Tree::memory_space;
+#ifdef ARBORX_ENABLE_MPI
   using value_type =
-      std::conditional_t<is_distributed<Tree>{}, Kokkos::pair<int, int>, int>;
+      std::conditional_t<is_distributed<Tree>{}, ArborX::PairIndexRank, int>;
+#else
+  using value_type = int;
+#endif
   Kokkos::View<value_type *, memory_space> values("Testing::values", 0);
   Kokkos::View<int *, memory_space> offsets("Testing::offsets", 0);
   tree.query(exec_space, queries, values, offsets);
@@ -107,19 +111,19 @@ auto query(ExecutionSpace const &exec_space, Tree const &tree,
                  (reference),                                                  \
              boost::test_tools::per_element());
 
+#ifdef ARBORX_ENABLE_MPI
 // Workaround for NVCC that complains that the enclosing parent function
 // (query_with_distance) for an extended __host__ __device__ lambda must not
 // have deduced return type
 template <typename DeviceType, typename ExecutionSpace>
-Kokkos::View<Kokkos::pair<Kokkos::pair<int, int>, float> *, DeviceType>
+Kokkos::View<ArborX::Details::TupleIndexRankDistance *, DeviceType>
 zip(ExecutionSpace const &space, Kokkos::View<int *, DeviceType> indices,
     Kokkos::View<int *, DeviceType> ranks,
     Kokkos::View<float *, DeviceType> distances)
 {
   auto const n = indices.extent(0);
-  Kokkos::View<Kokkos::pair<Kokkos::pair<int, int>, float> *, DeviceType>
-      values(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::values"),
-             n);
+  Kokkos::View<ArborX::Details::TupleIndexRankDistance *, DeviceType> values(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::values"), n);
   Kokkos::parallel_for(
       "ArborX:UnitTestSupport:zip",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, n), KOKKOS_LAMBDA(int i) {
@@ -128,7 +132,6 @@ zip(ExecutionSpace const &space, Kokkos::View<int *, DeviceType> indices,
   return values;
 }
 
-#ifdef ARBORX_ENABLE_MPI
 template <typename ExecutionSpace, typename Tree, typename Queries>
 auto query_with_distance(ExecutionSpace const &exec_space, Tree const &tree,
                          Queries const &queries,

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -117,13 +117,13 @@ auto query(ExecutionSpace const &exec_space, Tree const &tree,
 // (query_with_distance) for an extended __host__ __device__ lambda must not
 // have deduced return type
 template <typename DeviceType, typename ExecutionSpace>
-Kokkos::View<ArborX::Details::TupleIndexRankDistance *, DeviceType>
+Kokkos::View<ArborX::Details::PairIndexRankAndDistance *, DeviceType>
 zip(ExecutionSpace const &space, Kokkos::View<int *, DeviceType> indices,
     Kokkos::View<int *, DeviceType> ranks,
     Kokkos::View<float *, DeviceType> distances)
 {
   auto const n = indices.extent(0);
-  Kokkos::View<ArborX::Details::TupleIndexRankDistance *, DeviceType> values(
+  Kokkos::View<ArborX::Details::PairIndexRankAndDistance *, DeviceType> values(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::values"), n);
   Kokkos::parallel_for(
       "ArborX:UnitTestSupport:zip",

--- a/test/boost_ext/ArborXPairIndexRankComparison.hpp
+++ b/test/boost_ext/ArborXPairIndexRankComparison.hpp
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_BOOST_TEST_ARBORX_PAIR_INDEX_RANK_COMPARISON_HPP
+#define ARBORX_BOOST_TEST_ARBORX_PAIR_INDEX_RANK_COMPARISON_HPP
+
+#include <ArborX_PairIndexRank.hpp>
+
+#include <boost/test/tools/detail/print_helper.hpp>
+
+#include <iostream>
+
+namespace boost::test_tools::tt_detail
+{
+
+template <>
+struct print_log_value<ArborX::PairIndexRank>
+{
+  void operator()(std::ostream &os, ArborX::PairIndexRank const &p)
+  {
+    os << '(' << p.index << ',' << p.rank << ')';
+  }
+};
+
+} // namespace boost::test_tools::tt_detail
+
+#endif

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -28,8 +28,8 @@
 
 namespace tt = boost::test_tools;
 
-using PairIndexRank = Kokkos::pair<int, int>;
-using TupleIndexRankDistance = Kokkos::pair<Kokkos::pair<int, int>, float>;
+using PairIndexRank = ArborX::PairIndexRank;
+using TupleIndexRankDistance = ArborX::Details::TupleIndexRankDistance;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
 {

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -96,11 +96,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   values.reserve(n + 1);
   for (int i = 0; i < n; ++i)
   {
-    values.emplace_back(n - 1 - i, comm_size - 1 - comm_rank);
+    values.push_back({n - 1 - i, comm_size - 1 - comm_rank});
   }
   if (comm_rank > 0)
   {
-    values.emplace_back(0, comm_size - comm_rank);
+    values.push_back({0, comm_size - comm_rank});
     ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, queries,
                            make_reference_solution(values, {0, n + 1}));
   }
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(one_leaf_per_rank, DeviceType,
                                  std::vector<PairIndexRank> values;
                                  values.reserve(comm_size);
                                  for (int i = 0; i < comm_size; ++i)
-                                   values.emplace_back(0, i);
+                                   values.push_back({0, i});
                                  return values;
                                }(),
                                {0, comm_size}));

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -28,8 +28,8 @@
 
 namespace tt = boost::test_tools;
 
-using PairIndexRank = ArborX::PairIndexRank;
-using TupleIndexRankDistance = ArborX::Details::TupleIndexRankDistance;
+using ArborX::PairIndexRank;
+using ArborX::Details::TupleIndexRankDistance;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
 {

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -29,7 +29,7 @@
 namespace tt = boost::test_tools;
 
 using ArborX::PairIndexRank;
-using ArborX::Details::TupleIndexRankDistance;
+using ArborX::Details::PairIndexRankAndDistance;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
 {
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
 
   ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(
       ExecutionSpace{}, tree, makeNearestQueries<DeviceType>({}),
-      make_reference_solution<TupleIndexRankDistance>({}, {0}));
+      make_reference_solution<PairIndexRankAndDistance>({}, {0}));
 
   // Only rank 0 has a couple spatial queries with a spatial predicate
   if (comm_rank == 0)
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(empty_tree, DeviceType, ARBORX_DEVICE_TYPES)
       makeNearestQueries<DeviceType>({
           {{{0., 0., 0.}}, comm_size},
       }),
-      make_reference_solution<TupleIndexRankDistance>({}, {0, 0}));
+      make_reference_solution<PairIndexRankAndDistance>({}, {0, 0}));
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
 
   ARBORX_TEST_QUERY_TREE_WITH_DISTANCE(
       ExecutionSpace{}, tree, makeNearestQueries<DeviceType>({}),
-      make_reference_solution<TupleIndexRankDistance>({}, {0}));
+      make_reference_solution<PairIndexRankAndDistance>({}, {0}));
 
   // Querying for more neighbors than there are leaves in the tree
   ARBORX_TEST_QUERY_TREE(


### PR DESCRIPTION
Alternative to #816.

- Introduce `ArborX::IndexRankPair`
  It does not make sense for users to define their own struct to receive the results of the default call to the distributed query
- Update testing to use it