### PR TITLE
Avoid extra copy when sending across network in sendAcrossNetwork

### DIFF
--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -275,18 +275,32 @@ DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
   auto const &execution_space = space;
 #endif
 
-  auto imports_layout_right =
-      create_layout_right_mirror_view(execution_space, imports);
+  constexpr bool direct_mode = (View::rank == 1);
+
+  auto create_mirror = [](auto const &exec_space, auto const &view) {
+    if constexpr (direct_mode)
+      return Kokkos::create_mirror_view(exec_space, view);
+    else
+      return create_layout_right_mirror_view(exec_space, view);
+  };
+
+  auto imports_mirror = create_mirror(execution_space, imports);
 
   Kokkos::View<NonConstValueType *, MirrorSpace,
                Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-      import_buffer(imports_layout_right.data(), imports_layout_right.size());
+      import_buffer(imports_mirror.data(), imports_mirror.size());
 
   distributor.doPostsAndWaits(space, exports, num_packets, import_buffer);
 
-  auto tmp_view =
-      Kokkos::create_mirror_view_and_copy(space, imports_layout_right);
-  Kokkos::deep_copy(space, imports, tmp_view);
+  if constexpr (direct_mode)
+  {
+    Kokkos::deep_copy(space, imports, imports_mirror);
+  }
+  else
+  {
+    auto tmp_view = Kokkos::create_mirror_view_and_copy(space, imports_mirror);
+    Kokkos::deep_copy(space, imports, tmp_view);
+  }
 
   Kokkos::Profiling::popRegion();
 }


### PR DESCRIPTION
Even for 1D views we were making an extra copy.