### PR TITLE
Fix using-declaration introducing `Kokkos::bit_cast` into `KokkosExt`

### DIFF
--- a/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp
@@ -20,8 +20,7 @@ namespace KokkosExt
 {
 
 #if KOKKOS_VERSION >= 40100
-template <class To, class From>
-using bit_cast = Kokkos::bit_cast<To, From>;
+using Kokkos::bit_cast;
 #else
 template <class To, class From>
 KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&


### PR DESCRIPTION
#888 broke our nightly builds
```

In file included from /var/jenkins/workspace/ArborX-nightly/build-arborx/benchmarks/dbscan/dbscan_2.cpp:1:
In file included from /var/jenkins/workspace/ArborX-nightly/benchmarks/dbscan/dbscan_timpl.hpp:14:
In file included from /var/jenkins/workspace/ArborX-nightly/src/ArborX_HDBSCAN.hpp:16:
In file included from /var/jenkins/workspace/ArborX-nightly/src/details/ArborX_MinimumSpanningTree.hpp:17:
/var/jenkins/workspace/ArborX-nightly/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp:24:18: error: expected a type
using bit_cast = Kokkos::bit_cast<To, From>;
                 ^
/var/jenkins/workspace/ArborX-nightly/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp:24:26: error: expected ';' after alias declaration
using bit_cast = Kokkos::bit_cast<To, From>;
                         ^
                         ;
In file included from /var/jenkins/workspace/ArborX-nightly/build-arborx/benchmarks/dbscan/dbscan_2.cpp:1:
In file included from /var/jenkins/workspace/ArborX-nightly/benchmarks/dbscan/dbscan_timpl.hpp:14:
In file included from /var/jenkins/workspace/ArborX-nightly/src/ArborX_HDBSCAN.hpp:16:
/var/jenkins/workspace/ArborX-nightly/src/details/ArborX_MinimumSpanningTree.hpp:616:36: error: no template named 'bit_cast' in namespace 'KokkosExt'; did you mean 'Kokkos::bit_cast'?
        keys(e) = (key << shift) + KokkosExt::bit_cast<int>(edge.weight);
                                   ^~~~~~~~~~~~~~~~~~~
                                   Kokkos::bit_cast
/var/jenkins/workspace/ArborX-nightly/install-kokkos/include/Kokkos_BitManipulation.hpp:113:1: note: 'Kokkos::bit_cast' declared here
bit_cast(From const& from) noexcept {
^
In file included from /var/jenkins/workspace/ArborX-nightly/build-arborx/benchmarks/dbscan/dbscan_2.cpp:1:
In file included from /var/jenkins/workspace/ArborX-nightly/benchmarks/dbscan/dbscan_timpl.hpp:14:
In file included from /var/jenkins/workspace/ArborX-nightly/src/ArborX_HDBSCAN.hpp:16:
/var/jenkins/workspace/ArborX-nightly/src/details/ArborX_MinimumSpanningTree.hpp:616:36: error: no template named 'bit_cast' in namespace 'KokkosExt'; did you mean 'Kokkos::bit_cast'?
        keys(e) = (key << shift) + KokkosExt::bit_cast<int>(edge.weight);
                                   ^~~~~~~~~~~~~~~~~~~
                                   Kokkos::bit_cast
/var/jenkins/workspace/ArborX-nightly/install-kokkos/include/Kokkos_BitManipulation.hpp:113:1: note: 'Kokkos::bit_cast' declared here
bit_cast(From const& from) noexcept {
^
```