### PR TITLE
Make data file sampling portable

### DIFF
--- a/benchmarks/dbscan/data.hpp
+++ b/benchmarks/dbscan/data.hpp
@@ -26,7 +26,11 @@ std::vector<Point<DIM>> sampleData(std::vector<Point<DIM>> const &data,
 {
   std::vector<Point<DIM>> sampled_data(num_samples);
 
-  // Lehmer (or Park-Miller) RNG
+  // We use a hardcoded Lehmer (or Park-Miller) random generator instead of C++
+  // <random> to guarantee sampling reproducibility across platforms and
+  // compilers. The magic numbers are all from the Lehmer algorithm, with the
+  // exception for the state initialization, which is initialized to a positive
+  // number less than modulus.
   assert(num_samples > 1);
   unsigned int state =
       1337 % (num_samples - 1) + 1; // any positive number less than modulus

--- a/benchmarks/dbscan/data.hpp
+++ b/benchmarks/dbscan/data.hpp
@@ -32,9 +32,7 @@ std::vector<Point<DIM>> sampleData(std::vector<Point<DIM>> const &data,
   // exception for the state initialization, which is initialized to a positive
   // number less than modulus.
   assert(num_samples > 1);
-  unsigned int state =
-      1337 % (num_samples - 1) + 1; // any positive number less than modulus
-  auto rand = [&state]() {
+  auto rand = [state = (1337 % (num_samples - 1) + 1)]() mutable {
     state = ((unsigned long long)state * 48271) % 0x7fffffff;
     return state;
   };


### PR DESCRIPTION
Standard does not guarantee portability of `<random>`. While by some luck random engines are portable (except for the `default_random_engine`), `uniform_int_distribution` is not.

The problem is then that when we sample a dataset on different platforms/compilers, we get a different data. It is problematic for reproduciblity.

While it is possible to use something like boost random, I opted instead to use [Lehmer](https://en.wikipedia.org/wiki/Lehmer_random_number_generator) random generator in place, as it is fast, easy to implement, and does what we need.