### PR TITLE
CI: Reduce the number of procs used to compiled ArborX

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -306,7 +306,7 @@ pipeline {
                                     -D ARBORX_ENABLE_BENCHMARKS=ON \
                                 ..
                             '''
-                            sh 'make -j6 VERBOSE=1'
+                            sh 'make -j4 VERBOSE=1'
                             sh 'ctest $CTEST_OPTIONS'
                         }
                     }


### PR DESCRIPTION
This should fix the CI issue we have gcc. The maximum amount of memory per process that we need is 3.4 GB (in benchmark). Since most of the programs in benchmark are light, we can afford to use `make -j 4`.