### PR TITLE
Switch ranges for leaf and internal indices

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -95,7 +95,7 @@ private:
     // Need address of the root node's bounding box to copy it back on the host,
     // but can't access node elements from the constructor since the data is on
     // the device.
-    assert(Details::HappyTreeFriends::getRoot(*this) == (n > 1 ? n : 0) &&
+    assert((n == 1 || Details::HappyTreeFriends::getRoot(*this) == n) &&
            "workaround below assumes root is stored as first element");
     return (n > 1 ? &_internal_nodes.data()->bounding_volume
                   : &_leaf_nodes.data()->bounding_volume);

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -456,7 +456,7 @@ struct CallbackWithDistance
       Kokkos::parallel_for(
           "ArborX::DistributedTree::query::nearest::"
           "compute_reverse_permutation",
-          Kokkos::RangePolicy<ExecutionSpace>(exec_space, n - 1, 2 * n - 1),
+          Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
           ARBORX_CLASS_LAMBDA(int const i) {
             _rev_permute(HappyTreeFriends::getLeafPermutationIndex(_tree, i)) =
                 i;

--- a/src/details/ArborX_DetailsHalfTraversal.hpp
+++ b/src/details/ArborX_DetailsHalfTraversal.hpp
@@ -44,10 +44,9 @@ struct HalfTraversal
     }
     else
     {
-      auto const n = _bvh.size();
       Kokkos::parallel_for(
           "ArborX::Experimental::HalfTraversal",
-          Kokkos::RangePolicy<ExecutionSpace>(space, n - 1, 2 * n - 1), *this);
+          Kokkos::RangePolicy<ExecutionSpace>(space, 0, _bvh.size()), *this);
     }
   }
 

--- a/src/details/ArborX_DetailsHappyTreeFriends.hpp
+++ b/src/details/ArborX_DetailsHappyTreeFriends.hpp
@@ -28,12 +28,14 @@ struct HappyTreeFriends
   template <class BVH>
   static KOKKOS_FUNCTION int getRoot(BVH const &bvh)
   {
-    return (bvh.size() > 1 ? bvh.size() : 0);
+    assert(bvh.size() > 1);
+    return bvh.size();
   }
 
   template <class BVH>
   static KOKKOS_FUNCTION bool isLeaf(BVH const &bvh, int i)
   {
+    assert(bvh.size() > 1);
     assert(i >= 0 && i < 2 * (int)bvh.size() - 1);
     return i < (int)bvh.size();
   }

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -89,17 +89,14 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
   {
     auto const &predicate = Access::get(_predicates, queryIndex);
 
-    int node;
-    int next = HappyTreeFriends::getRoot(_bvh); // start with root
+    int node = HappyTreeFriends::getRoot(_bvh); // start with root
     do
     {
-      node = next;
-
       if (predicate(HappyTreeFriends::getBoundingVolume(_bvh, node)))
       {
         if (!HappyTreeFriends::isLeaf(_bvh, node))
         {
-          next = HappyTreeFriends::getLeftChild(_bvh, node);
+          node = HappyTreeFriends::getLeftChild(_bvh, node);
         }
         else
         {
@@ -107,14 +104,14 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
                   _callback, predicate,
                   HappyTreeFriends::getLeafPermutationIndex(_bvh, node)))
             return;
-          next = HappyTreeFriends::getRope(_bvh, node);
+          node = HappyTreeFriends::getRope(_bvh, node);
         }
       }
       else
       {
-        next = HappyTreeFriends::getRope(_bvh, node);
+        node = HappyTreeFriends::getRope(_bvh, node);
       }
-    } while (next != ROPE_SENTINEL);
+    } while (node != ROPE_SENTINEL);
   }
 };
 

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -76,7 +76,7 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
   KOKKOS_FUNCTION void operator()(OneLeafTree, int queryIndex) const
   {
     auto const &predicate = Access::get(_predicates, queryIndex);
-    auto const root = HappyTreeFriends::getRoot(_bvh);
+    auto const root = 0;
     auto const &root_bounding_volume =
         HappyTreeFriends::getBoundingVolume(_bvh, root);
     if (predicate(root_bounding_volume))
@@ -89,14 +89,17 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
   {
     auto const &predicate = Access::get(_predicates, queryIndex);
 
-    int node = HappyTreeFriends::getRoot(_bvh); // start with root
+    int node;
+    int next = HappyTreeFriends::getRoot(_bvh); // start with root
     do
     {
+      node = next;
+
       if (predicate(HappyTreeFriends::getBoundingVolume(_bvh, node)))
       {
         if (!HappyTreeFriends::isLeaf(_bvh, node))
         {
-          node = HappyTreeFriends::getLeftChild(_bvh, node);
+          next = HappyTreeFriends::getLeftChild(_bvh, node);
         }
         else
         {
@@ -104,14 +107,14 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
                   _callback, predicate,
                   HappyTreeFriends::getLeafPermutationIndex(_bvh, node)))
             return;
-          node = HappyTreeFriends::getRope(_bvh, node);
+          next = HappyTreeFriends::getRope(_bvh, node);
         }
       }
       else
       {
-        node = HappyTreeFriends::getRope(_bvh, node);
+        next = HappyTreeFriends::getRope(_bvh, node);
       }
-    } while (node != ROPE_SENTINEL);
+    } while (next != ROPE_SENTINEL);
   }
 };
 
@@ -421,7 +424,7 @@ struct TreeTraversal<BVH, Predicates, Callback,
   KOKKOS_FUNCTION void operator()(OneLeafTree, int queryIndex) const
   {
     auto const &predicate = Access::get(_predicates, queryIndex);
-    auto const root = HappyTreeFriends::getRoot(_bvh);
+    auto const root = 0;
     auto const &root_bounding_volume =
         HappyTreeFriends::getBoundingVolume(_bvh, root);
     using distance_type =

--- a/src/details/ArborX_DetailsTreeVisualization.hpp
+++ b/src/details/ArborX_DetailsTreeVisualization.hpp
@@ -188,8 +188,7 @@ struct TreeVisualization
                     n);
     Kokkos::parallel_for(
         "ArborX::Viz::compute_permutation",
-        Kokkos::RangePolicy<ExecutionSpace>(space, n - 1, 2 * n - 1),
-        KOKKOS_LAMBDA(int i) {
+        Kokkos::RangePolicy<ExecutionSpace>(space, 0, n), KOKKOS_LAMBDA(int i) {
           permute(HappyTreeFriends::getLeafPermutationIndex(tree, i)) = i;
         });
 

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -164,22 +164,19 @@ void traverse(LeafNodes leaf_nodes, InternalNodes internal_nodes, int root,
   int n = leaf_nodes.extent(0);
 
   using ArborX::Details::ROPE_SENTINEL;
-
-  auto leafIndex = [=](int i) { return i - (n - 1); };
-
   std::function<void(int, std::ostream &)> traverseRopes;
-  traverseRopes = [&leaf_nodes, &internal_nodes, &leafIndex,
+  traverseRopes = [&leaf_nodes, &internal_nodes, &n,
                    &traverseRopes](int node, std::ostream &os) {
-    int leaf_index = leafIndex(node);
-    if (leaf_index >= 0)
+    if (node < n)
     {
-      os << "L" << leaf_index;
-      int rope = leaf_nodes(leaf_index).rope;
+      os << "L" << node;
+      int rope = leaf_nodes(node).rope;
       if (rope != ROPE_SENTINEL)
         traverseRopes(rope, os);
     }
     else
     {
+      node = node - n;
       os << "I" << node;
       traverseRopes(internal_nodes(node).left_child, os);
     }
@@ -241,7 +238,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(example_tree_construction, DeviceType,
   generateHierarchy(primitives, sorted_morton_codes, leaf_nodes,
                     internal_nodes);
 
-  int const root = 0;
+  int const root = n;
 
   std::ostringstream sol;
   traverse(leaf_nodes, internal_nodes, root, sol);

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -165,7 +165,7 @@ void traverse(LeafNodes leaf_nodes, InternalNodes internal_nodes, int root,
 
   using ArborX::Details::ROPE_SENTINEL;
   std::function<void(int, std::ostream &)> traverseRopes;
-  traverseRopes = [&leaf_nodes, &internal_nodes, &n,
+  traverseRopes = [&leaf_nodes, &internal_nodes, n,
                    &traverseRopes](int node, std::ostream &os) {
     if (node < n)
     {

--- a/test/tstDetailsTreeNodeLabeling.cpp
+++ b/test/tstDetailsTreeNodeLabeling.cpp
@@ -30,6 +30,7 @@ struct MockBVH
   ArborX::Details::HappyTreeFriends::getLeftChild<MockBVH<MEMORY_SPACE>>(      \
       MockBVH<MEMORY_SPACE> const &x, int i)                                   \
   {                                                                            \
+    i -= x.size();                                                             \
     return x.children_(i).first;                                               \
   }                                                                            \
   template <>                                                                  \
@@ -37,6 +38,7 @@ struct MockBVH
   ArborX::Details::HappyTreeFriends::getRightChild<MockBVH<MEMORY_SPACE>>(     \
       MockBVH<MEMORY_SPACE> const &x, int i)                                   \
   {                                                                            \
+    i -= x.size();                                                             \
     return x.children_(i).second;                                              \
   }
 
@@ -107,8 +109,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(find_parents, DeviceType, ARBORX_DEVICE_TYPES)
         0   1
   */
   ARBORX_TEST_FIND_PARENTS(exec_space,
-                           (std::vector<Kokkos::pair<int, int>>{{1, 2}}),
-                           (std::vector<int>{-1, 0, 0}));
+                           (std::vector<Kokkos::pair<int, int>>{{0, 1}}),
+                           (std::vector<int>{2, 2, -1}));
   /*
      [0]----*----
            / \
@@ -117,8 +119,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(find_parents, DeviceType, ARBORX_DEVICE_TYPES)
       0   1   2
   */
   ARBORX_TEST_FIND_PARENTS(
-      exec_space, (std::vector<Kokkos::pair<int, int>>{{1, 4}, {2, 3}}),
-      (std::vector<int>{-1, 0, 1, 1, 0}));
+      exec_space, (std::vector<Kokkos::pair<int, int>>{{4, 2}, {0, 1}}),
+      (std::vector<int>{4, 4, 3, -1, 3}));
   /*
      [0]------------*--------------
                    / \
@@ -131,14 +133,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(find_parents, DeviceType, ARBORX_DEVICE_TYPES)
       0   1   2   3   4   5   6   7
   */
   auto const parents =
-      std::vector<int>{-1, 3, 3, 0, 0, 4, 5, 1, 1, 2, 2, 4, 6, 6, 5};
-  //                    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14
-  //                   [0][1][2][3][4][5][6] 0  1  2  3  4  5  6  7
+      std::vector<int>{9, 9, 10, 10, 12, 14, 14, 13, -1, 11, 11, 8, 8, 12, 13};
+  //                   0  1   2   3   4   5   6   7   8   9  10 11 12  13  14
+  //                   0  1   2   3   4   5   6   7, [0] [1] [2][3][4] [5] [6]
 
   auto const children = std::vector<Kokkos::pair<int, int>>{
-      {3, 4}, {7, 8}, {9, 10}, {1, 2}, {11, 5}, {6, 14}, {12, 13}};
-  //  [0]     [1]     [2]      [3]      [4]     [5]       [6]
-  //  [3][4]   0  1    2   3   [1][2]    4 [5]  [6]  7     5   6
+      {11, 12}, {0, 1}, {2, 3}, {9, 10}, {4, 13}, {14, 7}, {5, 6}};
+  //  [0]       [1]     [2]     [3]      [4]      [5]      [6]
+  //  [3] [4]    0  1    2   3  [1][2]    4 [5]   [6]  7    5  6
   ARBORX_TEST_FIND_PARENTS(exec_space, children, parents);
 }
 
@@ -156,32 +158,32 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(reduce_labels, DeviceType, ARBORX_DEVICE_TYPES)
        0   1   2   3   4   5   6   7
   */
   auto const parents =
-      std::vector<int>{-1, 3, 3, 0, 0, 4, 5, 1, 1, 2, 2, 4, 6, 6, 5};
-  //                    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14
-  //                   [0][1][2][3][4][5][6] 0  1  2  3  4  5  6  7
+      std::vector<int>{9, 9, 10, 10, 12, 14, 14, 13, -1, 11, 11, 8, 8, 12, 13};
+  //                   0  1   2   3   4   5   6   7   8   9  10 11 12  13  14
+  //                   0  1   2   3   4   5   6   7, [0] [1] [2][3][4] [5] [6]
 
   using ExecutionSpace = typename DeviceType::execution_space;
   ExecutionSpace exec_space;
 
   ARBORX_TEST_REDUCE_LABELS(
       exec_space, parents,
-      (std::vector<int>{0, 1, 2, 3, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0}),
+      (std::vector<int>{0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6}),
       (std::vector<int>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
   ARBORX_TEST_REDUCE_LABELS(
       exec_space, parents,
-      (std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7}),
+      (std::vector<int>{7, 7, 7, 7, 7, 7, 7, 7, 0, 1, 2, 3, 4, 5, 6}),
       (std::vector<int>{7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7}));
 
   ARBORX_TEST_REDUCE_LABELS(
       exec_space, parents,
-      (std::vector<int>{0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 7}),
-      (std::vector<int>{-1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6, 7}));
+      (std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6}),
+      (std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7, -1, -1, -1, -1, -1, -1, -1}));
 
   ARBORX_TEST_REDUCE_LABELS(
       exec_space, parents,
-      (std::vector<int>{0, 1, 2, 3, 4, 5, 6, 0, 0, 0, 3, 4, 4, 4, 7}),
-      (std::vector<int>{-1, 0, -1, -1, -1, -1, 4, 0, 0, 0, 3, 4, 4, 4, 7}));
+      (std::vector<int>{0, 0, 0, 3, 4, 4, 4, 7, 0, 1, 2, 3, 4, 5, 6}),
+      (std::vector<int>{0, 0, 0, 3, 4, 4, 4, 7, -1, 0, -1, -1, -1, -1, 4}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/tstDetailsTreeNodeLabeling.cpp
+++ b/test/tstDetailsTreeNodeLabeling.cpp
@@ -100,6 +100,8 @@ BOOST_AUTO_TEST_SUITE(TreeNodeLabeling)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(find_parents, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  // Mapping of internal nodes [x] in a diagram to the actual indices depends
+  // on the tree implementation. Currently, [x] -> x + n, where n = #leaves.
 
   using ExecutionSpace = typename DeviceType::execution_space;
   ExecutionSpace exec_space;


### PR DESCRIPTION
This PR makes leaf nodes correspond to $[0, n)$ range, and internal nodes to $[n, 2n-1)$.

While working on #864, I realized that part of the reason why MST is so complex is that because our internal nodes are indexed first, and leaf nodes after. Swapping them around makes the complexity much more manageable by getting rid of all `<blah> - n + 1` calculations. It also aligns better with tree reduction from a given view corresponding to leaf node values.

I see no downside to swapping the ranges around.
