### PR TITLE
Fix include files for ArborX_DetailsKokkosExtBitManipulation.hpp and Kokkos >= 4.1.00

### DIFF
--- a/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtBitManipulation.hpp
@@ -13,6 +13,9 @@
 #define ARBORX_DETAILS_KOKKOS_EXT_BIT_MANIPULATION_HPP
 
 #include <Kokkos_Macros.hpp>
+#if KOKKOS_VERSION >= 40100
+#include <Kokkos_BitManipulation.hpp>
+#endif
 
 #include <type_traits>
 


### PR DESCRIPTION
Apparently, we only test for Kokkos >= 4.1.00 in our nightlies which don't build the tests but only the benchmarks.