### PR TITLE
Avoid warning in return argument of triangle_intersection example

### DIFF
--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -368,5 +368,5 @@ int main()
       },
       Kokkos::LAnd<bool, Kokkos::HostSpace>(success));
   std::cout << "Check " << (success ? "succeeded" : "failed") << std::endl;
-  return !success;
+  return success ? 0 : 1;
 }

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -368,5 +368,5 @@ int main()
       },
       Kokkos::LAnd<bool, Kokkos::HostSpace>(success));
   std::cout << "Check " << (success ? "succeeded" : "failed") << std::endl;
-  return success ? 0 : 1;
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
Fixes the warning seen in https://cloud.cees.ornl.gov/jenkins-ci/job/ArborX/job/PR-937/1/clang/source.76f6aa80-42a7-46d1-839a-2a98ba42596e/#371. We didn't notice earlier since the `HIP` build in https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/ArborX/detail/PR-542/18/pipeline timed out.