### PR TITLE
Add KokkosExt::bit_cast

### DIFF
--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -14,6 +14,7 @@
 
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsKokkosExtBitManipulation.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsMutualReachabilityDistance.hpp>
@@ -612,12 +613,7 @@ void computeParents(ExecutionSpace const &space, Edges const &edges,
         // Comparison of weights as ints is the same as their comparison as
         // floats as long as they are positive and are not NaNs or inf
         static_assert(sizeof(int) == sizeof(float));
-        keys(e) = (key << shift) +
-#if KOKKOS_VERSION >= 40100
-                  Kokkos::bit_cast<int>(edge.weight);
-#else
-                  reinterpret_cast<int const &>(edge.weight);
-#endif
+        keys(e) = (key << shift) + KokkosExt::bit_cast<int>(edge.weight);
       });
 
   auto permute = sortObjects(space, keys);

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_KOKKOS_EXT_BIT_MANIPULATION_HPP
+#define ARBORX_DETAILS_KOKKOS_EXT_BIT_MANIPULATION_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <type_traits>
+
+namespace KokkosExt
+{
+
+#if KOKKOS_VERSION >= 40100
+template <class To, class From>
+using bit_cast = Kokkos::bit_cast<To, From>;
+#else
+template <class To, class From>
+KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&
+                                     std::is_trivially_copyable_v<To> &&
+                                     std::is_trivially_copyable_v<From>,
+                                 To>
+bit_cast(From const &from) noexcept
+{
+  To to;
+  memcpy(&to, &from, sizeof(To));
+  return to;
+}
+#endif
+
+} // namespace KokkosExt
+
+#endif


### PR DESCRIPTION
We get warnings/errors on Cuda for `reinterpret_cast`
```
../src/details/ArborX_MinimumSpanningTree.hpp:615:70: error:
dereferencing type-punned pointer will break strict-aliasing rules
[-Werror=strict-aliasing]
```

I think we should temporarily (until requiring 4.1) provide `bit_cast`.

Not sure whether to add the tests. Implicitly tested through Boruvka dendrogram test.