### PR TITLE
Allow different floating point types in hierarchy

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -42,9 +42,12 @@ struct HappyTreeFriends;
 template <
     typename MemorySpace, typename Value,
     typename IndexableGetter = Details::DefaultIndexableGetter,
-    typename BoundingVolume =
-        ExperimentalHyperGeometry::Box<GeometryTraits::dimension_v<std::decay_t<
-            decltype(std::declval<IndexableGetter>()(std::declval<Value>()))>>>>
+    typename BoundingVolume = ExperimentalHyperGeometry::Box<
+        GeometryTraits::dimension_v<std::decay_t<
+            decltype(std::declval<IndexableGetter>()(std::declval<Value>()))>>,
+        typename GeometryTraits::coordinate_type<
+            std::decay_t<decltype(std::declval<IndexableGetter>()(
+                std::declval<Value>()))>>::type>>
 class BasicBoundingVolumeHierarchy
 {
 public:
@@ -200,7 +203,9 @@ BasicBoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter,
       "ArborX::BVH::BVH::calculate_scene_bounding_box");
 
   // determine the bounding box of the scene
-  ExperimentalHyperGeometry::Box<DIM> bbox{};
+  ExperimentalHyperGeometry::Box<
+      DIM, typename GeometryTraits::coordinate_type<BoundingVolume>::type>
+      bbox{};
   Details::TreeConstruction::calculateBoundingBoxOfTheScene(
       space, Details::Indexables<Primitives>{primitives}, bbox);
 
@@ -285,7 +290,8 @@ void BasicBoundingVolumeHierarchy<
     Kokkos::Profiling::pushRegion(profiling_prefix + "::compute_permutation");
     using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
     ExperimentalHyperGeometry::Box<
-        GeometryTraits::dimension_v<bounding_volume_type>>
+        GeometryTraits::dimension_v<bounding_volume_type>,
+        typename GeometryTraits::coordinate_type<bounding_volume_type>::type>
         scene_bounding_box{};
     using namespace Details;
     expand(scene_bounding_box, bounds());

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -412,7 +412,8 @@ queryDispatch(Tag, Tree const &tree, ExecutionSpace const &space,
     Kokkos::Profiling::pushRegion(profiling_prefix + "::compute_permutation");
     using bounding_volume_type = std::decay_t<decltype(tree.bounds())>;
     ExperimentalHyperGeometry::Box<
-        GeometryTraits::dimension_v<bounding_volume_type>>
+        GeometryTraits::dimension_v<bounding_volume_type>,
+        typename GeometryTraits::coordinate_type<bounding_volume_type>::type>
         scene_bounding_box{};
     using namespace Details;
     expand(scene_bounding_box, tree.bounds());

--- a/src/details/ArborX_DetailsMortonCode.hpp
+++ b/src/details/ArborX_DetailsMortonCode.hpp
@@ -295,7 +295,7 @@ KOKKOS_INLINE_FUNCTION unsigned int morton32(Point const &p)
   unsigned int r = 0;
   for (int d = 0; d < DIM; ++d)
   {
-    auto x = min(max(p[d] * N, 0.f), (float)N - 1);
+    auto x = min(max((float)p[d] * N, 0.f), (float)N - 1);
     r += (expandBitsBy<DIM - 1>((unsigned int)x) << (DIM - d - 1));
   }
 
@@ -316,7 +316,7 @@ KOKKOS_INLINE_FUNCTION unsigned long long morton64(Point const &p)
   unsigned long long r = 0;
   for (int d = 0; d < DIM; ++d)
   {
-    auto x = min(max(p[d] * N, 0.f), (float)N - 1);
+    auto x = min(max((float)p[d] * N, 0.f), (float)N - 1);
     r += (expandBitsBy<DIM - 1>((unsigned long long)x) << (DIM - d - 1));
   }
 

--- a/test/tstCompileOnlyTypeRequirements.cpp
+++ b/test/tstCompileOnlyTypeRequirements.cpp
@@ -50,6 +50,11 @@ struct ArborX::GeometryTraits::dimension<Test::FakeBoundingVolume>
 {
   static constexpr int value = 3;
 };
+template <>
+struct ArborX::GeometryTraits::coordinate_type<Test::FakeBoundingVolume>
+{
+  using type = float;
+};
 
 // Compile-only
 void check_bounding_volume_and_predicate_geometry_type_requirements()


### PR DESCRIPTION
#916 made me realize that we never tested whether we are able to actually run a hierarchy built using `double`. Turns out we didn't. This patch fixes it, and updates one of the benchmarks (brute vs bvh) to run both float and double.

Scope:
- Fixes few places in the hierarchy where we unconditionally used `Box<DIM>` and similar
- Updates a benchmark