### PR TITLE
Fix CompressedStorage member functions

### DIFF
--- a/test/boost_ext/CompressedStorageComparison.hpp
+++ b/test/boost_ext/CompressedStorageComparison.hpp
@@ -40,7 +40,7 @@ struct CompressedStorage
       ConstForwardIterator old{*this};
       ++*this;
       return old;
-    };
+    }
     bool operator==(ConstForwardIterator const &o) { return i == o.i; }
     bool operator!=(ConstForwardIterator const &o) { return !(*this == o); }
     value_type operator*()


### PR DESCRIPTION
Found while working on #837.
- `operator==()` and `operator!=()` should return `bool`
- we get a warning for narrowing conversion in `cend()` so be explicit