### PR TITLE
Fix bug argument counter must be passed by reference

### DIFF
--- a/test/utf_main.cpp
+++ b/test/utf_main.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/utf_main.cpp
+++ b/test/utf_main.cpp
@@ -20,7 +20,7 @@
 
 struct ExecutionEnvironmentScopeGuard
 {
-  ExecutionEnvironmentScopeGuard(int argc, char *argv[])
+  ExecutionEnvironmentScopeGuard(int &argc, char *argv[])
   {
 #if defined(ARBORX_MPI_UNIT_TEST)
     MPI_Init(&argc, &argv);


### PR DESCRIPTION
Passing an argument recognized by Kokkos to a test executable yields a segfault.
The issue is that Kokkos decrement the argument counter and shift the arguments but Boost.Test gets the original count and dereferences a null pointer.