### PR TITLE
Allow computing morton codes for 1-dim points

### DIFF
--- a/src/details/ArborX_DetailsMortonCode.hpp
+++ b/src/details/ArborX_DetailsMortonCode.hpp
@@ -29,10 +29,16 @@ namespace Details
 template <int N>
 KOKKOS_INLINE_FUNCTION unsigned int expandBitsBy(unsigned int)
 {
-  static_assert(0 < N && N < 10,
-                "expandBitsBy can only be used with values 1-9");
+  static_assert(0 <= N && N < 10,
+                "expandBitsBy can only be used with values 0-9");
   Kokkos::abort("ArborX: implementation bug");
   return 0;
+}
+
+template <>
+KOKKOS_INLINE_FUNCTION unsigned int expandBitsBy<0>(unsigned int x)
+{
+  return x;
 }
 
 // Insert one 0 bit after each of the 16 low bits of x
@@ -146,10 +152,16 @@ KOKKOS_INLINE_FUNCTION unsigned int expandBitsBy<9>(unsigned int x)
 template <int N>
 KOKKOS_INLINE_FUNCTION unsigned long long expandBitsBy(unsigned long long)
 {
-  static_assert(0 < N && N < 10,
-                "expandBitsBy can only be used with values 1-9");
+  static_assert(0 <= N && N < 10,
+                "expandBitsBy can only be used with values 0-9");
   Kokkos::abort("ArborX: implementation bug");
   return 0;
+}
+
+template <>
+KOKKOS_INLINE_FUNCTION unsigned long long expandBitsBy<0>(unsigned long long x)
+{
+  return x;
 }
 
 // Insert one 0 bit after each of the 31 low bits of x
@@ -275,7 +287,7 @@ template <typename Point,
 KOKKOS_INLINE_FUNCTION unsigned int morton32(Point const &p)
 {
   constexpr int DIM = GeometryTraits::dimension_v<Point>;
-  constexpr unsigned N = (1u << (32 / DIM));
+  constexpr unsigned N = (DIM == 1) ? (1u << 31) : (1llu << (32 / DIM));
 
   using KokkosExt::max;
   using KokkosExt::min;
@@ -296,7 +308,7 @@ template <typename Point,
 KOKKOS_INLINE_FUNCTION unsigned long long morton64(Point const &p)
 {
   constexpr int DIM = GeometryTraits::dimension_v<Point>;
-  constexpr unsigned N = (1u << (63 / DIM));
+  constexpr unsigned long long N = (1llu << (63 / DIM));
 
   using KokkosExt::max;
   using KokkosExt::min;

--- a/src/details/ArborX_DetailsMortonCode.hpp
+++ b/src/details/ArborX_DetailsMortonCode.hpp
@@ -287,7 +287,7 @@ template <typename Point,
 KOKKOS_INLINE_FUNCTION unsigned int morton32(Point const &p)
 {
   constexpr int DIM = GeometryTraits::dimension_v<Point>;
-  constexpr unsigned N = (DIM == 1) ? (1u << 31) : (1llu << (32 / DIM));
+  constexpr unsigned N = 1u << (DIM == 1 ? 31 : 32 / DIM);
 
   using KokkosExt::max;
   using KokkosExt::min;

--- a/src/geometry/ArborX_HyperPoint.hpp
+++ b/src/geometry/ArborX_HyperPoint.hpp
@@ -36,6 +36,9 @@ struct Point
 
 // Deduction guides
 template <class T>
+Point(T x) -> Point<1, T>;
+
+template <class T>
 Point(T x, T y) -> Point<2, T>;
 
 template <class T>

--- a/test/tstDetailsMortonCodes.cpp
+++ b/test/tstDetailsMortonCodes.cpp
@@ -23,6 +23,7 @@ BOOST_AUTO_TEST_CASE(expand_bits)
 {
   // clang-format off
   unsigned x = 0b110010011101u;
+  BOOST_TEST(expandBitsBy<0>(x) ==                     0b110010011101u);
   BOOST_TEST(expandBitsBy<1>(x) ==         0b010100000100000101010001u);
   BOOST_TEST(expandBitsBy<2>(x) ==   0b000000001000000001001001000001u);
   BOOST_TEST(expandBitsBy<3>(x) == 0b00010000000000010001000100000001u);
@@ -34,6 +35,7 @@ BOOST_AUTO_TEST_CASE(expand_bits)
   BOOST_TEST(expandBitsBy<9>(x) ==   0b000000000100000000000000000001u);
 
   unsigned long long y = 0b11111111111111000001llu;
+  BOOST_TEST(expandBitsBy<0>(y) ==                                            0b11111111111111000001llu);
   BOOST_TEST(expandBitsBy<1>(y) ==                        0b0101010101010101010101010101000000000001llu);
   BOOST_TEST(expandBitsBy<2>(y) ==    0b001001001001001001001001001001001001001001000000000000000001llu);
   BOOST_TEST(expandBitsBy<3>(y) ==    0b000100010001000100010001000100010001000000000000000000000001llu);
@@ -49,6 +51,14 @@ BOOST_AUTO_TEST_CASE(expand_bits)
 BOOST_AUTO_TEST_CASE(morton_codes)
 {
   using ArborX::ExperimentalHyperGeometry::Point;
+
+  BOOST_TEST(morton32(Point{0.f}) == 0x0u);
+  BOOST_TEST(morton32(Point{0.5f}) == 0x40000000u);
+  BOOST_TEST(morton32(Point{1.f}) == 0x80000000u);
+
+  BOOST_TEST(morton64(Point{0.f}) == 0x0llu);
+  BOOST_TEST(morton64(Point{0.5f}) == 0x4000000000000000llu);
+  BOOST_TEST(morton64(Point{1.f}) == 0x8000000000000000llu);
 
   BOOST_TEST(morton32(Point{0.f, 0.f}) == 0x0u);
   BOOST_TEST(morton32(Point{1.f, 1.f}) == 0xffffffffu);


### PR DESCRIPTION
https://github.com/dealii/dealii/pull/15538 wants to use `ArborX` for 1d, 2d and 3d data and we currently convert everything to 3d. In order to allow using the `HyperGeometry` types, 1d Morton codes are missing, though, and this pull request adds them.