### PR TITLE
Use expand instead of += during scene calculation

### DIFF
--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -32,7 +32,7 @@ inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
   Kokkos::parallel_reduce(
       "ArborX::TreeConstruction::calculate_bounding_box_of_the_scene",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, indexables.size()),
-      KOKKOS_LAMBDA(int i, Box &update) { update += indexables(i); },
+      KOKKOS_LAMBDA(int i, Box &update) { expand(update, indexables(i)); },
       Kokkos::Sum<Box>{scene_bounding_box});
 }
 

--- a/test/tstCompileOnlyTypeRequirements.cpp
+++ b/test/tstCompileOnlyTypeRequirements.cpp
@@ -24,7 +24,6 @@ using PrimitivePointOrBox = ArborX::Point;
 // clang-format off
 struct FakeBoundingVolume
 {
-  KOKKOS_FUNCTION FakeBoundingVolume &operator+=(PrimitivePointOrBox) { return *this; }
 };
 KOKKOS_FUNCTION void expand(FakeBoundingVolume, FakeBoundingVolume) {}
 KOKKOS_FUNCTION void expand(FakeBoundingVolume, PrimitivePointOrBox) {}


### PR DESCRIPTION
This will use GeometryTraits machinery instead of relying on a specific type (Box) to provide += operator for all other geometries.

It is backwards compatible, as currently users only allowed to provide Point and Box, which are both ArborX types. So we control everything here.

The motivation here is to not provide `Box += KDOP` (as we already have an `expand` for it), as that is something one would have to do if constructing APIv2 hierarchy on KDOPs and calculating scene bounding box.