### PR TITLE
Use oneapi::dpl::sort_by_key if possible

### DIFF
--- a/src/kokkos_ext/ArborX_DetailsKokkosExtSort.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtSort.hpp
@@ -170,13 +170,18 @@ void sortByKey(Kokkos::Experimental::SYCL const &space, Keys &keys,
   if (n == 0)
     return;
 
-  auto zipped_begin =
-      oneapi::dpl::make_zip_iterator(keys.data(), values.data());
   oneapi::dpl::execution::device_policy policy(
       *space.impl_internal_space_instance()->m_queue);
+#if ONEDPL_VERSION_MAJOR > 2022 ||                                             \
+    (ONEDPL_VERSION_MAJOR == 2022 && ONEDPL_VESION_MINOR >= 2)
+  oneapi::dpl::sort_by_key(policy, keys.data(), keys.data() + n, values.data());
+#else
+  auto zipped_begin =
+      oneapi::dpl::make_zip_iterator(keys.data(), values.data());
   oneapi::dpl::sort(
       policy, zipped_begin, zipped_begin + n,
       [](auto lhs, auto rhs) { return std::get<0>(lhs) < std::get<0>(rhs); });
+#endif
 }
 #endif
 

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtSort.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtSort.hpp
@@ -173,7 +173,7 @@ void sortByKey(Kokkos::Experimental::SYCL const &space, Keys &keys,
   oneapi::dpl::execution::device_policy policy(
       *space.impl_internal_space_instance()->m_queue);
 #if ONEDPL_VERSION_MAJOR > 2022 ||                                             \
-    (ONEDPL_VERSION_MAJOR == 2022 && ONEDPL_VESION_MINOR >= 2)
+    (ONEDPL_VERSION_MAJOR == 2022 && ONEDPL_VERSION_MINOR >= 2)
   oneapi::dpl::sort_by_key(policy, keys.data(), keys.data() + n, values.data());
 #else
   auto zipped_begin =


### PR DESCRIPTION
Fixes #926. I didn't see much of a difference in performance but that also wasn't really expected at this point.