### PR TITLE
Move APIv1 converters into a separate legacy header

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -19,6 +19,7 @@
 #include <ArborX_DetailsBatchedQueries.hpp>
 #include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
 #include <ArborX_DetailsKokkosExtScopedProfileRegion.hpp>
+#include <ArborX_DetailsLegacy.hpp>
 #include <ArborX_DetailsNode.hpp>
 #include <ArborX_DetailsPermutedData.hpp>
 #include <ArborX_DetailsSortUtils.hpp>

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -208,19 +208,6 @@ void check_valid_callback(Callback const &callback, Predicates const &)
       "Callback 'operator()' return type must be void");
 }
 
-template <typename Callback, typename Value>
-struct LegacyCallbackWrapper
-{
-  Callback _callback;
-
-  template <typename Predicate>
-  KOKKOS_FUNCTION auto operator()(Predicate const &predicate,
-                                  Value const &value) const
-  {
-    return _callback(predicate, value.index);
-  }
-};
-
 } // namespace Details
 } // namespace ArborX
 

--- a/src/details/ArborX_DetailsHalfTraversal.hpp
+++ b/src/details/ArborX_DetailsHalfTraversal.hpp
@@ -14,6 +14,7 @@
 
 #include <ArborX_Callbacks.hpp> // LegacyCallbackWrapper
 #include <ArborX_DetailsHappyTreeFriends.hpp>
+#include <ArborX_DetailsLegacy.hpp>
 #include <ArborX_DetailsNode.hpp> // ROPE_SENTINEL
 
 #include <Kokkos_Core.hpp>

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DETAILS_LEGACY_HPP
+#define ARBORX_DETAILS_LEGACY_HPP
+
+#include <ArborX_AccessTraits.hpp>
+#include <ArborX_DetailsNode.hpp>
+
+namespace ArborX::Details
+{
+
+template <typename Primitives, typename BoundingVolume>
+class LegacyValues
+{
+  Primitives _primitives;
+  using Access = AccessTraits<Primitives, PrimitivesTag>;
+
+public:
+  using memory_space = typename Access::memory_space;
+  using value_type = Details::PairIndexVolume<BoundingVolume>;
+  using size_type =
+      Kokkos::detected_t<Details::AccessTraitsSizeArchetypeExpression, Access,
+                         Primitives>;
+
+  LegacyValues(Primitives const &primitives)
+      : _primitives(primitives)
+  {}
+
+  KOKKOS_FUNCTION
+  decltype(auto) operator()(size_type i) const
+  {
+    if constexpr (std::is_same_v<BoundingVolume,
+                                 typename AccessTraitsHelper<Access>::type>)
+    {
+      return value_type{(unsigned)i, Access::get(_primitives, i)};
+    }
+    else
+    {
+      BoundingVolume bounding_volume{};
+      expand(bounding_volume, Access::get(_primitives, i));
+      return value_type{(unsigned)i, bounding_volume};
+    }
+  }
+
+  KOKKOS_FUNCTION
+  size_type size() const { return Access::size(_primitives); }
+};
+
+template <typename Callback, typename Value>
+struct LegacyCallbackWrapper
+{
+  Callback _callback;
+
+  template <typename Predicate>
+  KOKKOS_FUNCTION auto operator()(Predicate const &predicate,
+                                  Value const &value) const
+  {
+    return _callback(predicate, value.index);
+  }
+};
+
+} // namespace ArborX::Details
+
+#endif

--- a/src/details/ArborX_IndexableGetter.hpp
+++ b/src/details/ArborX_IndexableGetter.hpp
@@ -40,43 +40,6 @@ struct DefaultIndexableGetter
   }
 };
 
-template <typename Primitives, typename BoundingVolume>
-class LegacyValues
-{
-  Primitives _primitives;
-  using Access = AccessTraits<Primitives, PrimitivesTag>;
-
-public:
-  using memory_space = typename Access::memory_space;
-  using value_type = Details::PairIndexVolume<BoundingVolume>;
-  using size_type =
-      Kokkos::detected_t<Details::AccessTraitsSizeArchetypeExpression, Access,
-                         Primitives>;
-
-  LegacyValues(Primitives const &primitives)
-      : _primitives(primitives)
-  {}
-
-  KOKKOS_FUNCTION
-  decltype(auto) operator()(size_type i) const
-  {
-    if constexpr (std::is_same_v<BoundingVolume,
-                                 typename AccessTraitsHelper<Access>::type>)
-    {
-      return value_type{(unsigned)i, Access::get(_primitives, i)};
-    }
-    else
-    {
-      BoundingVolume bounding_volume{};
-      expand(bounding_volume, Access::get(_primitives, i));
-      return value_type{(unsigned)i, bounding_volume};
-    }
-  }
-
-  KOKKOS_FUNCTION
-  size_type size() const { return Access::size(_primitives); }
-};
-
 template <typename Primitives>
 struct Indexables
 {

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -11,6 +11,7 @@
 #include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
 #include "ArborX_EnableViewComparison.hpp"
 #include <ArborX_DetailsAlgorithms.hpp>
+#include <ArborX_DetailsLegacy.hpp>
 #include <ArborX_DetailsMortonCode.hpp> // expandBits, morton32
 #include <ArborX_DetailsNode.hpp>       // ROPE SENTINEL
 #include <ArborX_DetailsSortUtils.hpp>  // sortObjects


### PR DESCRIPTION
This is just moving stuff around, no new code is introduced. Want to make `ArborX_IndexableGetter.hpp` and `ArborX_Callbacks.hpp` free from all the `Legacy` stuff, and move it to one place.