### PR TITLE
Disable tests in the nightly CUDA build

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -29,7 +29,8 @@ pipeline {
                         sh 'cmake -S source-kokkos -B build-kokkos -D CMAKE_INSTALL_PREFIX=$PWD/install-kokkos $CMAKE_OPTIONS -D Kokkos_ENABLE_CUDA=ON -D Kokkos_ENABLE_CUDA_LAMBDA=ON'
                         sh 'cmake --build build-kokkos --parallel 8'
                         sh 'cmake --install build-kokkos'
-                        sh 'cmake -B build-arborx -D CMAKE_INSTALL_PREFIX=$PWD/install-arborx -D Kokkos_ROOT=$PWD/install-kokkos $CMAKE_OPTIONS -D ARBORX_ENABLE_BENCHMARKS=ON -D ARBORX_ENABLE_TESTS=ON -D ARBORX_ENABLE_EXAMPLES=ON'
+                        // Disable tests as Ubuntu 22.04 comes with Boost 1.74 which causes build issues with CUDA
+                        sh 'cmake -B build-arborx -D CMAKE_INSTALL_PREFIX=$PWD/install-arborx -D Kokkos_ROOT=$PWD/install-kokkos $CMAKE_OPTIONS -D ARBORX_ENABLE_BENCHMARKS=ON -D ARBORX_ENABLE_TESTS=OFF -D ARBORX_ENABLE_EXAMPLES=ON'
                         sh 'cmake --build build-arborx --parallel 8'
                         dir('build-arborx') {
                             sh 'ctest $CTEST_OPTIONS'


### PR DESCRIPTION
Nightly tests fail because the CUDA build has enabled tests with boost 1.74. That was enabled in #913. My fault, I didn't understand @dalg24's [comment](https://github.com/arborx/ArborX/pull/913#discussion_r1270873170).

This patch disables tests, but keeps examples enabled. 

The alternative would be to install a newer boost version, either manually or using something an [external repo](https://launchpad.net/~mhier/+archive/ubuntu/libboost-latest). I chose simplicity as to not add a fragile point.