### PR TITLE
Test SYCL with Kokkos 4.1.00

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -398,6 +398,7 @@ pipeline {
                     }
                 }
 
+                // Disable deprecation warnings since we are using Kokkos::bit_cast which aliases a deprecated function in the oneAPI API.
                 stage('SYCL') {
                     agent {
                         dockerfile {

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -418,7 +418,7 @@ pipeline {
                                     -D CMAKE_BUILD_TYPE=Release \
                                     -D CMAKE_CXX_COMPILER=${DPCPP} \
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
-                                    -D CMAKE_CXX_FLAGS="-fp-model=precise -fsycl-device-code-split=per_kernel -Wpedantic -Wall -Wextra -Wno-unknown-cuda-version" \
+                                    -D CMAKE_CXX_FLAGS="-fp-model=precise -fsycl-device-code-split=per_kernel -Wpedantic -Wall -Wextra -Wno-unknown-cuda-version -Wno-deprecated-declarations" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
                                     -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
@@ -455,7 +455,7 @@ pipeline {
                                         -D CMAKE_BUILD_TYPE=Release \
                                         -D CMAKE_CXX_COMPILER=${DPCPP} \
                                         -D CMAKE_CXX_EXTENSIONS=OFF \
-                                        -D CMAKE_CXX_FLAGS="-Wno-unknown-cuda-version" \
+                                        -D CMAKE_CXX_FLAGS="-Wno-unknown-cuda-version -Wno-deprecated-declarations" \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
                                     examples \
                                 '''

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -109,8 +109,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     rm -rf ${SCRATCH_DIR}
 
 # Install Kokkos
-# Kokkos 4.0.99 using in-order queues for SYCL+Cuda
-ARG KOKKOS_VERSION=24c62bf5cc0e30f6a19de8e95b24197fbca9dd27
+ARG KOKKOS_VERSION=4.1.00
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SYCL=ON -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF -DKokkos_ARCH_VOLTA70=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS=-w"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -50,7 +50,7 @@ RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCT
     apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB && \
     echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
     apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0" && \
-    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-${DPCPP_VERSION} && \
+    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-${DPCPP_VERSION} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 ENV DPCPP=/opt/intel/oneapi/compiler/${DPCPP_VERSION}/linux/bin-llvm/clang++

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -1,4 +1,4 @@
-ARG BASE=nvidia/cuda:11.7.0-devel-ubuntu22.04
+ARG BASE=nvidia/cuda:11.7.1-devel-ubuntu22.04
 FROM $BASE
 
 ARG NPROCS=4


### PR DESCRIPTION
There is not much of a point in testing with an intermediate version if we can use the release.
Drive-by: 
- We don't need to also install `icpc` but can restrict the Dockerfile to `icpx`. 
- We also need to update the base image, see https://github.com/kokkos/kokkos/pull/6288.