### PR TITLE
Remove unnecessary work-around for HIP

### DIFF
--- a/src/details/ArborX_DetailsHappyTreeFriends.hpp
+++ b/src/details/ArborX_DetailsHappyTreeFriends.hpp
@@ -44,27 +44,14 @@ struct HappyTreeFriends
   }
 
   template <class BVH>
-  static KOKKOS_FUNCTION
-// FIXME_HIP See https://github.com/arborx/ArborX/issues/553
-#ifdef __HIP_DEVICE_COMPILE__
-      auto
-#else
-      auto const &
-#endif
-      getInternalBoundingVolume(BVH const &bvh, int i)
+  static KOKKOS_FUNCTION auto const &getInternalBoundingVolume(BVH const &bvh,
+                                                               int i)
   {
     return bvh._internal_nodes(internalIndex(bvh, i)).bounding_volume;
   }
 
   template <class BVH>
-  static KOKKOS_FUNCTION
-// FIXME_HIP See https://github.com/arborx/ArborX/issues/553
-#ifdef __HIP_DEVICE_COMPILE__
-      auto
-#else
-      auto const &
-#endif
-      getIndexable(BVH const &bvh, int i)
+  static KOKKOS_FUNCTION auto const &getIndexable(BVH const &bvh, int i)
   {
     return bvh._indexable_getter(getValue(bvh, i));
   }


### PR DESCRIPTION
This is not necessary anymore. Tested on frontier with rocm 5.2 and rocm 5.4.3. I don't have the input data to run DBSCAN (I keep losing it), so @aprokop should probably check that it gets the same results.

The different path for HIP was first introduced in #575.