### PR TITLE
Suppress -Wsycl-target warnings for SYCL CI

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -421,7 +421,7 @@ pipeline {
                                     -D CMAKE_BUILD_TYPE=Release \
                                     -D CMAKE_CXX_COMPILER=${DPCPP} \
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
-                                    -D CMAKE_CXX_FLAGS="-fp-model=precise -fsycl-device-code-split=per_kernel -Wpedantic -Wall -Wextra -Wno-unknown-cuda-version -Wno-deprecated-declarations" \
+                                    -D CMAKE_CXX_FLAGS="-fp-model=precise -fsycl-device-code-split=per_kernel -Wpedantic -Wall -Wextra -Wno-sycl-target -Wno-unknown-cuda-version -Wno-deprecated-declarations" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
                                     -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
@@ -458,7 +458,7 @@ pipeline {
                                         -D CMAKE_BUILD_TYPE=Release \
                                         -D CMAKE_CXX_COMPILER=${DPCPP} \
                                         -D CMAKE_CXX_EXTENSIONS=OFF \
-                                        -D CMAKE_CXX_FLAGS="-Wno-unknown-cuda-version -Wno-deprecated-declarations" \
+                                        -D CMAKE_CXX_FLAGS="-Wno-sycl-target -Wno-unknown-cuda-version -Wno-deprecated-declarations" \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
                                     examples \
                                 '''


### PR DESCRIPTION
We are seeing
```
clang++: warning: linked binaries do not contain expected 'nvptx64-nvidia-cuda' target; found targets: 'nvptx64-nvidia-cuda-sm_70' [-Wsycl-target]
```
a bunch in the CI. Supposedly, this was fixed by https://github.com/intel/llvm/pull/7434. It shouldn't matter much anyway (and if so it would be more of a `Kokkos` issue than an `ArborX` issue) and there is no reason to fail the CI because of this warning.