### PR TITLE
Update hyper-geometries coordinate type

### DIFF
--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -103,6 +103,11 @@ struct GeometryTraits::tag<ArborX::Box>
 {
   using type = BoxTag;
 };
+template <>
+struct ArborX::GeometryTraits::coordinate_type<ArborX::Box>
+{
+  using type = float;
+};
 
 } // namespace ArborX
 

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -51,6 +51,12 @@ struct tag
 };
 
 template <typename Geometry>
+struct coordinate_type
+{
+  using type = not_specialized;
+};
+
+template <typename Geometry>
 using DimensionNotSpecializedArchetypeAlias =
     typename dimension<Geometry>::not_specialized;
 

--- a/src/geometry/ArborX_HyperBox.hpp
+++ b/src/geometry/ArborX_HyperBox.hpp
@@ -27,7 +27,7 @@ namespace ArborX::ExperimentalHyperGeometry
  * size 2x spatial dimension with a default constructor to initialize
  * properly an "empty" box.
  */
-template <int DIM, class FloatingPoint = float>
+template <int DIM, class Coordinate = float>
 struct Box
 {
   KOKKOS_FUNCTION
@@ -36,15 +36,15 @@ struct Box
     for (int d = 0; d < DIM; ++d)
     {
       _min_corner[d] =
-          KokkosExt::ArithmeticTraits::finite_max<FloatingPoint>::value;
+          KokkosExt::ArithmeticTraits::finite_max<Coordinate>::value;
       _max_corner[d] =
-          KokkosExt::ArithmeticTraits::finite_min<FloatingPoint>::value;
+          KokkosExt::ArithmeticTraits::finite_min<Coordinate>::value;
     }
   }
 
   KOKKOS_FUNCTION
-  constexpr Box(Point<DIM, FloatingPoint> const &min_corner,
-                Point<DIM, FloatingPoint> const &max_corner)
+  constexpr Box(Point<DIM, Coordinate> const &min_corner,
+                Point<DIM, Coordinate> const &max_corner)
       : _min_corner(min_corner)
       , _max_corner(max_corner)
   {}
@@ -61,8 +61,8 @@ struct Box
   KOKKOS_FUNCTION
   constexpr auto const &maxCorner() const { return _max_corner; }
 
-  Point<DIM, FloatingPoint> _min_corner;
-  Point<DIM, FloatingPoint> _max_corner;
+  Point<DIM, Coordinate> _min_corner;
+  Point<DIM, Coordinate> _max_corner;
 
   template <typename OtherBox,
             std::enable_if_t<GeometryTraits::is_box<OtherBox>{}> * = nullptr>
@@ -97,31 +97,30 @@ struct Box
 
 } // namespace ArborX::ExperimentalHyperGeometry
 
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::dimension<
-    ArborX::ExperimentalHyperGeometry::Box<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Box<DIM, Coordinate>>
 {
   static constexpr int value = DIM;
 };
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::tag<
-    ArborX::ExperimentalHyperGeometry::Box<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Box<DIM, Coordinate>>
 {
   using type = BoxTag;
 };
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::coordinate_type<
-    ArborX::ExperimentalHyperGeometry::Box<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Box<DIM, Coordinate>>
 {
-  using type = FloatingPoint;
+  using type = Coordinate;
 };
 
-template <int DIM, typename FloatingPoint>
+template <int DIM, typename Coordinate>
 struct Kokkos::reduction_identity<
-    ArborX::ExperimentalHyperGeometry::Box<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Box<DIM, Coordinate>>
 {
-  KOKKOS_FUNCTION static ArborX::ExperimentalHyperGeometry::Box<DIM,
-                                                                FloatingPoint>
+  KOKKOS_FUNCTION static ArborX::ExperimentalHyperGeometry::Box<DIM, Coordinate>
   sum()
   {
     return {};

--- a/src/geometry/ArborX_HyperBox.hpp
+++ b/src/geometry/ArborX_HyperBox.hpp
@@ -109,6 +109,12 @@ struct ArborX::GeometryTraits::tag<
 {
   using type = BoxTag;
 };
+template <int DIM, class FloatingPoint>
+struct ArborX::GeometryTraits::coordinate_type<
+    ArborX::ExperimentalHyperGeometry::Box<DIM, FloatingPoint>>
+{
+  using type = FloatingPoint;
+};
 
 template <int DIM, typename FloatingPoint>
 struct Kokkos::reduction_identity<

--- a/src/geometry/ArborX_HyperPoint.hpp
+++ b/src/geometry/ArborX_HyperPoint.hpp
@@ -19,7 +19,7 @@
 namespace ArborX::ExperimentalHyperGeometry
 {
 
-template <int DIM, class FloatingPoint = float>
+template <int DIM, class Coordinate = float>
 struct Point
 {
   static_assert(DIM > 0);
@@ -33,7 +33,7 @@ struct Point
   // Initialization is needed to be able to use Point in constexpr
   // TODO: do we want to actually want to zero initialize it? Seems like
   // unnecessary work.
-  FloatingPoint _coords[DIM] = {};
+  Coordinate _coords[DIM] = {};
 };
 
 template <typename... T>
@@ -44,23 +44,23 @@ Point(T...)
 
 } // namespace ArborX::ExperimentalHyperGeometry
 
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::dimension<
-    ArborX::ExperimentalHyperGeometry::Point<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Point<DIM, Coordinate>>
 {
   static constexpr int value = DIM;
 };
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::tag<
-    ArborX::ExperimentalHyperGeometry::Point<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Point<DIM, Coordinate>>
 {
   using type = PointTag;
 };
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::coordinate_type<
-    ArborX::ExperimentalHyperGeometry::Point<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Point<DIM, Coordinate>>
 {
-  using type = FloatingPoint;
+  using type = Coordinate;
 };
 
 #endif

--- a/src/geometry/ArborX_HyperPoint.hpp
+++ b/src/geometry/ArborX_HyperPoint.hpp
@@ -56,5 +56,11 @@ struct ArborX::GeometryTraits::tag<
 {
   using type = PointTag;
 };
+template <int DIM, class FloatingPoint>
+struct ArborX::GeometryTraits::coordinate_type<
+    ArborX::ExperimentalHyperGeometry::Point<DIM, FloatingPoint>>
+{
+  using type = FloatingPoint;
+};
 
 #endif

--- a/src/geometry/ArborX_HyperSphere.hpp
+++ b/src/geometry/ArborX_HyperSphere.hpp
@@ -19,15 +19,14 @@
 namespace ArborX::ExperimentalHyperGeometry
 {
 
-template <int DIM, class FloatingPoint = float>
+template <int DIM, class Coordinate = float>
 struct Sphere
 {
   KOKKOS_DEFAULTED_FUNCTION
   Sphere() = default;
 
   KOKKOS_FUNCTION
-  constexpr Sphere(Point<DIM, FloatingPoint> const &centroid,
-                   FloatingPoint radius)
+  constexpr Sphere(Point<DIM, Coordinate> const &centroid, Coordinate radius)
       : _centroid(centroid)
       , _radius(radius)
   {}
@@ -41,29 +40,29 @@ struct Sphere
   KOKKOS_FUNCTION
   constexpr auto radius() const { return _radius; }
 
-  Point<DIM, FloatingPoint> _centroid = {};
-  FloatingPoint _radius = 0;
+  Point<DIM, Coordinate> _centroid = {};
+  Coordinate _radius = 0;
 };
 
 } // namespace ArborX::ExperimentalHyperGeometry
 
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::dimension<
-    ArborX::ExperimentalHyperGeometry::Sphere<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Sphere<DIM, Coordinate>>
 {
   static constexpr int value = DIM;
 };
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::tag<
-    ArborX::ExperimentalHyperGeometry::Sphere<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Sphere<DIM, Coordinate>>
 {
   using type = SphereTag;
 };
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::coordinate_type<
-    ArborX::ExperimentalHyperGeometry::Sphere<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Sphere<DIM, Coordinate>>
 {
-  using type = FloatingPoint;
+  using type = Coordinate;
 };
 
 #endif

--- a/src/geometry/ArborX_HyperSphere.hpp
+++ b/src/geometry/ArborX_HyperSphere.hpp
@@ -59,5 +59,11 @@ struct ArborX::GeometryTraits::tag<
 {
   using type = SphereTag;
 };
+template <int DIM, class FloatingPoint>
+struct ArborX::GeometryTraits::coordinate_type<
+    ArborX::ExperimentalHyperGeometry::Sphere<DIM, FloatingPoint>>
+{
+  using type = FloatingPoint;
+};
 
 #endif

--- a/src/geometry/ArborX_HyperSphere.hpp
+++ b/src/geometry/ArborX_HyperSphere.hpp
@@ -47,15 +47,15 @@ struct Sphere
 
 } // namespace ArborX::ExperimentalHyperGeometry
 
-template <int DIM>
+template <int DIM, class FloatingPoint>
 struct ArborX::GeometryTraits::dimension<
-    ArborX::ExperimentalHyperGeometry::Sphere<DIM>>
+    ArborX::ExperimentalHyperGeometry::Sphere<DIM, FloatingPoint>>
 {
   static constexpr int value = DIM;
 };
-template <int DIM>
+template <int DIM, class FloatingPoint>
 struct ArborX::GeometryTraits::tag<
-    ArborX::ExperimentalHyperGeometry::Sphere<DIM>>
+    ArborX::ExperimentalHyperGeometry::Sphere<DIM, FloatingPoint>>
 {
   using type = SphereTag;
 };

--- a/src/geometry/ArborX_HyperTriangle.hpp
+++ b/src/geometry/ArborX_HyperTriangle.hpp
@@ -7,25 +7,25 @@ namespace ArborX::ExperimentalHyperGeometry
 {
 // need to add a protection that
 // the points are not on the same line.
-template <int DIM, class FloatingPoint = float>
+template <int DIM, class Coordinate = float>
 struct Triangle
 {
-  ExperimentalHyperGeometry::Point<DIM, FloatingPoint> a;
-  ExperimentalHyperGeometry::Point<DIM, FloatingPoint> b;
-  ExperimentalHyperGeometry::Point<DIM, FloatingPoint> c;
+  ExperimentalHyperGeometry::Point<DIM, Coordinate> a;
+  ExperimentalHyperGeometry::Point<DIM, Coordinate> b;
+  ExperimentalHyperGeometry::Point<DIM, Coordinate> c;
 };
 
-template <int DIM, class FloatingPoint>
-Triangle(ExperimentalHyperGeometry::Point<DIM, FloatingPoint>,
-         ExperimentalHyperGeometry::Point<DIM, FloatingPoint>,
-         ExperimentalHyperGeometry::Point<DIM, FloatingPoint>)
-    -> Triangle<DIM, FloatingPoint>;
+template <int DIM, class Coordinate>
+Triangle(ExperimentalHyperGeometry::Point<DIM, Coordinate>,
+         ExperimentalHyperGeometry::Point<DIM, Coordinate>,
+         ExperimentalHyperGeometry::Point<DIM, Coordinate>)
+    -> Triangle<DIM, Coordinate>;
 
 } // namespace ArborX::ExperimentalHyperGeometry
 
-template <int DIM, class FloatingPoint>
+template <int DIM, class Coordinate>
 struct ArborX::GeometryTraits::dimension<
-    ArborX::ExperimentalHyperGeometry::Triangle<DIM, FloatingPoint>>
+    ArborX::ExperimentalHyperGeometry::Triangle<DIM, Coordinate>>
 {
   static constexpr int value = DIM;
 };

--- a/src/geometry/ArborX_KDOP.hpp
+++ b/src/geometry/ArborX_KDOP.hpp
@@ -329,5 +329,10 @@ struct ArborX::GeometryTraits::tag<ArborX::Experimental::KDOP<k>>
 {
   using type = KDOPTag;
 };
+template <int k>
+struct ArborX::GeometryTraits::coordinate_type<ArborX::Experimental::KDOP<k>>
+{
+  using type = float;
+};
 
 #endif

--- a/src/geometry/ArborX_Point.hpp
+++ b/src/geometry/ArborX_Point.hpp
@@ -68,6 +68,11 @@ struct GeometryTraits::tag<ArborX::Point>
 {
   using type = PointTag;
 };
+template <>
+struct ArborX::GeometryTraits::coordinate_type<ArborX::Point>
+{
+  using type = float;
+};
 
 } // namespace ArborX
 

--- a/src/geometry/ArborX_Sphere.hpp
+++ b/src/geometry/ArborX_Sphere.hpp
@@ -53,6 +53,11 @@ struct GeometryTraits::tag<ArborX::Sphere>
 {
   using type = SphereTag;
 };
+template <>
+struct ArborX::GeometryTraits::coordinate_type<ArborX::Sphere>
+{
+  using type = float;
+};
 
 } // namespace ArborX
 


### PR DESCRIPTION
- Rename second argument in hyper geometries: `FloatingPoint` -> `Coordinate`
- Provide `GeometricTraits::coordinate_type<Geometry>` similar to Boost Geometry
- Fix `ExperimentalHyperGeometry::Sphere` to allow coordinate type