### PR TITLE
Improve deduction guide for ExperimentalHyperGeometry::Point

### DIFF
--- a/src/geometry/ArborX_HyperPoint.hpp
+++ b/src/geometry/ArborX_HyperPoint.hpp
@@ -22,6 +22,8 @@ namespace ArborX::ExperimentalHyperGeometry
 template <int DIM, class FloatingPoint = float>
 struct Point
 {
+  static_assert(DIM > 0);
+
   KOKKOS_FUNCTION
   constexpr auto &operator[](unsigned int i) { return _coords[i]; }
 

--- a/src/geometry/ArborX_HyperPoint.hpp
+++ b/src/geometry/ArborX_HyperPoint.hpp
@@ -34,15 +34,11 @@ struct Point
   FloatingPoint _coords[DIM] = {};
 };
 
-// Deduction guides
-template <class T>
-Point(T x) -> Point<1, T>;
-
-template <class T>
-Point(T x, T y) -> Point<2, T>;
-
-template <class T>
-Point(T x, T y, T z) -> Point<3, T>;
+template <typename... T>
+Point(T...)
+    -> Point<sizeof...(T), std::conditional_t<
+                               (... || std::is_same_v<std::decay_t<T>, double>),
+                               double, float>>;
 
 } // namespace ArborX::ExperimentalHyperGeometry
 

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -82,6 +82,22 @@ void test_access_traits_compile_only()
   // check_valid_access_traits(PrimitivesTag{}, LegacyAccessTraits{});
 }
 
+void test_point_ctad()
+{
+  using ArborX::ExperimentalHyperGeometry::Point;
+  static_assert(std::is_same_v<decltype(Point{}), Point<0, float>>);
+  static_assert(std::is_same_v<decltype(Point{1}), Point<1, float>>);
+  static_assert(std::is_same_v<decltype(Point{1.}), Point<1, double>>);
+  static_assert(std::is_same_v<decltype(Point{1., 2}), Point<2, double>>);
+  static_assert(std::is_same_v<decltype(Point{1, 2.}), Point<2, double>>);
+  static_assert(std::is_same_v<decltype(Point{2, 2}), Point<2, float>>);
+  static_assert(std::is_same_v<decltype(Point{2., 3.f, 2.}), Point<3, double>>);
+  static_assert(
+      std::is_same_v<decltype(Point{2.f, 3.f, 2.f}), Point<3, float>>);
+  static_assert(
+      std::is_same_v<decltype(Point<3, int>{2, 3, 2}), Point<3, int>>);
+}
+
 template <class V>
 using deduce_point_t =
     decltype(ArborX::AccessTraits<V, ArborX::PrimitivesTag>::get(

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -85,7 +85,6 @@ void test_access_traits_compile_only()
 void test_point_ctad()
 {
   using ArborX::ExperimentalHyperGeometry::Point;
-  static_assert(std::is_same_v<decltype(Point{}), Point<0, float>>);
   static_assert(std::is_same_v<decltype(Point{1}), Point<1, float>>);
   static_assert(std::is_same_v<decltype(Point{1.}), Point<1, double>>);
   static_assert(std::is_same_v<decltype(Point{1., 2}), Point<2, double>>);


### PR DESCRIPTION
In response to https://github.com/arborx/ArborX/pull/916#issuecomment-1662433663 and https://github.com/arborx/ArborX/pull/916#discussion_r1282012041.
- ~~we ensure that the template type argument is a floating point type.~~
- the deduction guide now works for all dimensions, and uses `double` if any of the arguments is a `double` and `float` otherwise.