### PR TITLE
Allow rm -rf commands fail on Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ stages:
             -DCMAKE_CXX_COMPILER=g++
             -DBENCHMARK_ENABLE_TESTING=OFF .. &&
       make &&
-      rm -rf /ccsopen/proj/csc333/benchmark.install &&
+      (rm -rf /ccsopen/proj/csc333/benchmark.install || true) &&
       make install
   tags:
     - nobatch
@@ -51,7 +51,7 @@ BuildKokkos:
             -DKokkos_ARCH_POWER9=ON
             -DKokkos_ARCH_VOLTA70=ON .. &&
       make &&
-      rm -rf /ccsopen/proj/csc333/kokkos.install &&
+      (rm -rf /ccsopen/proj/csc333/kokkos.install || true )&&
       make install
   tags:
     - nobatch


### PR DESCRIPTION
Sometimes, they can't execute correctly due to the presence of the .nfs* (or similar) files from the filesystem. Which aborts the whole workflow. This will do the best effort to remove the install directory, but still continue if it only does partial cleanup.