### PR TITLE
Allow lower-dimensional DistributedTree

### DIFF
--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -149,7 +149,7 @@ DistributedTree<MemorySpace>::DistributedTree(MPI_Comm comm,
   int comm_size;
   MPI_Comm_size(getComm(), &comm_size);
 
-  Kokkos::View<Box *, MemorySpace> boxes(
+  Kokkos::View<BoundingVolumeType *, MemorySpace> boxes(
       Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                          "ArborX::DistributedTree::DistributedTree::"
                          "rank_bounding_boxes"),
@@ -163,8 +163,8 @@ DistributedTree<MemorySpace>::DistributedTree(MPI_Comm comm,
               " (fill on device done before MPI_Allgather)");
 
   MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                static_cast<void *>(boxes.data()), sizeof(Box), MPI_BYTE,
-                getComm());
+                static_cast<void *>(boxes.data()), sizeof(BoundingVolumeType),
+                MPI_BYTE, getComm());
 #else
   auto boxes_host = Kokkos::create_mirror_view(
       Kokkos::view_alloc(host_exec, Kokkos::WithoutInitializing), boxes);

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -82,7 +82,8 @@ struct AccessTraits<
   {
     auto const point = getGeometry(Access::get(x.predicates, i));
     auto const distance = x.distances(i);
-    return intersects(Sphere{point, distance});
+    return intersects(ExperimentalHyperGeometry::Sphere{
+        Details::toHyperPoint(point), distance});
   }
   template <class Dummy = Geometry,
             std::enable_if_t<std::is_same_v<Dummy, Geometry> &&

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -22,6 +22,7 @@
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_DetailsUtils.hpp>
+#include <ArborX_HyperSphere.hpp>
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_PairIndexRank.hpp>
 #include <ArborX_Predicates.hpp>
@@ -76,7 +77,7 @@ struct AccessTraits<
   }
   template <class Dummy = Geometry,
             std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
-                             std::is_same_v<Dummy, Point>> * = nullptr>
+                             GeometryTraits::is_point<Dummy>{}> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
     auto const point = getGeometry(Access::get(x.predicates, i));
@@ -85,7 +86,7 @@ struct AccessTraits<
   }
   template <class Dummy = Geometry,
             std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
-                             std::is_same_v<Dummy, Box>> * = nullptr>
+                             GeometryTraits::is_box<Dummy>{}> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
     auto box = getGeometry(Access::get(x.predicates, i));
@@ -101,7 +102,7 @@ struct AccessTraits<
   }
   template <class Dummy = Geometry,
             std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
-                             std::is_same_v<Dummy, Sphere>> * = nullptr>
+                             GeometryTraits::is_sphere<Dummy>{}> * = nullptr>
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
     auto const sphere = getGeometry(Access::get(x.predicates, i));
@@ -508,11 +509,7 @@ DistributedTreeImpl<DeviceType>::queryDispatchImpl(
   // recompute everything instead of just searching for potential better
   // neighbors and updating the list.
 
-  // Right now, distance calculations only work with BVH due to using functions
-  // in DistributedTreeNearestUtils. So, there's no point in replacing this
-  // with decltype.
-  CallbackWithDistance<BVH<typename DeviceType::memory_space>>
-      callback_with_distance(space, bottom_tree);
+  CallbackWithDistance callback_with_distance(space, bottom_tree);
 
   // NOTE: compiler would not deduce __range for the braced-init-list, but I
   // got it to work with the static_cast to function pointers.

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -15,6 +15,7 @@
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp> // min, max
 #include <ArborX_GeometryTraits.hpp>
+#include <ArborX_HyperPoint.hpp>
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_MathematicalFunctions.hpp> // isfinite
@@ -444,6 +445,20 @@ KOKKOS_FUNCTION void translateAndScale(Point const &in, Point &out,
     auto const b = ref.maxCorner()[d];
     out[d] = (a != b ? (in[d] - a) / (b - a) : 0);
   }
+}
+
+template <class T>
+KOKKOS_FUNCTION inline auto toHyperPoint(T const &p)
+{
+  static_assert(ArborX::GeometryTraits::is_point<T>{});
+  return p;
+}
+
+template <>
+KOKKOS_FUNCTION inline auto
+toHyperPoint<::ArborX::Point>(::ArborX::Point const &p)
+{
+  return ArborX::ExperimentalHyperGeometry::Point<3>{p[0], p[1], p[2]};
 }
 
 } // namespace Details

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -39,8 +39,8 @@ struct is_distributed : std::false_type
 {};
 
 #ifdef ARBORX_ENABLE_MPI
-template <typename D>
-struct is_distributed<ArborX::DistributedTree<D>> : std::true_type
+template <typename D, typename B>
+struct is_distributed<ArborX::DistributedTree<D, B>> : std::true_type
 {};
 
 template <typename I>


### PR DESCRIPTION
Based on top of #905, and also for allowing using `HyperGeometry` classes in `deal.II`. With #905, we can already use `BasicBoundingVolumeHierarchy` but not `DistributedTree`.

This pull provides a means to make that possible but is mostly meant as a base for discussion and as a proof-of-concept.
The current implementation simply adds a second template parameter for the bounding volume type to use for the lower and upper BVH trees (since that seemed to be the quickest solution).
Of course, we could also template on the tree type directly and/or introduce new classes for a `DistributedBoudingVolumeHierarchy` or similar.  