### PR TITLE
Template Triangle on dimension and floating point type 

### DIFF
--- a/src/geometry/ArborX_HyperTriangle.hpp
+++ b/src/geometry/ArborX_HyperTriangle.hpp
@@ -3,9 +3,7 @@
 
 #include <ArborX_HyperPoint.hpp>
 
-namespace ArborX
-{
-namespace Experimental
+namespace ArborX::ExperimentalHyperGeometry
 {
 // need to add a protection that
 // the points are not on the same line.
@@ -23,12 +21,11 @@ Triangle(ExperimentalHyperGeometry::Point<DIM, FloatingPoint>,
          ExperimentalHyperGeometry::Point<DIM, FloatingPoint>)
     -> Triangle<DIM, FloatingPoint>;
 
-} // namespace Experimental
-} // namespace ArborX
+} // namespace ArborX::ExperimentalHyperGeometry
 
 template <int DIM, class FloatingPoint>
 struct ArborX::GeometryTraits::dimension<
-    ArborX::Experimental::Triangle<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Triangle<DIM, FloatingPoint>>
 {
   static constexpr int value = DIM;
 };

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -15,9 +15,9 @@
 #include <ArborX_DetailsAlgorithms.hpp> // equal
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
 #include <ArborX_DetailsKokkosExtSwap.hpp>
+#include <ArborX_HyperTriangle.hpp>
 #include <ArborX_Point.hpp>
 #include <ArborX_Sphere.hpp>
-#include <ArborX_Triangle.hpp>
 
 #include <Kokkos_Macros.hpp>
 
@@ -297,7 +297,8 @@ KOKKOS_INLINE_FUNCTION bool rayEdgeIntersect(Point const &edge_vertex_1,
 // when the ray and the triangle is coplanar.
 // In the paper, they just need the boolean return.
 KOKKOS_INLINE_FUNCTION
-bool intersection(Ray const &ray, Triangle<3, float> const &triangle,
+bool intersection(Ray const &ray,
+                  ExperimentalHyperGeometry::Triangle<3> const &triangle,
                   float &tmin, float &tmax)
 {
   auto dir = ray.direction();
@@ -442,8 +443,9 @@ bool intersection(Ray const &ray, Triangle<3, float> const &triangle,
   return false;
 } // namespace Experimental
 
-KOKKOS_INLINE_FUNCTION bool intersects(Ray const &ray,
-                                       Triangle<3, float> const &triangle)
+KOKKOS_INLINE_FUNCTION bool
+intersects(Ray const &ray,
+           ExperimentalHyperGeometry::Triangle<3> const &triangle)
 {
   float tmin;
   float tmax;

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -40,8 +40,13 @@ struct Vector : private Point
   }
 };
 
-KOKKOS_INLINE_FUNCTION constexpr Vector makeVector(Point const &begin,
-                                                   Point const &end)
+template <typename Point1, typename Point2>
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    GeometryTraits::is_point<Point1>{} && GeometryTraits::is_point<Point2>{} &&
+        GeometryTraits::dimension<Point1>::value == 3 &&
+        GeometryTraits::dimension<Point2>::value == 3,
+    Vector>
+makeVector(Point1 const &begin, Point2 const &end)
 {
   Vector v;
   for (int d = 0; d < 3; ++d)
@@ -292,8 +297,8 @@ KOKKOS_INLINE_FUNCTION bool rayEdgeIntersect(Point const &edge_vertex_1,
 // when the ray and the triangle is coplanar.
 // In the paper, they just need the boolean return.
 KOKKOS_INLINE_FUNCTION
-bool intersection(Ray const &ray, Triangle const &triangle, float &tmin,
-                  float &tmax)
+bool intersection(Ray const &ray, Triangle<3, float> const &triangle,
+                  float &tmin, float &tmax)
 {
   auto dir = ray.direction();
   // normalize the direction vector by its largest component.
@@ -437,8 +442,8 @@ bool intersection(Ray const &ray, Triangle const &triangle, float &tmin,
   return false;
 } // namespace Experimental
 
-KOKKOS_INLINE_FUNCTION
-bool intersects(Ray const &ray, Triangle const &triangle)
+KOKKOS_INLINE_FUNCTION bool intersects(Ray const &ray,
+                                       Triangle<3, float> const &triangle)
 {
   float tmin;
   float tmax;

--- a/src/geometry/ArborX_Triangle.hpp
+++ b/src/geometry/ArborX_Triangle.hpp
@@ -1,7 +1,7 @@
 #ifndef ARBORX_TRIANGLE_HPP
 #define ARBORX_TRIANGLE_HPP
 
-#include <ArborX_Point.hpp>
+#include <ArborX_HyperPoint.hpp>
 
 namespace ArborX
 {
@@ -9,13 +9,27 @@ namespace Experimental
 {
 // need to add a protection that
 // the points are not on the same line.
+template <int DIM, class FloatingPoint = float>
 struct Triangle
 {
-  Point a;
-  Point b;
-  Point c;
+  ExperimentalHyperGeometry::Point<DIM, FloatingPoint> a;
+  ExperimentalHyperGeometry::Point<DIM, FloatingPoint> b;
+  ExperimentalHyperGeometry::Point<DIM, FloatingPoint> c;
 };
+
+template <int DIM, class FloatingPoint>
+Triangle(ExperimentalHyperGeometry::Point<DIM, FloatingPoint>,
+         ExperimentalHyperGeometry::Point<DIM, FloatingPoint>,
+         ExperimentalHyperGeometry::Point<DIM, FloatingPoint>)
+    -> Triangle<DIM, FloatingPoint>;
+
 } // namespace Experimental
 } // namespace ArborX
 
+template <int DIM, class FloatingPoint>
+struct ArborX::GeometryTraits::dimension<
+    ArborX::Experimental::Triangle<DIM, FloatingPoint>>
+{
+  static constexpr int value = DIM;
+};
 #endif

--- a/test/tstRay.cpp
+++ b/test/tstRay.cpp
@@ -398,8 +398,8 @@ BOOST_AUTO_TEST_CASE(intersects_triangle)
   using ArborX::Experimental::Ray;
   using ArborX::ExperimentalHyperGeometry::Point;
   using ArborX::ExperimentalHyperGeometry::Triangle;
-  constexpr Triangle unit_triangle{Point{0.f, 0.f, 0.f}, Point{1.f, 0.f, 0.f},
-                                   Point{0.f, 1.f, 0.f}};
+  constexpr Triangle unit_triangle{Point{0, 0, 0}, Point{1, 0, 0},
+                                   Point{0, 1, 0}};
 
   BOOST_TEST(intersects(Ray{{.1, .2, .3}, {0, 0, -1}}, unit_triangle));
   BOOST_TEST(intersects(Ray{{1.1, 1.2, 1}, {-1, -1, -1}}, unit_triangle));
@@ -445,8 +445,8 @@ BOOST_AUTO_TEST_CASE(intersects_triangle)
   // ray in a plane parallel to the triangle
   BOOST_TEST(!intersects(Ray{{-0.1, 0, 1}, {1, 0, 0}}, unit_triangle));
 
-  constexpr Triangle tilted_triangle{Point{0.f, 0.f, 0.f}, Point{2.f, 0.f, 1.f},
-                                     Point{0.f, 2.f, 1.f}};
+  constexpr Triangle tilted_triangle{Point{0, 0, 0}, Point{2, 0, 1},
+                                     Point{0, 2, 1}};
 
   // ray in the same plane as the triangle
   BOOST_TEST(!intersects(Ray{{10, 0, 0}, {1, 1, 1}}, tilted_triangle));
@@ -483,10 +483,10 @@ BOOST_AUTO_TEST_CASE(ray_triangle_intersection,
   using ArborX::ExperimentalHyperGeometry::Point;
   using ArborX::ExperimentalHyperGeometry::Triangle;
 
-  constexpr Triangle unit_triangle{Point{0.f, 0.f, 0.f}, Point{1.f, 0.f, 0.f},
-                                   Point{0.f, 1.f, 0.f}};
-  constexpr Triangle narrow_triangle{
-      Point{0.5f, 0.5f, 0.f}, Point{0.24f, 0.74f, 0.f}, Point{0.f, 1.f, 0.f}};
+  constexpr Triangle unit_triangle{Point{0, 0, 0}, Point{1, 0, 0},
+                                   Point{0, 1, 0}};
+  constexpr Triangle narrow_triangle{Point{0.5f, 0.5f, 0},
+                                     Point{0.24f, 0.74f, 0}, Point{0, 1.f, 0}};
 
   auto const sqrtf_3 = std::sqrt(3.f);
   auto const sqrtf_2 = std::sqrt(2.f);
@@ -540,10 +540,10 @@ BOOST_AUTO_TEST_CASE(ray_triangle_intersection,
   // test would fail the "Plucker coordinates"-based algorithm, thus it is necessary to
   // keep them here to show the watertightness of the current algorithm implemented.
   constexpr Point O{1.f, 1.f, 1.f};
-  constexpr Point A{2.f, 2.f, 0.f};
-  constexpr Point B{2.f, -1.f, 0.f};
-  constexpr Point C{-1.f, -1.f, 0.f};
-  constexpr Point D{-1.f, 2.f, 0.f};
+  constexpr Point A{2.f, 2.f, 0};
+  constexpr Point B{2.f, -1.f, 0};
+  constexpr Point C{-1.f, -1.f, 0};
+  constexpr Point D{-1.f, 2.f, 0};
 
   constexpr Triangle triangle_up{D, A, O};
   constexpr Triangle triangle_right{O, A, B};
@@ -576,12 +576,12 @@ BOOST_AUTO_TEST_CASE(ray_triangle_intersection,
   // between the origin of the ray and the vertices.
   // These tests will fail if there is no normalization.
   float const size_s = 0.0001;
-  Triangle small_triangle{Point{-size_s, 0.f, 0.f}, Point{0.f, size_s, 0.f}, Point{0.f, 0.f, size_s}};
+  Triangle small_triangle{Point{-size_s, 0, 0}, Point{0, size_s, 0}, Point{0, 0, size_s}};
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{0.0, 0.0, 0.0}, {-size_s, size_s, size_s}}), small_triangle, size_s/sqrtf_3, size_s/sqrtf_3);
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{-2.f*size_s, -size_s, 0.0}, {size_s, size_s, 0}}), small_triangle, sqrtf_2*size_s, 2.f*sqrtf_2*size_s);
 
   float const size_l = 10000;
-  Triangle large_triangle{Point{-size_l, 0.f, 0.f}, Point{0.f, 10000.f, 0.f}, Point{0.f, 0.f, 10000.f}};
+  Triangle large_triangle{Point{-size_l, 0, 0}, Point{0, 10000, 0}, Point{0, 0, 10000}};
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{0.0, 0.0, 0.0}, {-size_l, size_l, size_l}}), large_triangle, size_l/sqrtf_3, size_l/sqrtf_3);
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{-2.f*size_l, -size_l, 0.0}, {size_l, size_l, 0}}), large_triangle, sqrtf_2*size_l, 2.f*sqrtf_2*size_l);
 

--- a/test/tstRay.cpp
+++ b/test/tstRay.cpp
@@ -397,7 +397,9 @@ BOOST_AUTO_TEST_CASE(intersects_triangle)
 {
   using ArborX::Experimental::Ray;
   using ArborX::Experimental::Triangle;
-  constexpr Triangle unit_triangle{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}};
+  using ArborX::ExperimentalHyperGeometry::Point;
+  constexpr Triangle unit_triangle{Point{0.f, 0.f, 0.f}, Point{1.f, 0.f, 0.f},
+                                   Point{0.f, 1.f, 0.f}};
 
   BOOST_TEST(intersects(Ray{{.1, .2, .3}, {0, 0, -1}}, unit_triangle));
   BOOST_TEST(intersects(Ray{{1.1, 1.2, 1}, {-1, -1, -1}}, unit_triangle));
@@ -443,7 +445,8 @@ BOOST_AUTO_TEST_CASE(intersects_triangle)
   // ray in a plane parallel to the triangle
   BOOST_TEST(!intersects(Ray{{-0.1, 0, 1}, {1, 0, 0}}, unit_triangle));
 
-  constexpr Triangle tilted_triangle{{0, 0, 0}, {2, 0, 1}, {0, 2, 1}};
+  constexpr Triangle tilted_triangle{Point{0.f, 0.f, 0.f}, Point{2.f, 0.f, 1.f},
+                                     Point{0.f, 2.f, 1.f}};
 
   // ray in the same plane as the triangle
   BOOST_TEST(!intersects(Ray{{10, 0, 0}, {1, 1, 1}}, tilted_triangle));
@@ -476,12 +479,14 @@ BOOST_AUTO_TEST_CASE(intersects_triangle)
 BOOST_AUTO_TEST_CASE(ray_triangle_intersection,
                      *boost::unit_test::tolerance(2e-6f))
 {
-  using ArborX::Point;
   using ArborX::Experimental::Ray;
   using ArborX::Experimental::Triangle;
+  using ArborX::ExperimentalHyperGeometry::Point;
 
-  constexpr Triangle unit_triangle{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}};
-  constexpr Triangle narrow_triangle{{0.5, 0.5, 0}, {0.24, 0.74, 0}, {0, 1, 0}};
+  constexpr Triangle unit_triangle{Point{0.f, 0.f, 0.f}, Point{1.f, 0.f, 0.f},
+                                   Point{0.f, 1.f, 0.f}};
+  constexpr Triangle narrow_triangle{
+      Point{0.5f, 0.5f, 0.f}, Point{0.24f, 0.74f, 0.f}, Point{0.f, 1.f, 0.f}};
 
   auto const sqrtf_3 = std::sqrt(3.f);
   auto const sqrtf_2 = std::sqrt(2.f);
@@ -534,11 +539,11 @@ BOOST_AUTO_TEST_CASE(ray_triangle_intersection,
   // guarantees watertightness along the edges and at the vertices". I assume the below
   // test would fail the "Plucker coordinates"-based algorithm, thus it is necessary to
   // keep them here to show the watertightness of the current algorithm implemented.
-  constexpr Point O{1.0, 1.0, 1.0};
-  constexpr Point A{2.0, 2.0, 0.0};
-  constexpr Point B{2.0, -1.0, 0.0};
-  constexpr Point C{-1.0, -1.0, 0.0};
-  constexpr Point D{-1.0, 2.0f, 0.0f};
+  constexpr Point O{1.f, 1.f, 1.f};
+  constexpr Point A{2.f, 2.f, 0.f};
+  constexpr Point B{2.f, -1.f, 0.f};
+  constexpr Point C{-1.f, -1.f, 0.f};
+  constexpr Point D{-1.f, 2.f, 0.f};
 
   constexpr Triangle triangle_up{D, A, O};
   constexpr Triangle triangle_right{O, A, B};
@@ -571,12 +576,12 @@ BOOST_AUTO_TEST_CASE(ray_triangle_intersection,
   // between the origin of the ray and the vertices.
   // These tests will fail if there is no normalization.
   float const size_s = 0.0001;
-  Triangle small_triangle{{-size_s, 0, 0}, {0, size_s, 0}, {0, 0, size_s}};
+  Triangle small_triangle{Point{-size_s, 0.f, 0.f}, Point{0.f, size_s, 0.f}, Point{0.f, 0.f, size_s}};
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{0.0, 0.0, 0.0}, {-size_s, size_s, size_s}}), small_triangle, size_s/sqrtf_3, size_s/sqrtf_3);
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{-2.f*size_s, -size_s, 0.0}, {size_s, size_s, 0}}), small_triangle, sqrtf_2*size_s, 2.f*sqrtf_2*size_s);
 
   float const size_l = 10000;
-  Triangle large_triangle{{-size_l, 0, 0}, {0, 10000, 0}, {0, 0, 10000}};
+  Triangle large_triangle{Point{-size_l, 0.f, 0.f}, Point{0.f, 10000.f, 0.f}, Point{0.f, 0.f, 10000.f}};
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{0.0, 0.0, 0.0}, {-size_l, size_l, size_l}}), large_triangle, size_l/sqrtf_3, size_l/sqrtf_3);
   ARBORX_TEST_RAY_TRIANGLE_INTERSECTION((Ray{{-2.f*size_l, -size_l, 0.0}, {size_l, size_l, 0}}), large_triangle, sqrtf_2*size_l, 2.f*sqrtf_2*size_l);
 
@@ -590,8 +595,9 @@ BOOST_AUTO_TEST_CASE(make_euclidean_vector)
 {
   using ArborX::Experimental::makeVector;
   using ArborX::Experimental::Vector;
-  static_assert(makeVector({0, 0, 0}, {1, 2, 3}) == Vector{1, 2, 3});
-  static_assert(makeVector({1, 2, 3}, {4, 5, 6}) == Vector{3, 3, 3});
+  using ArborX::ExperimentalHyperGeometry::Point;
+  static_assert(makeVector(Point{0, 0, 0}, Point{1, 2, 3}) == Vector{1, 2, 3});
+  static_assert(makeVector(Point{1, 2, 3}, Point{4, 5, 6}) == Vector{3, 3, 3});
 }
 
 BOOST_AUTO_TEST_CASE(dot_product)

--- a/test/tstRay.cpp
+++ b/test/tstRay.cpp
@@ -9,8 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 #include <ArborX_Box.hpp>
+#include <ArborX_HyperTriangle.hpp>
 #include <ArborX_Ray.hpp>
-#include <ArborX_Triangle.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -396,8 +396,8 @@ BOOST_AUTO_TEST_CASE(ray_sphere_intersection,
 BOOST_AUTO_TEST_CASE(intersects_triangle)
 {
   using ArborX::Experimental::Ray;
-  using ArborX::Experimental::Triangle;
   using ArborX::ExperimentalHyperGeometry::Point;
+  using ArborX::ExperimentalHyperGeometry::Triangle;
   constexpr Triangle unit_triangle{Point{0.f, 0.f, 0.f}, Point{1.f, 0.f, 0.f},
                                    Point{0.f, 1.f, 0.f}};
 
@@ -480,8 +480,8 @@ BOOST_AUTO_TEST_CASE(ray_triangle_intersection,
                      *boost::unit_test::tolerance(2e-6f))
 {
   using ArborX::Experimental::Ray;
-  using ArborX::Experimental::Triangle;
   using ArborX::ExperimentalHyperGeometry::Point;
+  using ArborX::ExperimentalHyperGeometry::Triangle;
 
   constexpr Triangle unit_triangle{Point{0.f, 0.f, 0.f}, Point{1.f, 0.f, 0.f},
                                    Point{0.f, 1.f, 0.f}};


### PR DESCRIPTION
Related to #542, #784, and #903.
This pull requests templates `ArborX::Experimental::Triangle` on the underlying points' dimension and floating point type. We discussed in the meeting that we don't care much about backward compatibility since the class is an Experimental namespace.
I chose to template separately on the dimension and floating point type instead of on the `Point` type for consistency with the classes in the `ExperimentalHyperGeometry` namespace.

~~Drive-by: We forgot to use the floating point type template argument in `ArborX::ExperimentalHyperGeometry::Sphere`'s GeometryTraits.~~