### PR TITLE
Rename `create_layout_right_mirror_view{->_no_init}` which does not initialize

### DIFF
--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -276,7 +276,7 @@ DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
 #endif
 
   auto imports_layout_right =
-      create_layout_right_mirror_view(execution_space, imports);
+      create_layout_right_mirror_view_no_init(execution_space, imports);
 
   Kokkos::View<NonConstValueType *, MirrorSpace,
                Kokkos::MemoryTraits<Kokkos::Unmanaged>>

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -284,9 +284,11 @@ DistributedTreeImpl<DeviceType>::sendAcrossNetwork(
 
   distributor.doPostsAndWaits(space, exports, num_packets, import_buffer);
 
-  if constexpr (View::rank == 1 &&
-                !std::is_same_v<typename View::traits::array_layout,
-                                Kokkos::LayoutStride>)
+  constexpr bool can_skip_copy =
+      (View::rank == 1 &&
+       (std::is_same_v<typename View::array_layout, Kokkos::LayoutLeft> ||
+        std::is_same_v<typename View::array_layout, Kokkos::LayoutRight>));
+  if constexpr (can_skip_copy)
   {
     // For 1D non-strided views, we can directly copy to the original location,
     // as layout is the same

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -49,7 +49,7 @@ template <typename View, typename ExecutionSpace>
 inline Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
                     typename ExecutionSpace::memory_space>
 create_layout_right_mirror_view(
-    ExecutionSpace const & /*execution_space*/, View const &src,
+    ExecutionSpace const &space, View const &src,
     typename std::enable_if<!(
         (std::is_same<typename View::traits::array_layout,
                       Kokkos::LayoutRight>::value ||
@@ -63,8 +63,10 @@ create_layout_right_mirror_view(
       internal::PointerDepth<typename View::traits::data_type>::value;
   return Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
                       typename ExecutionSpace::memory_space>(
-      std::string(src.label()).append("_layout_right_mirror"), src.extent(0),
-      pointer_depth > 1 ? src.extent(1) : KOKKOS_INVALID_INDEX,
+      Kokkos::view_alloc(
+          space, Kokkos::WithoutInitializing,
+          std::string(src.label()).append("_layout_right_mirror")),
+      src.extent(0), pointer_depth > 1 ? src.extent(1) : KOKKOS_INVALID_INDEX,
       pointer_depth > 2 ? src.extent(2) : KOKKOS_INVALID_INDEX,
       pointer_depth > 3 ? src.extent(3) : KOKKOS_INVALID_INDEX,
       pointer_depth > 4 ? src.extent(4) : KOKKOS_INVALID_INDEX,

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -52,12 +52,11 @@ create_layout_right_mirror_view(ExecutionSpace const &execution_space,
                                 View const &src)
 {
   constexpr bool has_compatible_layout =
-      (std::is_same_v<typename View::traits::array_layout,
-                      Kokkos::LayoutRight> ||
-       (View::rank == 1 && !std::is_same_v<typename View::traits::array_layout,
-                                           Kokkos::LayoutStride>));
+      (std::is_same_v<typename View::array_layout, Kokkos::LayoutRight> ||
+       (View::rank == 1 &&
+        !std::is_same_v<typename View::array_layout, Kokkos::LayoutStride>));
   constexpr bool has_compatible_memory_space =
-      std::is_same_v<typename View::traits::memory_space,
+      std::is_same_v<typename View::memory_space,
                      typename ExecutionSpace::memory_space>;
 
   if constexpr (has_compatible_layout && has_compatible_memory_space)
@@ -96,12 +95,11 @@ create_layout_right_mirror_view_and_copy(ExecutionSpace const &execution_space,
                                          View const &src)
 {
   constexpr bool has_compatible_layout =
-      (std::is_same_v<typename View::traits::array_layout,
-                      Kokkos::LayoutRight> ||
-       (View::rank == 1 && !std::is_same_v<typename View::traits::array_layout,
-                                           Kokkos::LayoutStride>));
+      (std::is_same_v<typename View::array_layout, Kokkos::LayoutRight> ||
+       (View::rank == 1 &&
+        !std::is_same_v<typename View::array_layout, Kokkos::LayoutStride>));
   constexpr bool has_compatible_memory_space =
-      std::is_same_v<typename View::traits::memory_space,
+      std::is_same_v<typename View::memory_space,
                      typename ExecutionSpace::memory_space>;
 
   if constexpr (has_compatible_layout && has_compatible_memory_space)

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -48,8 +48,8 @@ struct PointerDepth<PointerType[N]>
 template <typename View, typename ExecutionSpace>
 inline Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
                     typename ExecutionSpace::memory_space>
-create_layout_right_mirror_view(ExecutionSpace const &execution_space,
-                                View const &src)
+create_layout_right_mirror_view_no_init(ExecutionSpace const &execution_space,
+                                        View const &src)
 {
   constexpr bool has_compatible_layout =
       (std::is_same_v<typename View::array_layout, Kokkos::LayoutRight> ||
@@ -83,9 +83,9 @@ create_layout_right_mirror_view(ExecutionSpace const &execution_space,
 }
 
 template <typename View>
-inline auto create_layout_right_mirror_view(View const &src)
+inline auto create_layout_right_mirror_view_no_init(View const &src)
 {
-  return create_layout_right_mirror_view(
+  return create_layout_right_mirror_view_no_init(
       typename View::traits::host_mirror_space{}, src);
 }
 

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -91,52 +91,46 @@ inline auto create_layout_right_mirror_view(View const &src)
 }
 
 template <typename View, typename ExecutionSpace>
-inline auto create_layout_right_mirror_view_and_copy(
-    ExecutionSpace const &execution_space, View const &src,
-    typename std::enable_if<!(
-        (std::is_same<typename View::traits::array_layout,
-                      Kokkos::LayoutRight>::value ||
-         (View::rank == 1 && !std::is_same<typename View::traits::array_layout,
-                                           Kokkos::LayoutStride>::value)) &&
-        std::is_same<typename View::traits::memory_space,
-                     typename ExecutionSpace::memory_space>::value)>::type * =
-        0)
+inline auto
+create_layout_right_mirror_view_and_copy(ExecutionSpace const &execution_space,
+                                         View const &src)
 {
-  constexpr int pointer_depth =
-      internal::PointerDepth<typename View::traits::data_type>::value;
-  Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
-               typename ExecutionSpace::memory_space>
-      layout_right_view(
-          Kokkos::view_alloc(
-              execution_space, Kokkos::WithoutInitializing,
-              std::string(src.label()).append("_layout_right_mirror")),
-          src.extent(0),
-          pointer_depth > 1 ? src.extent(1) : KOKKOS_INVALID_INDEX,
-          pointer_depth > 2 ? src.extent(2) : KOKKOS_INVALID_INDEX,
-          pointer_depth > 3 ? src.extent(3) : KOKKOS_INVALID_INDEX,
-          pointer_depth > 4 ? src.extent(4) : KOKKOS_INVALID_INDEX,
-          pointer_depth > 5 ? src.extent(5) : KOKKOS_INVALID_INDEX,
-          pointer_depth > 6 ? src.extent(6) : KOKKOS_INVALID_INDEX,
-          pointer_depth > 7 ? src.extent(7) : KOKKOS_INVALID_INDEX);
-  auto tmp_view = Kokkos::create_mirror_view_and_copy(execution_space, src);
-  // TODO not quite sure wy this can't be execution_space
-  Kokkos::deep_copy(/*execution_space, */ layout_right_view, tmp_view);
-  return layout_right_view;
-}
+  constexpr bool has_compatible_layout =
+      (std::is_same_v<typename View::traits::array_layout,
+                      Kokkos::LayoutRight> ||
+       (View::rank == 1 && !std::is_same_v<typename View::traits::array_layout,
+                                           Kokkos::LayoutStride>));
+  constexpr bool has_compatible_memory_space =
+      std::is_same_v<typename View::traits::memory_space,
+                     typename ExecutionSpace::memory_space>;
 
-template <typename View, typename ExecutionSpace>
-inline auto create_layout_right_mirror_view_and_copy(
-    ExecutionSpace const & /*execution_space*/, View const &src,
-    typename std::enable_if<
-        ((std::is_same<typename View::traits::array_layout,
-                       Kokkos::LayoutRight>::value ||
-          (View::rank == 1 && !std::is_same<typename View::traits::array_layout,
-                                            Kokkos::LayoutStride>::value)) &&
-         std::is_same<typename View::traits::memory_space,
-                      typename ExecutionSpace::memory_space>::value)>::type * =
-        nullptr)
-{
-  return src;
+  if constexpr (has_compatible_layout && has_compatible_memory_space)
+  {
+    return src;
+  }
+  else
+  {
+    constexpr int pointer_depth =
+        internal::PointerDepth<typename View::traits::data_type>::value;
+    Kokkos::View<typename View::traits::data_type, Kokkos::LayoutRight,
+                 typename ExecutionSpace::memory_space>
+        layout_right_view(
+            Kokkos::view_alloc(
+                execution_space, Kokkos::WithoutInitializing,
+                std::string(src.label()).append("_layout_right_mirror")),
+            src.extent(0),
+            pointer_depth > 1 ? src.extent(1) : KOKKOS_INVALID_INDEX,
+            pointer_depth > 2 ? src.extent(2) : KOKKOS_INVALID_INDEX,
+            pointer_depth > 3 ? src.extent(3) : KOKKOS_INVALID_INDEX,
+            pointer_depth > 4 ? src.extent(4) : KOKKOS_INVALID_INDEX,
+            pointer_depth > 5 ? src.extent(5) : KOKKOS_INVALID_INDEX,
+            pointer_depth > 6 ? src.extent(6) : KOKKOS_INVALID_INDEX,
+            pointer_depth > 7 ? src.extent(7) : KOKKOS_INVALID_INDEX);
+    auto tmp_view = Kokkos::create_mirror_view_and_copy(execution_space, src);
+    // TODO not quite sure why this can't be execution_space
+    Kokkos::deep_copy(/*execution_space, */ layout_right_view, tmp_view);
+    return layout_right_view;
+  }
 }
 
 // NOTE: This functor is used in exclusivePrefixSum( src, dst ).  We were

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -54,7 +54,8 @@ create_layout_right_mirror_view_no_init(ExecutionSpace const &execution_space,
   constexpr bool has_compatible_layout =
       (std::is_same_v<typename View::array_layout, Kokkos::LayoutRight> ||
        (View::rank == 1 &&
-        !std::is_same_v<typename View::array_layout, Kokkos::LayoutStride>));
+        (std::is_same_v<typename View::array_layout, Kokkos::LayoutLeft> ||
+         std::is_same_v<typename View::array_layout, Kokkos::LayoutRight>)));
   constexpr bool has_compatible_memory_space =
       std::is_same_v<typename View::memory_space,
                      typename ExecutionSpace::memory_space>;
@@ -97,7 +98,8 @@ create_layout_right_mirror_view_and_copy(ExecutionSpace const &execution_space,
   constexpr bool has_compatible_layout =
       (std::is_same_v<typename View::array_layout, Kokkos::LayoutRight> ||
        (View::rank == 1 &&
-        !std::is_same_v<typename View::array_layout, Kokkos::LayoutStride>));
+        (std::is_same_v<typename View::array_layout, Kokkos::LayoutLeft> ||
+         std::is_same_v<typename View::array_layout, Kokkos::LayoutRight>)));
   constexpr bool has_compatible_memory_space =
       std::is_same_v<typename View::memory_space,
                      typename ExecutionSpace::memory_space>;

--- a/test/tstDetailsDistributedTreeImpl.cpp
+++ b/test/tstDetailsDistributedTreeImpl.cpp
@@ -227,10 +227,10 @@ inline void checkNewViewWasAllocated(View1 const &v1, View2 const &v2)
   BOOST_TEST(v1.extent(7) == v2.extent(7));
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(create_layout_right_mirror_view, DeviceType,
-                              ARBORX_DEVICE_TYPES)
+BOOST_AUTO_TEST_CASE_TEMPLATE(create_layout_right_mirror_view_no_init,
+                              DeviceType, ARBORX_DEVICE_TYPES)
 {
-  using ArborX::Details::create_layout_right_mirror_view;
+  using ArborX::Details::create_layout_right_mirror_view_no_init;
   using Kokkos::ALL;
   using Kokkos::LayoutLeft;
   using Kokkos::LayoutRight;
@@ -244,37 +244,37 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(create_layout_right_mirror_view, DeviceType,
 
   // rank-1 and not strided -> do not allocate
   View<int *, LayoutLeft, DeviceType> u("u", 255);
-  auto u_h = create_layout_right_mirror_view(u);
+  auto u_h = create_layout_right_mirror_view_no_init(u);
   checkViewWasNotAllocated(u, u_h);
 
   // right layout -> do not allocate
   View<int **, LayoutRight, DeviceType> v("v", 2, 3);
-  auto v_h = create_layout_right_mirror_view(v);
+  auto v_h = create_layout_right_mirror_view_no_init(v);
   checkViewWasNotAllocated(v, v_h);
 
   // the same with compile time size
   View<int[2][3], LayoutRight, DeviceType> v_c("v");
-  auto v_c_h = create_layout_right_mirror_view(v_c);
+  auto v_c_h = create_layout_right_mirror_view_no_init(v_c);
   checkViewWasNotAllocated(v_c, v_c_h);
 
   // left layout and rank > 1 -> allocate
   View<int **, LayoutLeft, DeviceType> w("w", 4, 5);
-  auto w_h = create_layout_right_mirror_view(w);
+  auto w_h = create_layout_right_mirror_view_no_init(w);
   checkNewViewWasAllocated(w, w_h);
 
   // the same with compile time size
   View<int *[5], LayoutLeft, DeviceType> w_c("v", 4);
-  auto w_c_h = create_layout_right_mirror_view(w_c);
+  auto w_c_h = create_layout_right_mirror_view_no_init(w_c);
   checkNewViewWasAllocated(w_c, w_c_h);
 
   // strided layout -> allocate
   auto x = subview(v, ALL, 0);
-  auto x_h = create_layout_right_mirror_view(x);
+  auto x_h = create_layout_right_mirror_view_no_init(x);
   checkNewViewWasAllocated(x, x_h);
 
   // subview is rank-1 and not strided -> do not allocate
   auto y = subview(u, make_pair(8, 16));
-  auto y_h = create_layout_right_mirror_view(y);
+  auto y_h = create_layout_right_mirror_view_no_init(y);
   checkViewWasNotAllocated(y, y_h);
 }
 


### PR DESCRIPTION
Creating layout right mirror view is done on the host for the non CUDA-aware MPI, so initialization was also done on the host, potentially slow.

Drive-by changes:
- Reorganize `create_layout_right_mirror_view` and `create_layout_right_mirror_view_and_copy` functions to switch to using constexpr as to not duplicate the logic
- Replace check `!LayoutStrided` by `LayoutLeft || Layout_Right`