### PR TITLE
Switch to using invoke_result_t 

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -41,15 +41,13 @@ namespace Details
 struct HappyTreeFriends;
 } // namespace Details
 
-template <
-    typename MemorySpace, typename Value,
-    typename IndexableGetter = Details::DefaultIndexableGetter,
-    typename BoundingVolume = ExperimentalHyperGeometry::Box<
-        GeometryTraits::dimension_v<std::decay_t<
-            decltype(std::declval<IndexableGetter>()(std::declval<Value>()))>>,
-        typename GeometryTraits::coordinate_type<
-            std::decay_t<decltype(std::declval<IndexableGetter>()(
-                std::declval<Value>()))>>::type>>
+template <typename MemorySpace, typename Value,
+          typename IndexableGetter = Details::DefaultIndexableGetter,
+          typename BoundingVolume = ExperimentalHyperGeometry::Box<
+              GeometryTraits::dimension_v<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
+              typename GeometryTraits::coordinate_type<std::decay_t<
+                  std::invoke_result_t<IndexableGetter, Value>>>::type>>
 class BasicBoundingVolumeHierarchy
 {
 public:
@@ -106,8 +104,8 @@ public:
 private:
   friend struct Details::HappyTreeFriends;
 
-  using indexable_type = std::decay_t<decltype(std::declval<IndexableGetter>()(
-      std::declval<Value>()))>;
+  using indexable_type =
+      std::decay_t<std::invoke_result_t<IndexableGetter, Value>>;
   using leaf_node_type = Details::LeafNode<value_type>;
   using internal_node_type = Details::InternalNode<bounding_volume_type>;
 

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -17,7 +17,7 @@
 #include <Kokkos_DetectionIdiom.hpp>
 #include <Kokkos_Macros.hpp>
 
-#include <utility> // declval
+#include <type_traits>
 
 namespace ArborX
 {
@@ -50,15 +50,12 @@ struct DefaultCallback
 // archetypal expression for user callbacks
 template <typename Callback, typename Predicate, typename Out>
 using InlineCallbackArchetypeExpression =
-    decltype(std::declval<Callback const &>()(std::declval<Predicate const &>(),
-                                              0, std::declval<Out const &>()));
+    std::invoke_result_t<Callback, Predicate, int, Out>;
 
 // legacy nearest predicate archetypal expression for user callbacks
 template <typename Callback, typename Predicate, typename Out>
 using Legacy_NearestPredicateInlineCallbackArchetypeExpression =
-    decltype(std::declval<Callback const &>()(std::declval<Predicate const &>(),
-                                              0, 0.f,
-                                              std::declval<Out const &>()));
+    std::invoke_result_t<Callback, Predicate, int, float, Out>;
 
 // archetypal alias for a 'tag' type member in user callbacks
 template <typename Callback>
@@ -125,8 +122,7 @@ Sorry!)error");
 // EXPERIMENTAL archetypal expression for user callbacks
 template <typename Callback, typename Predicate, typename Primitive>
 using Experimental_CallbackArchetypeExpression =
-    decltype(std::declval<Callback const &>()(
-        std::declval<Predicate const &>(), std::declval<Primitive const &>()));
+    std::invoke_result_t<Callback, Predicate, Primitive>;
 
 // Determine whether the callback returns a hint to exit the tree traversal
 // early.

--- a/src/details/ArborX_DetailsHappyTreeFriends.hpp
+++ b/src/details/ArborX_DetailsHappyTreeFriends.hpp
@@ -17,7 +17,6 @@
 #include <Kokkos_Macros.hpp>
 
 #include <type_traits>
-#include <utility> // declval
 
 namespace ArborX::Details
 {

--- a/src/details/ArborX_SpaceFillingCurves.hpp
+++ b/src/details/ArborX_SpaceFillingCurves.hpp
@@ -76,8 +76,7 @@ namespace Details
 
 template <class SpaceFillingCurve, class Box, class Geometry>
 using SpaceFillingCurveProjectionArchetypeExpression =
-    decltype(std::declval<SpaceFillingCurve const &>()(
-        std::declval<Box const &>(), std::declval<Geometry const &>()));
+    std::invoke_result_t<SpaceFillingCurve, Box, Geometry>;
 
 template <int DIM, class SpaceFillingCurve>
 void check_valid_space_filling_curve(SpaceFillingCurve const &)


### PR DESCRIPTION
We have few places that use a combination of `decltype` and `declval` that could be simplified by using `invoke_result_t` (available starting c++17).