### PR TITLE
Drop outdated comment in `expand<Box1, Box2>`

### DIFF
--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -308,9 +308,6 @@ struct expand<BoxTag, KDOPTag, Box, KDOP>
 };
 
 // expand a box to include a box
-// NOTE: we must be able to use expand(box, box) in a
-// Kokkos::parallel_reduce() in which case the arguments must be declared
-// volatile
 template <typename Box1, typename Box2>
 struct expand<BoxTag, BoxTag, Box1, Box2>
 {


### PR DESCRIPTION
It is templated to support different types of boxes, not to avoid adding a volatile overload like in its original form.