### PR TITLE
Move citation details

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,17 @@
+@article{arborx2020,
+  author = {Lebrun-Grandi\'{e}, D. and Prokopenko, A. and Turcksin, B. and Slattery, S. R.},
+  title = {{ArborX}: A Performance Portable Geometric Search Library},
+  year = {2020},
+  issue_date = {December 2020},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  volume = {47},
+  number = {1},
+  issn = {0098-3500},
+  url = {https://doi.org/10.1145/3412558},
+  doi = {10.1145/3412558},
+  journal = {ACM Trans. Math. Softw.},
+  month = dec,
+  articleno = {2},
+  numpages = {15}
+}

--- a/README.md
+++ b/README.md
@@ -30,27 +30,9 @@ We encourage you to contribute to ArborX! Please check out the
 
 Citing ArborX
 -------------
-If you publish work which mentions ArborX, please cite the following paper:
+## Citing
 
-```BibTeX
-@article{arborx2020,
-  author = {Lebrun-Grandi\'{e}, D. and Prokopenko, A. and Turcksin, B. and Slattery, S. R.},
-  title = {{ArborX}: A Performance Portable Geometric Search Library},
-  year = {2020},
-  issue_date = {December 2020},
-  publisher = {Association for Computing Machinery},
-  address = {New York, NY, USA},
-  volume = {47},
-  number = {1},
-  issn = {0098-3500},
-  url = {https://doi.org/10.1145/3412558},
-  doi = {10.1145/3412558},
-  journal = {ACM Trans. Math. Softw.},
-  month = dec,
-  articleno = {2},
-  numpages = {15}
-}
-```
+If you use ArborX in your work, please cite the [TOMS article](CITATION.bib).
 
 License
 -------


### PR DESCRIPTION
GitHub will add "Cite this repository" link on the right once it detects the presence of the citation file. The documentation is [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files). I don't see a need to use CFF format yet, though it could make it a bit easier to cite in different formats.