### PR TITLE
Remove Enable template parameter from BasicBoundingVolumeHierarchy and DistributedTree

### DIFF
--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -31,7 +31,7 @@ namespace ArborX
  *  \note query() must be called as collective over all processes in the
  *  communicator passed to the constructor.
  */
-template <typename MemorySpace, typename Enable = void>
+template <typename MemorySpace>
 class DistributedTree
 {
 public:
@@ -109,10 +109,11 @@ private:
   Kokkos::View<size_type *, MemorySpace> _bottom_tree_sizes;
 };
 
-template <typename MemorySpace, typename Enable>
+template <typename MemorySpace>
 template <typename ExecutionSpace, typename Primitives>
-DistributedTree<MemorySpace, Enable>::DistributedTree(
-    MPI_Comm comm, ExecutionSpace const &space, Primitives const &primitives)
+DistributedTree<MemorySpace>::DistributedTree(MPI_Comm comm,
+                                              ExecutionSpace const &space,
+                                              Primitives const &primitives)
 {
   Kokkos::Profiling::pushRegion("ArborX::DistributedTree::DistributedTree");
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -38,8 +38,7 @@ namespace Details
 struct HappyTreeFriends;
 } // namespace Details
 
-template <typename MemorySpace, typename BoundingVolume = Box,
-          typename Enable = void>
+template <typename MemorySpace, typename BoundingVolume = Box>
 class BasicBoundingVolumeHierarchy
 {
 public:
@@ -114,10 +113,10 @@ using BoundingVolumeHierarchy = BasicBoundingVolumeHierarchy<MemorySpace>;
 template <typename MemorySpace>
 using BVH = BoundingVolumeHierarchy<MemorySpace>;
 
-template <typename MemorySpace, typename BoundingVolume, typename Enable>
+template <typename MemorySpace, typename BoundingVolume>
 template <typename ExecutionSpace, typename Primitives,
           typename SpaceFillingCurve>
-BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
+BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume>::
     BasicBoundingVolumeHierarchy(ExecutionSpace const &space,
                                  Primitives const &primitives,
                                  SpaceFillingCurve const &curve)
@@ -209,9 +208,9 @@ BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::
   Kokkos::Profiling::popRegion();
 }
 
-template <typename MemorySpace, typename BoundingVolume, typename Enable>
+template <typename MemorySpace, typename BoundingVolume>
 template <typename ExecutionSpace, typename Predicates, typename Callback>
-void BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume, Enable>::query(
+void BasicBoundingVolumeHierarchy<MemorySpace, BoundingVolume>::query(
     ExecutionSpace const &space, Predicates const &predicates,
     Callback const &legacy_callback,
     Experimental::TraversalPolicy const &policy) const


### PR DESCRIPTION
- `Enable` in `BasicBoundingVolumeHierarchy` could have been removed in #458
- `Enable` in `DistributedTree` could have been removed in #706