### PR TITLE
Fix compiling with cuda-12.2

### DIFF
--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -278,8 +278,9 @@ public:
             space, std::declval<typename ImportView::memory_space>(),
             std::declval<ExportViewWithoutMemoryTraits>()));
 
-    constexpr int pointer_depth = internal::PointerDepth<
-        typename DestBufferMirrorViewType::traits::data_type>::value;
+    // nvcc-12.2 fails compiling if using DestBufferMirrorViewType here
+    constexpr int pointer_depth =
+        internal::PointerDepth<typename ExportView::data_type>::value;
     DestBufferMirrorViewType dest_buffer_mirror(
         "ArborX::Distributor::doPostsAndWaits::destination_buffer_mirror", 0,
         pointer_depth > 1 ? 0 : KOKKOS_INVALID_INDEX,


### PR DESCRIPTION
Compiling with cuda-12.2 gives errors like
```
cd /app/ArborX/build/test && /app/kokkos-cuda-12.2/bin/kokkos_launch_compiler /app/kokkos-cuda-12.2/bin/nvcc_wrapper /usr/bin/c++ /usr/bin/c++ -DARBORX_MPI_UNIT_TEST -DBOOST_TEST_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_NO_LIB -DKOKKOS_DEPENDENCE -I/app/ArborX/build/test -I/app/ArborX/src -I/app/ArborX/src/details -I/app/ArborX/src/geometry -I/app/ArborX/src/kokkos_ext -I/app/ArborX/build/include -isystem /app/kokkos-cuda-12.2/include -isystem /usr/local/cuda/include -isystem /usr/lib/x86_64-linux-gnu/openmpi/include -isystem /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -isystem /opt/boost/include -O2 -g -DNDEBUG -extended-lambda -Wext-lambda-captures-this -arch=sm_80 -std=c++17 -MD -MT test/CMakeFiles/ArborX_Test_DistributedTree.exe.dir/tstKokkosToolsDistributedAnnotations.cpp.o -MF CMakeFiles/ArborX_Test_DistributedTree.exe.dir/tstKokkosToolsDistributedAnnotations.cpp.o.d -o CMakeFiles/ArborX_Test_DistributedTree.exe.dir/tstKokkosToolsDistributedAnnotations.cpp.o -c /app/ArborX/test/tstKokkosToolsDistributedAnnotations.cpp
/app/ArborX/src/details/ArborX_DetailsDistributor.hpp: In instantiation of 'void ArborX::Details::Distributor<DeviceType>::doPostsAndWaits(const ExecutionSpace&, const ExportView&, size_t, const ImportView&) const [with ExecutionSpace = Kokkos::Cuda; ExportView = Kokkos::View<int*, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> >; ImportView = Kokkos::View<int*, Kokkos::HostSpace, Kokkos::MemoryTraits<1> >; DeviceType = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>; size_t = long unsigned int]':
/app/ArborX/src/details/ArborX_DetailsDistributedTreeImpl.hpp:292:28:   required from 'static typename std::enable_if<Kokkos::is_view<View>::value>::type ArborX::Details::DistributedTreeImpl<DeviceType>::sendAcrossNetwork(const ExecutionSpace&, const ArborX::Details::Distributor<DeviceType>&, View, typename View::non_const_type) [with ExecutionSpace = Kokkos::Cuda; View = Kokkos::View<int*, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> >; DeviceType = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>; typename std::enable_if<Kokkos::is_view<View>::value>::type = void; typename View::non_const_type = Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::Experimental::EmptyViewHooks, Kokkos::MemoryTraits<0> >]'
/app/ArborX/src/details/ArborX_DetailsDistributedTreeImpl.hpp:735:18:   required from 'static void ArborX::Details::DistributedTreeImpl<DeviceType>::forwardQueries(MPI_Comm, const ExecutionSpace&, const Predicates&, Kokkos::View<int*, DeviceType>, Kokkos::View<int*, DeviceType>, Kokkos::View<Query*, DeviceType>&, Kokkos::View<int*, DeviceType>&, Ranks&) [with ExecutionSpace = Kokkos::Cuda; Predicates = Kokkos::View<ArborX::Intersects<ArborX::Box>*, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> >; Ranks = Kokkos::View<int*, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> >; Query = ArborX::Intersects<ArborX::Box>; DeviceType = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>; MPI_Comm = ompi_communicator_t*]'
/tmp/tmpxft_00006045_00000000-6_tstKokkosToolsDistributedAnnotations.cudafe1.stub.c:107:1129:   required from here
/app/ArborX/src/details/ArborX_DetailsDistributor.hpp:281:148: error: no type named 'traits' in 'cuda::std::__4::false_type' {aka 'struct cuda::std::__4::integral_constant<bool, false>'}
  281 |     constexpr int pointer_depth = internal::PointerDepth<
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                      
```
Using `ExportView` instead of `DestBufferMirrorViewType` fixes the issue.