### PR TITLE
Update the container os for gitlab workflow to Ubuntu 22.04

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Trigger GitLab CI


### PR DESCRIPTION
Warning message from GitHub:
```
The ubuntu-18.04 environment is deprecated, consider switching to
ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details
see https://github.com/actions/virtual-environments/issues/6002
```