### PR TITLE
Decrease the amount of memory used ccache

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -10,7 +10,7 @@ pipeline {
 
     environment {
         CCACHE_DIR = '/tmp/ccache'
-        CCACHE_MAXSIZE = '10G'
+        CCACHE_MAXSIZE = '5G'
         ARBORX_DIR = '/opt/arborx'
         BENCHMARK_COLOR = 'no'
         BOOST_TEST_COLOR_OUTPUT = 'no'


### PR DESCRIPTION
ArborX's ccache is using too much memory and filling up the machines. This should fix the issue.