### PR TITLE
Change default BoundingVolume for BasicBVH to the right dimensionality

### DIFF
--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
@@ -91,8 +91,7 @@ void ArborXBenchmark::run(int nprimitives, int nqueries, int nrepeats)
     {
       Kokkos::Timer timer;
       ArborX::BasicBoundingVolumeHierarchy<
-          MemorySpace, ArborX::Details::PairIndexVolume<Box>,
-          ArborX::Details::DefaultIndexableGetter, Box>
+          MemorySpace, ArborX::Details::PairIndexVolume<Box>>
           bvh{space, primitives};
 
       Kokkos::View<int *, ExecutionSpace> indices("indices_ref", 0);

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -305,9 +305,8 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   constexpr int dim = GeometryTraits::dimension_v<
       typename Details::AccessTraitsHelper<Access>::type>;
   using Box = ExperimentalHyperGeometry::Box<dim>;
-  ArborX::BasicBoundingVolumeHierarchy<
-      MemorySpace, ArborX::Details::PairIndexVolume<Box>,
-      ArborX::Details::DefaultIndexableGetter, Box>
+  ArborX::BasicBoundingVolumeHierarchy<MemorySpace,
+                                       ArborX::Details::PairIndexVolume<Box>>
       bvh(exec_space, primitives);
 
   auto const predicates =

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -290,8 +290,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
     // Build the tree
     Kokkos::Profiling::pushRegion("ArborX::DBSCAN::tree_construction");
     ArborX::BasicBoundingVolumeHierarchy<MemorySpace,
-                                         Details::PairIndexVolume<Box>,
-                                         Details::DefaultIndexableGetter, Box>
+                                         Details::PairIndexVolume<Box>>
         bvh(exec_space, primitives);
     Kokkos::Profiling::popRegion();
 
@@ -413,8 +412,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
     // Build the tree
     Kokkos::Profiling::pushRegion("ArborX::DBSCAN::tree_construction");
     ArborX::BasicBoundingVolumeHierarchy<MemorySpace,
-                                         Details::PairIndexVolume<Box>,
-                                         Details::DefaultIndexableGetter, Box>
+                                         Details::PairIndexVolume<Box>>
         bvh(exec_space,
             Details::MixedBoxPrimitives<
                 Primitives, decltype(dense_cell_offsets),

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -39,9 +39,12 @@ namespace Details
 struct HappyTreeFriends;
 } // namespace Details
 
-template <typename MemorySpace, typename Value,
-          typename IndexableGetter = Details::DefaultIndexableGetter,
-          typename BoundingVolume = Box>
+template <
+    typename MemorySpace, typename Value,
+    typename IndexableGetter = Details::DefaultIndexableGetter,
+    typename BoundingVolume =
+        ExperimentalHyperGeometry::Box<GeometryTraits::dimension_v<std::decay_t<
+            decltype(std::declval<IndexableGetter>()(std::declval<Value>()))>>>>
 class BasicBoundingVolumeHierarchy
 {
 public:
@@ -88,6 +91,8 @@ public:
 private:
   friend struct Details::HappyTreeFriends;
 
+  using indexable_type = std::decay_t<decltype(std::declval<IndexableGetter>()(
+      std::declval<Value>()))>;
   using leaf_node_type = Details::LeafNode<value_type>;
   using internal_node_type = Details::InternalNode<bounding_volume_type>;
 
@@ -186,8 +191,7 @@ BasicBoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter,
   if (size() == 1)
   {
     Details::TreeConstruction::initializeSingleLeafTree(
-        space,
-        Details::LegacyValues<Primitives, bounding_volume_type>{primitives},
+        space, Details::LegacyValues<Primitives, indexable_type>{primitives},
         _indexable_getter, _leaf_nodes, _bounds);
     return;
   }
@@ -228,8 +232,7 @@ BasicBoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter,
 
   // Generate bounding volume hierarchy
   Details::TreeConstruction::generateHierarchy(
-      space,
-      Details::LegacyValues<Primitives, bounding_volume_type>{primitives},
+      space, Details::LegacyValues<Primitives, indexable_type>{primitives},
       _indexable_getter, permutation_indices, linear_ordering_indices,
       _leaf_nodes, _internal_nodes, _bounds);
 

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -716,9 +716,8 @@ struct MinimumSpanningTree
     auto const n = AccessTraits<Primitives, PrimitivesTag>::size(primitives);
 
     Kokkos::Profiling::pushRegion("ArborX::MST::construction");
-    BasicBoundingVolumeHierarchy<MemorySpace, PairIndexVolume<Box>,
-                                 DefaultIndexableGetter, Box>
-        bvh(space, primitives);
+    BasicBoundingVolumeHierarchy<MemorySpace, PairIndexVolume<Box>> bvh(
+        space, primitives);
     Kokkos::Profiling::popRegion();
 
     if (k > 1)


### PR DESCRIPTION
The right dimensionality of the box depends on the return type of the `IndexableGetter`.