### PR TITLE
Use sycl::ext::oneapi::experimenta::printf

### DIFF
--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -47,6 +47,9 @@ bool verifyCorePointsNonnegativeIndex(ExecutionSpace const &exec_space,
         {
 #ifndef __SYCL_DEVICE_ONLY__
           printf("Core point is marked as noise: %d [%d]\n", i, labels(i));
+#else
+          sycl::ext::oneapi::experimental::printf(
+              "Core point is marked as noise: %d [%d]\n", i, labels(i));
 #endif
           update++;
         }
@@ -84,6 +87,11 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
               printf("Connected cores do not belong to the same cluster: "
                      "%d [%d] -> %d [%d]\n",
                      i, labels(i), j, labels(j));
+#else
+              sycl::ext::oneapi::experimental::printf(
+                  "Connected cores do not belong to the same cluster: "
+                  "%d [%d] -> %d [%d]\n",
+                  i, labels(i), j, labels(j));
 #endif
               update++;
             }
@@ -137,6 +145,10 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
 #ifndef __SYCL_DEVICE_ONLY__
             printf("Border point does not belong to a cluster: %d [%d]\n", i,
                    labels(i));
+#else
+            sycl::ext::oneapi::experimental::printf(
+                "Border point does not belong to a cluster: %d [%d]\n", i,
+                labels(i));
 #endif
             update++;
           }
@@ -146,6 +158,9 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
 #ifndef __SYCL_DEVICE_ONLY__
             printf("Noise point does not have index -1: %d [%d]\n", i,
                    labels(i));
+#else
+            sycl::ext::oneapi::experimental::printf(
+                "Noise point does not have index -1: %d [%d]\n", i, labels(i));
 #endif
             update++;
           }

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -45,12 +45,10 @@ bool verifyCorePointsNonnegativeIndex(ExecutionSpace const &exec_space,
         bool self_is_core_point = (offset(i + 1) - offset(i) >= core_min_size);
         if (self_is_core_point && labels(i) < 0)
         {
-#ifndef __SYCL_DEVICE_ONLY__
-          printf("Core point is marked as noise: %d [%d]\n", i, labels(i));
-#else
-          sycl::ext::oneapi::experimental::printf(
-              "Core point is marked as noise: %d [%d]\n", i, labels(i));
+#ifdef __SYCL_DEVICE_ONLY__
+          using sycl::ext::oneapi::experimental::printf;
 #endif
+          printf("Core point is marked as noise: %d [%d]\n", i, labels(i));
           update++;
         }
       },
@@ -83,16 +81,12 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
 
             if (neigh_is_core_point && labels(i) != labels(j))
             {
-#ifndef __SYCL_DEVICE_ONLY__
+#ifdef __SYCL_DEVICE_ONLY__
+              using sycl::ext::oneapi::experimental::printf;
+#endif
               printf("Connected cores do not belong to the same cluster: "
                      "%d [%d] -> %d [%d]\n",
                      i, labels(i), j, labels(j));
-#else
-              sycl::ext::oneapi::experimental::printf(
-                  "Connected cores do not belong to the same cluster: "
-                  "%d [%d] -> %d [%d]\n",
-                  i, labels(i), j, labels(j));
-#endif
               update++;
             }
           }
@@ -142,26 +136,21 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
           // Border point must be connected to a core point
           if (is_border && !have_shared_core)
           {
-#ifndef __SYCL_DEVICE_ONLY__
+#ifdef __SYCL_DEVICE_ONLY__
+            using sycl::ext::oneapi::experimental::printf;
+#endif
             printf("Border point does not belong to a cluster: %d [%d]\n", i,
                    labels(i));
-#else
-            sycl::ext::oneapi::experimental::printf(
-                "Border point does not belong to a cluster: %d [%d]\n", i,
-                labels(i));
-#endif
             update++;
           }
           // Noise points must have index -1
           if (!is_border && labels(i) != -1)
           {
-#ifndef __SYCL_DEVICE_ONLY__
+#ifdef __SYCL_DEVICE_ONLY__
+            using sycl::ext::oneapi::experimental::printf;
+#endif
             printf("Noise point does not have index -1: %d [%d]\n", i,
                    labels(i));
-#else
-            sycl::ext::oneapi::experimental::printf(
-                "Noise point does not have index -1: %d [%d]\n", i, labels(i));
-#endif
             update++;
           }
         }

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -56,12 +56,10 @@ struct PrintfCallback
   KOKKOS_FUNCTION void operator()(Predicate, int primitive,
                                   OutputFunctor const &out) const
   {
-#ifndef __SYCL_DEVICE_ONLY__
-    printf("Found %d from functor\n", primitive);
-#else
-    sycl::ext::oneapi::experimental::printf("Found %d from functor\n",
-                                            primitive);
+#ifdef __SYCL_DEVICE_ONLY__
+    using sycl::ext::oneapi::experimental::printf;
 #endif
+    printf("Found %d from functor\n", primitive);
     out(primitive);
   }
 };
@@ -97,12 +95,10 @@ int main(int argc, char *argv[])
         bvh, ExecutionSpace{}, FirstOctant{},
         KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                       auto /*output_functor*/) {
-#ifndef __SYCL_DEVICE_ONLY__
-          printf("Found %d from generic lambda\n", primitive);
-#else
-          sycl::ext::oneapi::experimental::printf(
-              "Found %d from generic lambda\n", primitive);
+#ifdef __SYCL_DEVICE_ONLY__
+          using sycl::ext::oneapi::experimental::printf;
 #endif
+          printf("Found %d from generic lambda\n", primitive);
         },
         values, offsets);
 #endif
@@ -119,12 +115,10 @@ int main(int argc, char *argv[])
         bvh, ExecutionSpace{}, NearestToOrigin{k},
         KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                       auto /*output_functor*/) {
-#ifndef __SYCL_DEVICE_ONLY__
-          printf("Found %d from generic lambda\n", primitive);
-#else
-          sycl::ext::oneapi::experimental::printf(
-              "Found %d from generic lambda\n", primitive);
+#ifdef __SYCL_DEVICE_ONLY__
+          using sycl::ext::oneapi::experimental::printf;
 #endif
+          printf("Found %d from generic lambda\n", primitive);
         },
         values, offsets);
 #endif
@@ -139,11 +133,10 @@ int main(int argc, char *argv[])
     bvh.query(
         ExecutionSpace{}, FirstOctant{},
         KOKKOS_LAMBDA(auto /*predicate*/, int j) {
-#ifndef __SYCL_DEVICE_ONLY__
-          printf("%d %d %d\n", ++c(), -1, j);
-#else
-          sycl::ext::oneapi::experimental::printf("%d %d %d\n", ++c(), -1, j);
+#ifdef __SYCL_DEVICE_ONLY__
+          using sycl::ext::oneapi::experimental::printf;
 #endif
+          printf("%d %d %d\n", ++c(), -1, j);
         });
 #endif
   }

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -58,6 +58,9 @@ struct PrintfCallback
   {
 #ifndef __SYCL_DEVICE_ONLY__
     printf("Found %d from functor\n", primitive);
+#else
+    sycl::ext::oneapi::experimental::printf("Found %d from functor\n",
+                                            primitive);
 #endif
     out(primitive);
   }
@@ -97,7 +100,8 @@ int main(int argc, char *argv[])
 #ifndef __SYCL_DEVICE_ONLY__
           printf("Found %d from generic lambda\n", primitive);
 #else
-          (void)primitive;
+          sycl::ext::oneapi::experimental::printf(
+              "Found %d from generic lambda\n", primitive);
 #endif
         },
         values, offsets);
@@ -118,7 +122,8 @@ int main(int argc, char *argv[])
 #ifndef __SYCL_DEVICE_ONLY__
           printf("Found %d from generic lambda\n", primitive);
 #else
-          (void)primitive;
+          sycl::ext::oneapi::experimental::printf(
+              "Found %d from generic lambda\n", primitive);
 #endif
         },
         values, offsets);
@@ -137,7 +142,7 @@ int main(int argc, char *argv[])
 #ifndef __SYCL_DEVICE_ONLY__
           printf("%d %d %d\n", ++c(), -1, j);
 #else
-          (void)j;
+          sycl::ext::oneapi::experimental::printf("%d %d %d\n", ++c(), -1, j);
 #endif
         });
 #endif


### PR DESCRIPTION
This avoids some compiler errors on the testbeds that have already been reported.