### PR TITLE
Do not use `View::Rank`, prefer `View::rank`

### DIFF
--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -46,7 +46,7 @@ auto sortObjects(ExecutionSpace const &space, ViewType &view)
 // Helper functions and structs for applyPermutations
 namespace PermuteHelper
 {
-template <class DstViewType, class SrcViewType, int Rank = DstViewType::Rank>
+template <class DstViewType, class SrcViewType, int Rank = DstViewType::rank>
 struct CopyOp;
 
 template <class DstViewType, class SrcViewType>


### PR DESCRIPTION
`View::Rank` just happens to work.  It is not even documented by Kokkos.  (I am considering whether it should be deprecated.)
Use `View::rank` instead (or View::rank() in later Kokkos versions, that is 4.1+)