### PR TITLE
Get rid of old Point, Box, Sphere

### DIFF
--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -129,9 +129,9 @@ makeSpatialQueries(int n_values, int n_queries, int n_neighbors,
               n_queries);
   // Radius is computed so that the number of results per query for a uniformly
   // distributed points in a [-a,a]^3 box is approximately n_neighbors.
-  // Calculation: n_values*(4/3*pi*r^3)/(2a)^3 = n_neighbors
-  double const r = std::cbrt(static_cast<double>(n_neighbors) * 6. /
-                             Kokkos::numbers::pi_v<double>);
+  // Calculation: n_values*(4/3*M_PI*r^3)/(2a)^3 = n_neighbors
+  float const r = std::cbrt(static_cast<float>(n_neighbors) * 6 /
+                            Kokkos::numbers::pi_v<float>);
   using ExecutionSpace = typename DeviceType::execution_space;
   Kokkos::parallel_for(
       "bvh_driver:setup_radius_search_queries",

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -178,7 +178,7 @@ template <typename DeviceType>
 struct RadiusSearches
 {
   Kokkos::View<ArborX::Point *, DeviceType> points;
-  double radius;
+  float radius;
 };
 
 template <typename DeviceType>
@@ -299,10 +299,10 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "Testing::queries"),
       n_queries);
   {
-    double a = 0.;
-    double offset_x = 0.;
-    double offset_y = 0.;
-    double offset_z = 0.;
+    float a = 0.;
+    float offset_x = 0.;
+    float offset_y = 0.;
+    float offset_z = 0.;
     int i_max = 0;
     // Change the geometry of the problem. In 1D, all the point clouds are
     // aligned on a line. In 2D, the point clouds create a board and in 3D,
@@ -349,7 +349,7 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     }
 
     // Generate random points uniformly distributed within a box.
-    std::uniform_real_distribution<double> distribution(-1., 1.);
+    std::uniform_real_distribution<float> distribution(-1., 1.);
     std::default_random_engine generator;
     auto random = [&distribution, &generator]() {
       return distribution(generator);
@@ -405,11 +405,10 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
   Kokkos::parallel_for(
       "bvh_driver:construct_bounding_boxes",
       Kokkos::RangePolicy<ExecutionSpace>(0, n_values), KOKKOS_LAMBDA(int i) {
-        double const x = random_values(i)[0];
-        double const y = random_values(i)[1];
-        double const z = random_values(i)[2];
-        bounding_boxes(i) = {{{x - 1., y - 1., z - 1.}},
-                             {{x + 1., y + 1., z + 1.}}};
+        float const x = random_values(i)[0];
+        float const y = random_values(i)[1];
+        float const z = random_values(i)[2];
+        bounding_boxes(i) = {{{x - 1, y - 1, z - 1}}, {{x + 1, y + 1, z + 1}}};
       });
 
   auto construction = time_monitor.getNewTimer("construction");
@@ -452,23 +451,23 @@ int main_(std::vector<std::string> const &args, const MPI_Comm comm)
     // average of the lengths of a half-edge and a half-diagonal to account for
     // that (approximately). An exact calculation would require computing
     // an integral.
-    double r = 0.;
+    float r = 0.;
     switch (partition_dim)
     {
     case 1:
       // Derivation (first term): n_values*(2*r)/(2a) = n_neighbors
-      r = static_cast<double>(n_neighbors) - 1.;
+      r = static_cast<float>(n_neighbors) - 1.;
       break;
     case 2:
       // Derivation (first term): n_values*(pi*r^2)/(2a)^2 = n_neighbors
-      r = std::sqrt(static_cast<double>(n_neighbors) * 4. /
-                    Kokkos::numbers::pi_v<double>) -
+      r = std::sqrt(static_cast<float>(n_neighbors) * 4 /
+                    Kokkos::numbers::pi_v<float>) -
           (1. + std::sqrt(2.)) / 2;
       break;
     case 3:
       // Derivation (first term): n_values*(4/3*pi*r^3)/(2a)^3 = n_neighbors
-      r = std::cbrt(static_cast<double>(n_neighbors) * 6. /
-                    Kokkos::numbers::pi_v<double>) -
+      r = std::cbrt(static_cast<float>(n_neighbors) * 6 /
+                    Kokkos::numbers::pi_v<float>) -
           (1. + std::cbrt(3.)) / 2;
       break;
     }

--- a/examples/simple_intersection/example_intersection.cpp
+++ b/examples/simple_intersection/example_intersection.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/simple_intersection/example_intersection.cpp
+++ b/examples/simple_intersection/example_intersection.cpp
@@ -61,9 +61,9 @@ public:
         for (int k = 0; k < nz; ++k)
         {
           ArborX::Point p_lower{
-              {(i - .25) * hx, (j - .25) * hy, (k - .25) * hz}};
+              {(i - .25f) * hx, (j - .25f) * hy, (k - .25f) * hz}};
           ArborX::Point p_upper{
-              {(i + .25) * hx, (j + .25) * hy, (k + .25) * hz}};
+              {(i + .25f) * hx, (j + .25f) * hy, (k + .25f) * hz}};
           boxes_host[index(i, j, k)] = {p_lower, p_upper};
         }
     Kokkos::deep_copy(execution_space, _boxes, boxes_host);

--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *
@@ -12,109 +12,11 @@
 #ifndef ARBORX_BOX_HPP
 #define ARBORX_BOX_HPP
 
-#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
-#include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
-#include <ArborX_GeometryTraits.hpp>
-#include <ArborX_Point.hpp>
-
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_ReductionIdentity.hpp>
+#include <ArborX_HyperBox.hpp>
 
 namespace ArborX
 {
-/**
- * Axis-Aligned Bounding Box. This is just a thin wrapper around an array of
- * size 2x spatial dimension with a default constructor to initialize
- * properly an "empty" box.
- */
-struct Box
-{
-  KOKKOS_DEFAULTED_FUNCTION
-  constexpr Box() = default;
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Box(Point const &min_corner, Point const &max_corner)
-      : _min_corner(min_corner)
-      , _max_corner(max_corner)
-  {}
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point &minCorner() { return _min_corner; }
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point const &minCorner() const { return _min_corner; }
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point &maxCorner() { return _max_corner; }
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point const &maxCorner() const { return _max_corner; }
-
-  Point _min_corner = {{KokkosExt::ArithmeticTraits::finite_max<float>::value,
-                        KokkosExt::ArithmeticTraits::finite_max<float>::value,
-                        KokkosExt::ArithmeticTraits::finite_max<float>::value}};
-  Point _max_corner = {{KokkosExt::ArithmeticTraits::finite_min<float>::value,
-                        KokkosExt::ArithmeticTraits::finite_min<float>::value,
-                        KokkosExt::ArithmeticTraits::finite_min<float>::value}};
-
-  KOKKOS_FUNCTION Box &operator+=(Box const &other)
-  {
-    using KokkosExt::max;
-    using KokkosExt::min;
-
-    for (int d = 0; d < 3; ++d)
-    {
-      minCorner()[d] = min(minCorner()[d], other.minCorner()[d]);
-      maxCorner()[d] = max(maxCorner()[d], other.maxCorner()[d]);
-    }
-    return *this;
-  }
-
-  KOKKOS_FUNCTION Box &operator+=(Point const &point)
-  {
-    using KokkosExt::max;
-    using KokkosExt::min;
-
-    for (int d = 0; d < 3; ++d)
-    {
-      minCorner()[d] = min(minCorner()[d], point[d]);
-      maxCorner()[d] = max(maxCorner()[d], point[d]);
-    }
-    return *this;
-  }
-
-// FIXME Temporary workaround until we clarify requirements on the Kokkos side.
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_SYCL)
-private:
-  friend KOKKOS_FUNCTION Box operator+(Box box, Box const &other)
-  {
-    return box += other;
-  }
-#endif
-};
-
-template <>
-struct GeometryTraits::dimension<ArborX::Box>
-{
-  static constexpr int value = 3;
-};
-template <>
-struct GeometryTraits::tag<ArborX::Box>
-{
-  using type = BoxTag;
-};
-template <>
-struct ArborX::GeometryTraits::coordinate_type<ArborX::Box>
-{
-  using type = float;
-};
-
-} // namespace ArborX
-
-template <>
-struct Kokkos::reduction_identity<ArborX::Box>
-{
-  KOKKOS_FUNCTION static ArborX::Box sum() { return {}; }
-};
+using Box = ArborX::ExperimentalHyperGeometry::Box<3, float>;
+}
 
 #endif

--- a/src/geometry/ArborX_Point.hpp
+++ b/src/geometry/ArborX_Point.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *
@@ -9,71 +9,14 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#ifndef ARBORX_DETAILS_POINT_HPP
-#define ARBORX_DETAILS_POINT_HPP
+#ifndef ARBORX_POINT_HPP
+#define ARBORX_POINT_HPP
 
-#include <ArborX_GeometryTraits.hpp>
-
-#include <Kokkos_Macros.hpp>
-
-#include <utility>
+#include <ArborX_HyperPoint.hpp>
 
 namespace ArborX
 {
-class Point
-{
-private:
-  struct Data
-  {
-    float coords[3];
-  } _data = {};
-
-  struct Abomination
-  {
-    double xyz[3];
-  };
-
-public:
-  KOKKOS_DEFAULTED_FUNCTION
-  constexpr Point() noexcept = default;
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point(Abomination data)
-      : Point(static_cast<float>(data.xyz[0]), static_cast<float>(data.xyz[1]),
-              static_cast<float>(data.xyz[2]))
-  {}
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point(float x, float y, float z)
-      : _data{{x, y, z}}
-  {}
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr float &operator[](unsigned int i) { return _data.coords[i]; }
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr float const &operator[](unsigned int i) const
-  {
-    return _data.coords[i];
-  }
-};
-
-template <>
-struct GeometryTraits::dimension<ArborX::Point>
-{
-  static constexpr int value = 3;
-};
-template <>
-struct GeometryTraits::tag<ArborX::Point>
-{
-  using type = PointTag;
-};
-template <>
-struct ArborX::GeometryTraits::coordinate_type<ArborX::Point>
-{
-  using type = float;
-};
-
-} // namespace ArborX
+using Point = ArborX::ExperimentalHyperGeometry::Point<3, float>;
+}
 
 #endif

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -29,10 +29,8 @@ namespace ArborX
 namespace Experimental
 {
 
-struct Vector : private Point
+struct Vector : public Point
 {
-  using Point::Point;
-  using Point::operator[];
   friend KOKKOS_FUNCTION constexpr bool operator==(Vector const &v,
                                                    Vector const &w)
   {

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -45,12 +45,7 @@ KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
     Vector>
 makeVector(Point const &begin, Point const &end)
 {
-  Vector v;
-  for (int d = 0; d < 3; ++d)
-  {
-    v[d] = end[d] - begin[d];
-  }
-  return v;
+  return {end[0] - begin[0], end[1] - begin[1], end[2] - begin[2]};
 }
 
 KOKKOS_INLINE_FUNCTION constexpr auto dotProduct(Vector const &v,

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -38,14 +38,12 @@ struct Vector : public Point
   }
 };
 
-template <typename Point1, typename Point2>
+template <typename Point>
 KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    GeometryTraits::is_point<Point1>::value &&
-        GeometryTraits::is_point<Point2>::value &&
-        GeometryTraits::dimension_v<Point1> == 3 &&
-        GeometryTraits::dimension_v<Point2> == 3,
+    GeometryTraits::is_point<Point>::value &&
+        GeometryTraits::dimension_v<Point> == 3,
     Vector>
-makeVector(Point1 const &begin, Point2 const &end)
+makeVector(Point const &begin, Point const &end)
 {
   Vector v;
   for (int d = 0; d < 3; ++d)

--- a/src/geometry/ArborX_Sphere.hpp
+++ b/src/geometry/ArborX_Sphere.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *
@@ -8,57 +8,14 @@
  *                                                                          *
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
-#ifndef ARBORX_Sphere_HPP
-#define ARBORX_Sphere_HPP
+#ifndef ARBORX_SPHERE_HPP
+#define ARBORX_SPHERE_HPP
 
-#include <ArborX_GeometryTraits.hpp>
-#include <ArborX_Point.hpp>
-
-#include <Kokkos_Macros.hpp>
+#include <ArborX_HyperSphere.hpp>
 
 namespace ArborX
 {
-
-struct Sphere
-{
-  KOKKOS_DEFAULTED_FUNCTION
-  Sphere() = default;
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Sphere(Point const &centroid, double radius) // FIXME
-      : _centroid(centroid)
-      , _radius(static_cast<float>(radius))
-  {}
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point &centroid() { return _centroid; }
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr Point const &centroid() const { return _centroid; }
-
-  KOKKOS_INLINE_FUNCTION
-  constexpr float radius() const { return _radius; }
-
-  Point _centroid = {};
-  float _radius = 0.;
-};
-
-template <>
-struct GeometryTraits::dimension<ArborX::Sphere>
-{
-  static constexpr int value = 3;
-};
-template <>
-struct GeometryTraits::tag<ArborX::Sphere>
-{
-  using type = SphereTag;
-};
-template <>
-struct ArborX::GeometryTraits::coordinate_type<ArborX::Sphere>
-{
-  using type = float;
-};
-
-} // namespace ArborX
+using Sphere = ArborX::ExperimentalHyperGeometry::Sphere<3, float>;
+}
 
 #endif

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -169,8 +169,8 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(!bg::is_valid(other_invalid_box, message));
   BOOST_TEST(message == "Box has corners in wrong order");
 
-  auto const infty = std::numeric_limits<double>::infinity();
-  other_invalid_box = {{{1., 5., 3.}}, {{infty, 3., 6.}}};
+  auto const infty = std::numeric_limits<float>::infinity();
+  other_invalid_box = {{{1.f, 5.f, 3.f}}, {{infty, 3.f, 6.f}}};
   BOOST_TEST(!details::isValid(other_invalid_box));
   BOOST_TEST(!bg::is_valid(other_invalid_box, message));
   BOOST_TEST(message == "Geometry has point(s) with invalid coordinate(s)");

--- a/test/tstKDOP.cpp
+++ b/test/tstKDOP.cpp
@@ -68,17 +68,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(intersects_point, KDOP_t, KDOP_types)
   {
     KDOP_t x; // unit cube with (1,1,0)--(1,1,1) edge chopped away
     // bottom face
-    x += Point(0, 0, 0);
-    x += Point(1, 0, 0);
-    x += Point(1, 0.75, 0);
-    x += Point(0.75, 1, 0);
-    x += Point(0, 1, 0);
+    x += Point{0, 0, 0};
+    x += Point{1, 0, 0};
+    x += Point{1, 0.75f, 0};
+    x += Point{0.75f, 1, 0};
+    x += Point{0, 1, 0};
     // top
-    x += Point(0, 0, 1);
-    x += Point(1, 0, 1);
-    x += Point(1, 0.75, 1);
-    x += Point(0.75, 1, 1);
-    x += Point(0, 1, 1);
+    x += Point{0, 0, 1};
+    x += Point{1, 0, 1};
+    x += Point{1, 0.75f, 1};
+    x += Point{0.75f, 1, 1};
+    x += Point{0, 1, 1};
     // test intersection with point on the missing edge
     BOOST_TEST(intersects(Point{1, 1, 0.5}, x) ==
                (std::is_same<KDOP_t, KDOP<6>>::value ||
@@ -106,16 +106,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(intersects_point, KDOP_t, KDOP_types)
   {
     KDOP_t x; // unit cube with (1,1,1) corner cut off
     // bottom face
-    x += Point(0, 0, 0);
-    x += Point(1, 0, 0);
-    x += Point(1, 1, 0);
-    x += Point(0, 1, 0);
+    x += Point{0, 0, 0};
+    x += Point{1, 0, 0};
+    x += Point{1, 1, 0};
+    x += Point{0, 1, 0};
     // top
-    x += Point(0, 0, 1);
-    x += Point(1, 0, 1);
-    x += Point(1, 0.75, 1);
-    x += Point(0.75, 1, 1);
-    x += Point(0, 1, 1);
+    x += Point{0, 0, 1};
+    x += Point{1, 0, 1};
+    x += Point{1, 0.75f, 1};
+    x += Point{0.75f, 1, 1};
+    x += Point{0, 1, 1};
     // test intersection with center of the missing corner
     BOOST_TEST(intersects(Point{1, 1, 1}, x) ==
                (std::is_same<KDOP_t, KDOP<6>>::value ||

--- a/test/tstKDOP.cpp
+++ b/test/tstKDOP.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_spatial_predicate, TreeTypeTraits,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
 
   auto values = initialize_values(points, /*delta*/ 0.f);
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_nearest_predicate, TreeTypeTraits,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
   ArborX::Point const origin = {{0., 0., 0.}};
 
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_spatial_predicate,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
   float const delta = 5.f;
 
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_nearest_predicate,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
   float const delta = 5.f;
   ArborX::Point const origin = {{0., 0., 0.}};

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_SUITE(ComparisonWithBoost)
 namespace tt = boost::test_tools;
 
 inline Kokkos::View<ArborX::Point *, Kokkos::HostSpace>
-make_stuctured_cloud(double Lx, double Ly, double Lz, int nx, int ny, int nz)
+make_stuctured_cloud(float Lx, float Ly, float Lz, int nx, int ny, int nz)
 {
   std::function<int(int, int, int)> ind = [nx, ny](int i, int j, int k) {
     return i + j * nx + k * (nx * ny);
@@ -61,9 +61,9 @@ template <typename Tree, typename ExecutionSpace, typename DeviceType,
 void boost_rtree_nearest_predicate()
 {
   // construct a cloud of points (nodes of a structured grid)
-  double Lx = 10.0;
-  double Ly = 10.0;
-  double Lz = 10.0;
+  float Lx = 10.0;
+  float Ly = 10.0;
+  float Lz = 10.0;
   int nx = 11;
   int ny = 11;
   int nz = 11;
@@ -125,9 +125,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
 #endif
 
   // construct a cloud of points (nodes of a structured grid)
-  double Lx = 10.0;
-  double Ly = 10.0;
-  double Lz = 10.0;
+  float Lx = 10.0;
+  float Ly = 10.0;
+  float Lz = 10.0;
   int nx = 11;
   int ny = 11;
   int nz = 11;
@@ -140,11 +140,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
   auto points = ArborXTest::make_random_cloud<ArborX::Point>(
       ExecutionSpace{}, n_points, Lx, Ly, Lz);
 
-  Kokkos::View<double *, ExecutionSpace> radii("radii", n_points);
+  Kokkos::View<float *, ExecutionSpace> radii("radii", n_points);
   auto radii_host = Kokkos::create_mirror_view(radii);
   // use random radius for the search
   std::default_random_engine generator;
-  std::uniform_real_distribution<double> distribution_radius(
+  std::uniform_real_distribution<float> distribution_radius(
       0.0, std::sqrt(Lx * Lx + Ly * Ly + Lz * Lz));
   for (unsigned int i = 0; i < n_points; ++i)
   {

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -350,8 +350,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_spatial_predicate,
   boxes.reserve(n);
   for (int i = 0; i < n; ++i)
   {
-    double const a = i;
-    double const b = i + 1;
+    float const a = i;
+    float const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
   ExecutionSpace space;
@@ -384,8 +384,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_nearest_predicate,
   boxes.reserve(n);
   for (int i = 0; i < n; ++i)
   {
-    double const a = i;
-    double const b = i + 1;
+    float const a = i;
+    float const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
   ExecutionSpace space;

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
   std::uniform_int_distribution<> dist_x(0, nx - 1);
   std::uniform_int_distribution<> dist_y(0, ny - 1);
   std::uniform_int_distribution<> dist_z(0, nz - 1);
-  std::uniform_real_distribution<double> dist_shift(-0.45, 0.45);
+  std::uniform_real_distribution<float> dist_shift(-0.45, 0.45);
 
   // The generation is a bit convoluted to avoid a situation where a centroid
   // of a box falls on any of the lattice planes, resulting in multiple
@@ -244,8 +244,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
     auto const x = (i + dist_shift(generator)) * hx;
     auto const y = (j + dist_shift(generator)) * hy;
     auto const z = (k + dist_shift(generator)) * hz;
-    bounding_boxes_host(l) = {{{x - 0.5 * hx, y - 0.5 * hy, z - 0.5 * hz}},
-                              {{x + 0.5 * hx, y + 0.5 * hy, z + 0.5 * hz}}};
+    bounding_boxes_host(l) = {{{x - 0.5f * hx, y - 0.5f * hy, z - 0.5f * hz}},
+                              {{x + 0.5f * hx, y + 0.5f * hy, z + 0.5f * hz}}};
 
     // Save the indices for the check
     indices_ref[l] = ind(i, j, k);

--- a/test/tstQueryTreeRay.cpp
+++ b/test/tstQueryTreeRay.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeRay.cpp
+++ b/test/tstQueryTreeRay.cpp
@@ -79,8 +79,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_nearest, DeviceType,
 
   std::vector<ArborX::Box> boxes;
   for (unsigned int i = 0; i < 10; ++i)
-    boxes.emplace_back(ArborX::Point(i, i, i),
-                       ArborX::Point(i + 1, i + 1, i + 1));
+    boxes.emplace_back(ArborX::Point{(float)i, (float)i, (float)i},
+                       ArborX::Point{(float)i + 1, (float)i + 1, (float)i + 1});
   Kokkos::View<ArborX::Box *, DeviceType> device_boxes("boxes", 10);
   Kokkos::deep_copy(exec_space, device_boxes,
                     Kokkos::View<ArborX::Box *, Kokkos::HostSpace>(
@@ -110,8 +110,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_intersection, DeviceType,
 
   std::vector<ArborX::Box> boxes;
   for (unsigned int i = 0; i < 10; ++i)
-    boxes.emplace_back(ArborX::Point(i, i, i),
-                       ArborX::Point(i + 1, i + 1, i + 1));
+    boxes.emplace_back(ArborX::Point{(float)i, (float)i, (float)i},
+                       ArborX::Point{(float)i + 1, (float)i + 1, (float)i + 1});
   Kokkos::View<ArborX::Box *, DeviceType> device_boxes("boxes", 10);
   Kokkos::deep_copy(exec_space, device_boxes,
                     Kokkos::View<ArborX::Box *, Kokkos::HostSpace>(
@@ -188,8 +188,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_intersection_new, DeviceType,
   std::vector<ArborX::Box> boxes;
   int const n = 10;
   for (unsigned int i = 0; i < n; ++i)
-    boxes.emplace_back(ArborX::Point(i, i, i),
-                       ArborX::Point(i + 1, i + 1, i + 1));
+    boxes.emplace_back(ArborX::Point{(float)i, (float)i, (float)i},
+                       ArborX::Point{(float)i + 1, (float)i + 1, (float)i + 1});
   auto device_boxes = ArborXTest::toView<DeviceType>(boxes, "boxes");
 
   ArborX::BVH<memory_space> const tree(exec_space, device_boxes);


### PR DESCRIPTION
This PR unified old and new geometries by aliasing old with news

It breaks backwards compatibility:
**`ArborX::Point` will no longer narrow down `double` to `float`**. 

It also prevents a user from doing 
```c++
  int i = <some non constant>;
  ArborX::Point p{i, i, i};
```
as it results in a warning about narrowing non-constant.

I'm presenting this PR to discuss how we would want to proceed. When do we want to break backwards compatibility? I don't think we could do any deprecation.

In the long term, hyper-geometries would be in `ArborX::` namespace instead of experimental. But that would introduce a second backward-incompatible change. Do we want to do both in the same sweep?