### PR TITLE
Move union-find dendrogram sorting to the main struct

### DIFF
--- a/benchmarks/dbscan/dbscan_timpl.hpp
+++ b/benchmarks/dbscan/dbscan_timpl.hpp
@@ -272,7 +272,7 @@ bool ArborXBenchmark::run(ArborXBenchmark::Parameters const &params)
       printf("-- dendrogram       : %10.3f\n",
              ArborX_Benchmark::get_time("ArborX::HDBSCAN::dendrogram"));
       printf("---- edge sort      : %10.3f\n",
-             ArborX_Benchmark::get_time("ArborX::Dendrogram::edge_sort"));
+             ArborX_Benchmark::get_time("ArborX::Dendrogram::sort_edges"));
       printf("total time          : %10.3f\n",
              ArborX_Benchmark::get_time("ArborX::HDBSCAN::total"));
     }

--- a/src/details/ArborX_Dendrogram.hpp
+++ b/src/details/ArborX_Dendrogram.hpp
@@ -48,7 +48,7 @@ struct Dendrogram
         num_edges);
     splitEdges(exec_space, edges, unweighted_edges, _parent_heights);
 
-    Kokkos::Profiling::pushRegion("ArborX::Dendrogram::edge_sort");
+    Kokkos::Profiling::pushRegion("ArborX::Dendrogram::sort_edges");
     KokkosExt::sortByKey(exec_space, _parent_heights, unweighted_edges);
     Kokkos::Profiling::popRegion();
 

--- a/src/details/ArborX_DetailsDendrogram.hpp
+++ b/src/details/ArborX_DetailsDendrogram.hpp
@@ -87,7 +87,7 @@ void dendrogramUnionFindHost(Edges sorted_edges_host, Parents &parents_host)
 template <typename ExecutionSpace, typename MemorySpace>
 void dendrogramUnionFind(
     ExecutionSpace const &exec_space,
-    Kokkos::View<UnweightedEdge const *, MemorySpace> sorted_unweighted_edges,
+    Kokkos::View<UnweightedEdge const *, MemorySpace> sorted_edges,
     Kokkos::View<int *, MemorySpace> &parents)
 {
   Kokkos::Profiling::pushRegion("ArborX::Dendrogram::dendrogram_union_find");
@@ -95,15 +95,15 @@ void dendrogramUnionFind(
   Kokkos::Profiling::pushRegion(
       "ArborX::Dendrogram::dendrogram_union_find::copy_to_host");
 
-  auto sorted_unweighted_edges_host = Kokkos::create_mirror_view_and_copy(
-      Kokkos::HostSpace{}, sorted_unweighted_edges);
+  auto sorted_edges_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, sorted_edges);
   auto parents_host = Kokkos::create_mirror_view(parents);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion(
       "ArborX::Dendrogram::dendrogram_union_find::union_find");
 
-  dendrogramUnionFindHost(sorted_unweighted_edges_host, parents_host);
+  dendrogramUnionFindHost(sorted_edges_host, parents_host);
 
   Kokkos::Profiling::popRegion();
   Kokkos::Profiling::pushRegion(


### PR DESCRIPTION
This is in preparation for integration of the new dendrogram routine.
The sort routine is going to be common for both, so I'm moving it to before the dispatch.
Also, this means that we don't need to pass parents heights to the dendrogram construction, making them weight-agnostic.