### PR TITLE
Workaround to compile ArborX with Trilinos 14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(ArborX CXX)
 
+# Workaround to compile against Trilinos 14.0. That version of Trilinos does not
+# set the compatibility mode for Kokkos correctly.
 find_package(Kokkos QUIET 3.7.01 CONFIG)
 if (NOT Kokkos_FOUND)
   find_package(Kokkos 4.0.00 REQUIRED CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(ArborX CXX)
 
-find_package(Kokkos 3.7.01 REQUIRED CONFIG)
+find_package(Kokkos QUIET 3.7.01 CONFIG)
+if (NOT Kokkos_FOUND)
+  find_package(Kokkos 4.0.00 REQUIRED CONFIG)
+endif()
 message(STATUS "Found Kokkos: ${Kokkos_DIR} (version \"${Kokkos_VERSION}\")")
 if(Kokkos_ENABLE_CUDA)
   kokkos_check(OPTIONS CUDA_LAMBDA)


### PR DESCRIPTION
This PR target the release 1.4 branch in order to create a new release 1.4.1. We first try to find Kokkos 3.7 or later. If that fails, we try to find Kokkos 4.0. Without this PR, ArborX 1.4 cannot be built using any release version of Trilinos .