### PR TITLE
Pseudo-inverse of symmetric matrices using SVD / Utility for moving least squares

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="/EHsc /bigobj" -DKokkos_ROOT="C:\kokkos-install" ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -DARBORX_ENABLE_MPI=OFF -DARBORX_ENABLE_TESTS=ON -DARBORX_ENABLE_EXAMPLES=ON -DARBORX_ENABLE_BENCHMARKS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="/EHsc /bigobj" -DKokkos_ROOT="C:\kokkos-install" ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -DARBORX_ENABLE_MPI=OFF -DARBORX_ENABLE_TESTS=ON -DARBORX_ENABLE_EXAMPLES=ON -DARBORX_ENABLE_BENCHMARKS=ON -DARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS=OFF ..
     - name: Build ArborX
       shell: bash
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 .#*
 /build*
+.vscode

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -21,7 +21,8 @@ namespace ArborX::Interpolation::Details
 {
 
 template <typename Matrix>
-KOKKOS_INLINE_FUNCTION void ensureIsSquareMatrix(Matrix const &mat)
+KOKKOS_INLINE_FUNCTION void
+ensureIsSquareMatrix([[maybe_unused]] Matrix const &mat)
 {
   static_assert(Kokkos::is_view_v<Matrix>, "Matrix must be a view");
   static_assert(Matrix::rank == 2, "Matrix must be 2D");
@@ -33,7 +34,7 @@ KOKKOS_INLINE_FUNCTION void ensureIsSquareSymmetricMatrix(Matrix const &mat)
 {
   ensureIsSquareMatrix(mat);
 
-  auto is_symmetric = [&]() {
+  [[maybe_unused]] auto is_symmetric = [&]() {
     int const size = mat.extent(0);
     for (int i = 0; i < size; i++)
       for (int j = i + 1; j < size; j++)
@@ -136,7 +137,10 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
     // | b | c |              | 0 | y |
     // +---+---+              +---+---+
 
-    value_t cos_theta, sin_theta, x, y;
+    value_t cos_theta;
+    value_t sin_theta;
+    value_t x;
+    value_t y;
     if (a == c)
     {
       cos_theta = Kokkos::sqrt(value_t(2)) / 2;

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -188,11 +188,11 @@ void symmetricPseudoInverseSVD(ExecutionSpace const &space, InOutMatrices &ios)
     assert(ios.extent(1) == ios.extent(2)); // Matrices must be square
 
     view_t s_matrices(
-        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                            "ArborX::SymmetricPseudoInverseSVD::sigma_list"),
         ios.extent(0), ios.extent(1), ios.extent(2));
     view_t u_matrices(
-        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                            "ArborX::SymmetricPseudoInverseSVD::givens_list"),
         ios.extent(0), ios.extent(1), ios.extent(2));
 
@@ -211,11 +211,11 @@ void symmetricPseudoInverseSVD(ExecutionSpace const &space, InOutMatrices &ios)
     assert(ios.extent(0) == ios.extent(1)); // Matrix must be square
 
     view_t s_matrices(
-        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                            "ArborX::SymmetricPseudoInverseSVD::sigma"),
         ios.extent(0), ios.extent(1));
     view_t u_matrices(
-        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                            "ArborX::SymmetricPseudoInverseSVD::givens"),
         ios.extent(0), ios.extent(1));
 

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -34,21 +34,24 @@ KOKKOS_INLINE_FUNCTION void ensureIsSquareSymmetricMatrix(Matrix const &mat)
   ensureIsSquareMatrix(mat);
   using value_t = typename Matrix::non_const_value_type;
 
-  bool is_symmetric = true;
-  int size = mat.extent(0);
-  for (int i = 0; i < size; i++)
-    for (int j = i + 1; j < size; j++)
-    {
-      auto const val = Kokkos::abs(mat(i, j) - mat(j, i));
-      auto const ref = Kokkos::abs(mat(i, j));
-      static constexpr value_t epsilon = Kokkos::Experimental::epsilon_v<float>;
-      if (ref == value_t(0) && val > epsilon)
-        is_symmetric = false;
-      if (ref != value_t(0) && val / ref > epsilon)
-        is_symmetric = false;
-    }
+  auto is_symmetric = [&]() {
+    int size = mat.extent(0);
+    for (int i = 0; i < size; i++)
+      for (int j = i + 1; j < size; j++)
+      {
+        auto const val = Kokkos::abs(mat(i, j) - mat(j, i));
+        auto const ref = Kokkos::abs(mat(i, j));
+        static constexpr value_t epsilon =
+            Kokkos::Experimental::epsilon_v<float>;
+        if (ref == value_t(0) && val > epsilon)
+          return false;
+        if (ref != value_t(0) && val / ref > epsilon)
+          return false;
+      }
+    return true;
+  };
 
-  KOKKOS_ASSERT(is_symmetric);
+  KOKKOS_ASSERT(is_symmetric());
 }
 
 // Gets the argmax from the upper triangle part of a matrix

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -1,0 +1,240 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#pragma once
+
+#include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace ArborX::Interpolation::Details
+{
+
+// Pseudo-inverse of symmetric matrices using SVD
+// We must find U, E (diagonal and positive) and V such that A = U.E.V^T
+// We also know that A is symmetric (by construction), so U = SV where S is
+// a sign matrix (only 1 or -1 in the diagonal, 0 elsewhere).
+// Thus A = U.E.S.U^T and A^-1 = U.[ E^-1.S ].U^T
+// Here we have IO = A/A^-1, S = E.S/E^-1.S and U = U
+template <typename InOutMatrix, typename SMatrix, typename UMatrix>
+KOKKOS_FUNCTION void
+symmetricPseudoInverseSVDSerialKernel(InOutMatrix &io, SMatrix &s, UMatrix &u)
+{
+  using value_t = typename InOutMatrix::non_const_value_type;
+  std::size_t const size = io.extent(0);
+
+  // We first initialize u as the identity matrix and copy io to s
+  for (std::size_t i = 0; i < size; i++)
+    for (std::size_t j = 0; j < size; j++)
+    {
+      u(i, j) = value_t(i == j);
+      s(i, j) = io(i, j);
+    }
+
+  // We define the "norm" that will return where to perform the elimination
+  auto argmaxUpperTriangle = [=](std::size_t &p, std::size_t &q) {
+    value_t max = 0;
+    p = q = 0;
+
+    for (std::size_t i = 0; i < size; i++)
+      for (std::size_t j = i + 1; j < size; j++)
+      {
+        value_t val = Kokkos::abs(s(i, j));
+        if (max < val)
+        {
+          max = val;
+          p = i;
+          q = j;
+        }
+      }
+
+    return max;
+  };
+
+  std::size_t p, q;
+  value_t norm = argmaxUpperTriangle(p, q);
+
+  // What value of epsilon is acceptable? Too small and we falsely inverse 0.
+  // Too big and we are not accurate enough. The float's epsilon seems to be an
+  // accurate epsilon for both calculations (maybe use 2 different epsilons?)
+  static constexpr value_t epsilon = Kokkos::Experimental::epsilon_v<float>;
+  while (norm > epsilon)
+  {
+    value_t a = s(p, p);
+    value_t b = s(p, q);
+    value_t c = s(q, q);
+
+    // Our submatrix is now
+    // +---------+---------+   +---+---+
+    // | s(p, p) | s(p, q) |   | a | b |
+    // +---------+---------+ = +---+---+
+    // | s(q, p) | s(q, q) |   | b | c |
+    // +---------+---------+   +---+---+
+
+    // Lets compute x, y and theta such that
+    // +---+---+              +---+---+
+    // | a | b |              | x | 0 |
+    // +---+---+ = R(theta) * +---+---+ * R(theta)^T
+    // | b | c |              | 0 | y |
+    // +---+---+              +---+---+
+
+    // Alternative without trig
+    // if (a != c)
+    //   u = (2 * b) / (a - c)
+    //   v = 1 / sqrt(u * u + 1)
+    //   cos = sqrt((1 + v) / 2)
+    //   sin = sgn(u) * sqrt((1 - v) / 2)
+    //   x = (a + c + (a - c) / v) / 2
+    //   y = (a + c - (a - c) / v) / 2 or y = a + c - x
+    // else
+    //   cos = sqrt(2) / 2
+    //   sin = sqrt(2) / 2
+    //   x = a + b
+    //   y = a - b
+
+    value_t theta, x, y;
+    if (a == c) // <-- better to check if |a - c| < epsilon?
+    {
+      theta = Kokkos::numbers::pi_v<value_t> / 4;
+      x = a + b;
+      y = a - b;
+    }
+    else
+    {
+      theta = Kokkos::atan((2 * b) / (a - c)) / 2;
+      value_t a_c_cos2 = (a - c) / Kokkos::cos(2 * theta);
+      x = (a + c + a_c_cos2) / 2;
+      y = (a + c - a_c_cos2) / 2;
+    }
+    value_t cos_theta = Kokkos::cos(theta);
+    value_t sin_theta = Kokkos::sin(theta);
+
+    // Now lets compute the following new values for U amd E.S
+    // M <- R'(theta)^T . S . R'(theta)
+    // U  <- U . R'(theta)
+
+    // R'(theta)^T . S
+    for (std::size_t i = 0; i < size; i++)
+    {
+      value_t s_pi = s(p, i);
+      value_t s_qi = s(q, i);
+      s(p, i) = cos_theta * s_pi + sin_theta * s_qi;
+      s(q, i) = -sin_theta * s_pi + cos_theta * s_qi;
+    }
+
+    // [R'(theta)^T . S] . R'(theta)
+    for (std::size_t i = 0; i < size; i++)
+    {
+      value_t s_ip = s(i, p);
+      value_t s_iq = s(i, q);
+      s(i, p) = cos_theta * s_ip + sin_theta * s_iq;
+      s(i, q) = -sin_theta * s_ip + cos_theta * s_iq;
+    }
+
+    // U . R'(theta)
+    for (std::size_t i = 0; i < size; i++)
+    {
+      value_t u_ip = u(i, p);
+      value_t u_iq = u(i, q);
+      u(i, p) = cos_theta * u_ip + sin_theta * u_iq;
+      u(i, q) = -sin_theta * u_ip + cos_theta * u_iq;
+    }
+
+    // These should theorically hold but is it ok to force them to their
+    // real value?
+    s(p, p) = x;
+    s(q, q) = y;
+    s(p, q) = 0;
+    s(q, p) = 0;
+
+    norm = argmaxUpperTriangle(p, q);
+  }
+
+  // We compute the max to get a range of the invertible eigen values
+  value_t max = epsilon;
+  for (std::size_t i = 0; i < size; i++)
+    max = Kokkos::max(Kokkos::abs(s(i, i)), max);
+
+  // We inverse the diagonal of S, except if "0" is found
+  for (std::size_t i = 0; i < size; i++)
+    s(i, i) = (Kokkos::abs(s(i, i)) < max * epsilon) ? 0 : 1 / s(i, i);
+
+  // Then we fill out IO as the pseudo inverse
+  for (std::size_t i = 0; i < size; i++)
+    for (std::size_t j = 0; j < size; j++)
+    {
+      value_t tmp = 0;
+      for (std::size_t k = 0; k < size; k++)
+        tmp += s(k, k) * u(i, k) * u(j, k);
+      io(i, j) = tmp;
+    }
+}
+
+template <typename ExecutionSpace, typename InOutMatrices>
+void symmetricPseudoInverseSVD(ExecutionSpace const &space, InOutMatrices &ios)
+{
+  // InOutMatrices is a single or list of matrices (i.e 2 or 3D view)
+  static_assert(Kokkos::is_view_v<InOutMatrices>, "In-out data must be a view");
+  static_assert(InOutMatrices::rank == 3 || InOutMatrices::rank == 2,
+                "In-out view must be a matrix or a list of matrices");
+  static_assert(
+      KokkosExt::is_accessible_from<typename InOutMatrices::memory_space,
+                                    ExecutionSpace>::value,
+      "In-out view must be accessible from the execution space");
+  using view_t = Kokkos::View<typename InOutMatrices::non_const_data_type,
+                              typename InOutMatrices::memory_space>;
+
+  if constexpr (view_t::rank == 3)
+  {
+    assert(ios.extent(1) == ios.extent(2)); // Matrices must be square
+
+    view_t s_matrices(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                           "ArborX::SymmetricPseudoInverseSVD::sigma_list"),
+        ios.extent(0), ios.extent(1), ios.extent(2));
+    view_t u_matrices(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                           "ArborX::SymmetricPseudoInverseSVD::givens_list"),
+        ios.extent(0), ios.extent(1), ios.extent(2));
+
+    Kokkos::parallel_for(
+        "ArborX::SymmetricPseudoInverseSVD::computation_list",
+        Kokkos::RangePolicy<ExecutionSpace>(space, 0, ios.extent(0)),
+        KOKKOS_LAMBDA(int const i) {
+          auto io = Kokkos::subview(ios, i, Kokkos::ALL, Kokkos::ALL);
+          auto s = Kokkos::subview(s_matrices, i, Kokkos::ALL, Kokkos::ALL);
+          auto u = Kokkos::subview(u_matrices, i, Kokkos::ALL, Kokkos::ALL);
+          symmetricPseudoInverseSVDSerialKernel(io, s, u);
+        });
+  }
+  else if constexpr (view_t::rank == 2)
+  {
+    assert(ios.extent(0) == ios.extent(1)); // Matrix must be square
+
+    view_t s_matrices(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                           "ArborX::SymmetricPseudoInverseSVD::sigma"),
+        ios.extent(0), ios.extent(1));
+    view_t u_matrices(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                           "ArborX::SymmetricPseudoInverseSVD::givens"),
+        ios.extent(0), ios.extent(1));
+
+    Kokkos::parallel_for(
+        "ArborX::SymmetricPseudoInverseSVD::computation",
+        Kokkos::RangePolicy<ExecutionSpace>(space, 0, 1),
+        KOKKOS_LAMBDA(int const) {
+          symmetricPseudoInverseSVDSerialKernel(ios, s_matrices, u_matrices);
+        });
+  }
+}
+
+} // namespace ArborX::Interpolation::Details

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -87,7 +87,7 @@ KOKKOS_FUNCTION auto argmaxUpperTriangle(Matrix const &mat)
 // Pseudo-inverse of symmetric matrices using SVD
 // We must find U, E (diagonal and positive) and V such that A = U.E.V^T
 // We also suppose, as the input, that A is symmetric, so U = SV where S is
-// a sign matrix (only 1 or -1 in the diagonal, 0 elsewhere).
+// a sign matrix (only 1 or -1 on the diagonal, 0 elsewhere).
 // Thus A = U.ES.U^T and A^-1 = U.[ ES^-1 ].U^T
 template <typename AMatrix, typename ESMatrix, typename UMatrix>
 KOKKOS_FUNCTION void
@@ -106,7 +106,7 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
                                typename ESMatrix::value_type> &&
                     std::is_same_v<typename ESMatrix::value_type,
                                    typename UMatrix::value_type>,
-                "Each input matrix must have the same value type");
+                "All input matrices must have the same value type");
   KOKKOS_ASSERT(A.extent(0) == ES.extent(0) && ES.extent(0) == U.extent(0));
   using value_t = typename AMatrix::non_const_value_type;
   int const size = A.extent(0);
@@ -138,7 +138,7 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
     // | ES(q, p) | ES(q, q) |   | b | c |
     // +----------+----------+   +---+---+
 
-    // Lets compute x, y and theta such that
+    // Let's compute x, y and theta such that
     // +---+---+              +---+---+
     // | a | b |              | x | 0 |
     // +---+---+ = R(theta) * +---+---+ * R(theta)^T
@@ -163,7 +163,7 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
       y = a + c - x;
     }
 
-    // Now lets compute the following new values for U and ES
+    // Now let's compute the following new values for U and ES
     // ES <- R'(theta)^T . ES . R'(theta)
     // U  <- U . R'(theta)
 
@@ -203,12 +203,12 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
     }
   }
 
-  // We compute the max to get a range of the invertible eigen values
+  // We compute the max to get a range of the invertible eigenvalues
   auto max_eigen = epsilon;
   for (int i = 0; i < size; i++)
     max_eigen = Kokkos::max(Kokkos::abs(ES(i, i)), max_eigen);
 
-  // We inverse the diagonal of ES, except if "0" is found
+  // We invert the diagonal of ES, except if "0" is found
   for (int i = 0; i < size; i++)
     ES(i, i) = (Kokkos::abs(ES(i, i)) < max_eigen * epsilon) ? 0 : 1 / ES(i, i);
 
@@ -227,7 +227,7 @@ template <typename ExecutionSpace, typename InOutMatrices>
 void symmetricPseudoInverseSVD(ExecutionSpace const &space,
                                InOutMatrices &matrices)
 {
-  // InOutMatrices is a single or list of matrices (i.e 2 or 3D view)
+  // InOutMatrices is a list of square symmetric matrices (3D view)
   static_assert(Kokkos::is_view_v<InOutMatrices>, "matrices must be a view");
   static_assert(!std::is_const_v<typename InOutMatrices::value_type>,
                 "matrices must be writable");

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -35,7 +35,7 @@ KOKKOS_INLINE_FUNCTION void ensureIsSquareSymmetricMatrix(Matrix const &mat)
   using value_t = typename Matrix::non_const_value_type;
 
   auto is_symmetric = [&]() {
-    int size = mat.extent(0);
+    int const size = mat.extent(0);
     for (int i = 0; i < size; i++)
       for (int j = i + 1; j < size; j++)
       {
@@ -60,7 +60,6 @@ KOKKOS_FUNCTION auto argmaxUpperTriangle(Matrix const &mat)
 {
   ensureIsSquareMatrix(mat);
   using value_t = typename Matrix::non_const_value_type;
-  int const size = mat.extent(0);
 
   struct
   {
@@ -69,6 +68,7 @@ KOKKOS_FUNCTION auto argmaxUpperTriangle(Matrix const &mat)
     int col = 0;
   } result;
 
+  int const size = mat.extent(0);
   for (int i = 0; i < size; i++)
     for (int j = i + 1; j < size; j++)
     {

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -32,22 +32,13 @@ template <typename Matrix>
 KOKKOS_INLINE_FUNCTION void ensureIsSquareSymmetricMatrix(Matrix const &mat)
 {
   ensureIsSquareMatrix(mat);
-  using value_t = typename Matrix::non_const_value_type;
 
   auto is_symmetric = [&]() {
     int const size = mat.extent(0);
     for (int i = 0; i < size; i++)
       for (int j = i + 1; j < size; j++)
-      {
-        auto const val = Kokkos::abs(mat(i, j) - mat(j, i));
-        auto const ref = Kokkos::abs(mat(i, j));
-        static constexpr value_t epsilon =
-            Kokkos::Experimental::epsilon_v<float>;
-        if (ref == value_t(0) && val > epsilon)
+        if (mat(i, j) != mat(j, i))
           return false;
-        if (ref != value_t(0) && val / ref > epsilon)
-          return false;
-      }
     return true;
   };
 

--- a/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp
@@ -168,8 +168,7 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
     // U  <- U . R'(theta)
 
     // R'(theta)^T . ES . R'(theta)
-    int i = 0;
-    for (; i < p; i++)
+    for (int i = 0; i < p; i++)
     {
       auto const es_ip = ES(i, p);
       auto const es_iq = ES(i, q);
@@ -177,8 +176,7 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
       ES(i, q) = -sin_theta * es_ip + cos_theta * es_iq;
     }
     ES(p, p) = x;
-    i++;
-    for (; i < q; i++)
+    for (int i = p + 1; i < q; i++)
     {
       auto const es_pi = ES(p, i);
       auto const es_iq = ES(i, q);
@@ -186,8 +184,7 @@ symmetricPseudoInverseSVDSerialKernel(AMatrix &A, ESMatrix &ES, UMatrix &U)
       ES(i, q) = -sin_theta * es_pi + cos_theta * es_iq;
     }
     ES(q, q) = y;
-    i++;
-    for (; i < size; i++)
+    for (int i = q + 1; i < size; i++)
     {
       auto const es_pi = ES(p, i);
       auto const es_qi = ES(q, i);

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -19,6 +19,63 @@
 #include "BoostTest_CUDA_clang_workarounds.hpp"
 #include <boost/test/utils/is_forward_iterable.hpp>
 
+template <typename T>
+struct KokkosViewIterator;
+
+template <typename T, typename... P>
+struct KokkosViewIterator<Kokkos::View<T, P...>>
+{
+  using self_t = KokkosViewIterator<Kokkos::View<T, P...>>;
+  using view_t = Kokkos::View<T, P...>;
+  using value_t = typename view_t::value_type;
+  static constexpr std::size_t rank = view_t::rank;
+
+  value_t &operator*()
+  {
+    return view.access(index[0], index[1], index[2], index[3], index[4],
+                       index[5], index[6], index[7]);
+  }
+
+  value_t *operator->() { return &operator*(); }
+
+  self_t &operator++()
+  {
+    index[rank - 1]++;
+    auto const layout = view.layout();
+
+    for (std::size_t i = rank - 1; i > 0; i--)
+      if (index[i] == layout.dimension[i] ||
+          layout.dimension[i] == KOKKOS_INVALID_INDEX)
+      {
+        index[i] = 0;
+        index[i - 1]++;
+      }
+
+    return *this;
+  }
+
+  self_t operator++(int)
+  {
+    self_t old = *this;
+    operator++();
+    return old;
+  }
+
+  static self_t begin(view_t const &view)
+  {
+    return {view, {{0, 0, 0, 0, 0, 0, 0, 0}}};
+  }
+
+  static self_t end(view_t const &view)
+  {
+    auto const layout = view.layout();
+    return {view, {{layout.dimension[0], 0, 0, 0, 0, 0, 0, 0}}};
+  }
+
+  view_t view;
+  Kokkos::Array<std::size_t, 8> index;
+};
+
 // Enable element-wise comparison for views that are accessible from the host
 namespace boost
 {
@@ -31,11 +88,8 @@ struct is_forward_iterable<Kokkos::View<T, P...>> : public boost::mpl::true_
   // NOTE Prefer static assertion to SFINAE because error message about no
   // operator== for the operands is not as clear.
   static_assert(
-      Kokkos::View<T, P...>::rank == 1 &&
-          !std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                        Kokkos::LayoutStride>::value &&
-          KokkosExt::is_accessible_from_host<Kokkos::View<T, P...>>::value,
-      "Restricted to contiguous rank-one host-accessible views");
+      KokkosExt::is_accessible_from_host<Kokkos::View<T, P...>>::value,
+      "Restricted to host-accessible views");
 };
 
 template <typename T, typename... P>
@@ -43,10 +97,18 @@ struct bt_iterator_traits<Kokkos::View<T, P...>, true>
 {
   using view_type = Kokkos::View<T, P...>;
   using value_type = typename view_type::value_type;
-  using const_iterator =
-      typename std::add_pointer<typename view_type::const_value_type>::type;
-  static const_iterator begin(view_type const &v) { return v.data(); }
-  static const_iterator end(view_type const &v) { return v.data() + v.size(); }
+  using const_iterator = KokkosViewIterator<view_type>;
+
+  static const_iterator begin(view_type const &v)
+  {
+    return const_iterator::begin(v);
+  }
+
+  static const_iterator end(view_type const &v)
+  {
+    return const_iterator::end(v);
+  }
+
   static std::size_t size(view_type const &v) { return v.size(); }
 };
 

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -34,7 +34,8 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
   bool same_dim_size = true;
   for (int i = 0; i < rank; i++)
   {
-    int ui = u.extent(i), vi = v.extent(i);
+    int ui = u.extent_int(i);
+    int vi = v.extent_int(i);
     BOOST_TEST(ui == vi, "check " << u_name << " == " << v_name
                                   << " failed at dimension " << i << " size ["
                                   << ui << " != " << vi << "]");
@@ -82,12 +83,13 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
   }
 }
 
-#define ARBORX_MDVIEW_TEST(VIEWA, VIEWB, ...)                                  \
+#define ARBORX_MDVIEW_TEST_TOL(VIEWA, VIEWB, TOL)                              \
   [](decltype(VIEWA) const &u, decltype(VIEWB) const &v) {                     \
     auto view_a = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, u); \
     auto view_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, v); \
                                                                                \
-    static_assert(decltype(view_a)::rank == decltype(view_b)::rank,            \
+    static_assert(std::decay_t<decltype(u)>::rank ==                           \
+                      std::decay_t<decltype(v)>::rank,                         \
                   "'" #VIEWA "' and '" #VIEWB "' must have the same rank");    \
                                                                                \
     std::string view_a_name(#VIEWA);                                           \
@@ -96,8 +98,10 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
     std::string view_b_name(#VIEWB);                                           \
     view_b_name += " (" + view_b.label() + ")";                                \
                                                                                \
-    arborxViewCheck(view_a, view_b, view_a_name, view_b_name, ##__VA_ARGS__);  \
+    arborxViewCheck(view_a, view_b, view_a_name, view_b_name, TOL);            \
   }(VIEWA, VIEWB)
+
+#define ARBORX_MDVIEW_TEST(VIEWA, VIEWB) ARBORX_MDVIEW_TEST_TOL(VIEWA, VIEWB, 0)
 
 // Enable element-wise comparison for views that are accessible from the host
 namespace boost

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -17,63 +17,76 @@
 #include <Kokkos_Core.hpp>
 
 #include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
 #include <boost/test/utils/is_forward_iterable.hpp>
 
-template <typename T>
-struct KokkosViewIterator;
-
-template <typename T, typename... P>
-struct KokkosViewIterator<Kokkos::View<T, P...>>
+template <typename U, typename V>
+void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
+                     std::string const &v_name, double tol = 0.)
 {
-  using self_t = KokkosViewIterator<Kokkos::View<T, P...>>;
-  using view_t = Kokkos::View<T, P...>;
-  using value_t = typename view_t::value_type;
+  static constexpr std::size_t rank = U::rank;
 
-  value_t &operator*()
+  bool same_dim_size = true;
+  for (std::size_t i = 0; i < rank; i++)
   {
-    return view.access(index[0], index[1], index[2], index[3], index[4],
-                       index[5], index[6], index[7]);
+    std::size_t ui = u.extent(i), vi = v.extent(i);
+    BOOST_TEST(ui == vi, u_name << " == " << v_name << " dimension " << i
+                                << " sizes"
+                                << boost::test_tools::tolerance(0.));
+    same_dim_size = (ui == vi) && same_dim_size;
   }
 
-  value_t *operator->() { return &operator*(); }
+  if (!same_dim_size)
+    return;
 
-  self_t &operator++()
+  auto const layout = u.layout();
+  Kokkos::Array<std::size_t, 8> index{0, 0, 0, 0, 0, 0, 0, 0};
+  auto make_index = [&]() {
+    std::stringstream sstr;
+    sstr << "(";
+    for (std::size_t i = 0; i < rank - 1; i++)
+      sstr << index[i] << ", ";
+    sstr << index[rank - 1] << ")";
+    return sstr.str();
+  };
+
+  while (index[0] != layout.dimension[0])
   {
-    index[7]++;
-    auto const layout = view.layout();
+    auto uval = u.access(index[0], index[1], index[2], index[3], index[4],
+                         index[5], index[6], index[7]);
+    auto vval = v.access(index[0], index[1], index[2], index[3], index[4],
+                         index[5], index[6], index[7]);
+    std::string index_str = make_index();
 
-    for (std::size_t i = 7; i > 0; i--)
-      if (index[i] == layout.dimension[i] ||
-          layout.dimension[i] == KOKKOS_INVALID_INDEX)
+    BOOST_TEST(uval == vval, u_name << " == " << v_name << " at " << index_str
+                                    << boost::test_tools::tolerance(tol));
+
+    index[rank - 1]++;
+    for (std::size_t i = rank - 1; i > 0; i--)
+      if (index[i] == layout.dimension[i])
       {
         index[i] = 0;
         index[i - 1]++;
       }
-
-    return *this;
   }
+}
 
-  self_t operator++(int)
-  {
-    self_t old = *this;
-    operator++();
-    return old;
-  }
-
-  static self_t begin(view_t const &view)
-  {
-    return {view, {{0, 0, 0, 0, 0, 0, 0, 0}}};
-  }
-
-  static self_t end(view_t const &view)
-  {
-    auto const layout = view.layout();
-    return {view, {{layout.dimension[0], 0, 0, 0, 0, 0, 0, 0}}};
-  }
-
-  view_t view;
-  Kokkos::Array<std::size_t, 8> index;
-};
+#define ARBORX_MDVIEW_TEST(VIEWA, VIEWB, ...)                                  \
+  [](decltype(VIEWA) const &u, decltype(VIEWB) const &v) {                     \
+    auto view_a = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, u); \
+    auto view_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, v); \
+                                                                               \
+    static_assert(decltype(view_a)::rank == decltype(view_b)::rank,            \
+                  "'" #VIEWA "' and '" #VIEWB "' must have the same rank");    \
+                                                                               \
+    std::string view_a_name(#VIEWA);                                           \
+    view_a_name += " (" + view_a.label() + ")";                                \
+                                                                               \
+    std::string view_b_name(#VIEWB);                                           \
+    view_b_name += " (" + view_b.label() + ")";                                \
+                                                                               \
+    arborxViewCheck(view_a, view_b, view_a_name, view_b_name, ##__VA_ARGS__);  \
+  }(VIEWA, VIEWB)
 
 // Enable element-wise comparison for views that are accessible from the host
 namespace boost
@@ -87,8 +100,11 @@ struct is_forward_iterable<Kokkos::View<T, P...>> : public boost::mpl::true_
   // NOTE Prefer static assertion to SFINAE because error message about no
   // operator== for the operands is not as clear.
   static_assert(
-      KokkosExt::is_accessible_from_host<Kokkos::View<T, P...>>::value,
-      "Restricted to host-accessible views");
+      Kokkos::View<T, P...>::rank == 1 &&
+          !std::is_same<typename Kokkos::View<T, P...>::array_layout,
+                        Kokkos::LayoutStride>::value &&
+          KokkosExt::is_accessible_from_host<Kokkos::View<T, P...>>::value,
+      "Restricted to contiguous rank-one host-accessible views");
 };
 
 template <typename T, typename... P>
@@ -96,18 +112,10 @@ struct bt_iterator_traits<Kokkos::View<T, P...>, true>
 {
   using view_type = Kokkos::View<T, P...>;
   using value_type = typename view_type::value_type;
-  using const_iterator = KokkosViewIterator<view_type>;
-
-  static const_iterator begin(view_type const &v)
-  {
-    return const_iterator::begin(v);
-  }
-
-  static const_iterator end(view_type const &v)
-  {
-    return const_iterator::end(v);
-  }
-
+  using const_iterator =
+      typename std::add_pointer<typename view_type::const_value_type>::type;
+  static const_iterator begin(view_type const &v) { return v.data(); }
+  static const_iterator end(view_type const &v) { return v.data() + v.size(); }
   static std::size_t size(view_type const &v) { return v.size(); }
 };
 

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -28,7 +28,6 @@ struct KokkosViewIterator<Kokkos::View<T, P...>>
   using self_t = KokkosViewIterator<Kokkos::View<T, P...>>;
   using view_t = Kokkos::View<T, P...>;
   using value_t = typename view_t::value_type;
-  static constexpr std::size_t rank = view_t::rank;
 
   value_t &operator*()
   {
@@ -40,10 +39,10 @@ struct KokkosViewIterator<Kokkos::View<T, P...>>
 
   self_t &operator++()
   {
-    index[rank - 1]++;
+    index[7]++;
     auto const layout = view.layout();
 
-    for (std::size_t i = rank - 1; i > 0; i--)
+    for (std::size_t i = 7; i > 0; i--)
       if (index[i] == layout.dimension[i] ||
           layout.dimension[i] == KOKKOS_INVALID_INDEX)
       {

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -24,12 +24,12 @@ template <typename U, typename V>
 void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
                      std::string const &v_name, double tol = 0.)
 {
-  static constexpr std::size_t rank = U::rank;
+  static constexpr int rank = U::rank;
 
   bool same_dim_size = true;
-  for (std::size_t i = 0; i < rank; i++)
+  for (int i = 0; i < rank; i++)
   {
-    std::size_t ui = u.extent(i), vi = v.extent(i);
+    int ui = u.extent(i), vi = v.extent(i);
     BOOST_TEST(ui == vi, u_name << " == " << v_name << " dimension " << i
                                 << " sizes"
                                 << boost::test_tools::tolerance(0.));
@@ -40,11 +40,11 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
     return;
 
   auto const layout = u.layout();
-  Kokkos::Array<std::size_t, 8> index{0, 0, 0, 0, 0, 0, 0, 0};
+  Kokkos::Array<int, 8> index{0, 0, 0, 0, 0, 0, 0, 0};
   auto make_index = [&]() {
     std::stringstream sstr;
     sstr << "(";
-    for (std::size_t i = 0; i < rank - 1; i++)
+    for (int i = 0; i < rank - 1; i++)
       sstr << index[i] << ", ";
     sstr << index[rank - 1] << ")";
     return sstr.str();
@@ -62,7 +62,7 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
                                     << boost::test_tools::tolerance(tol));
 
     index[rank - 1]++;
-    for (std::size_t i = rank - 1; i > 0; i--)
+    for (int i = rank - 1; i > 0; i--)
       if (index[i] == layout.dimension[i])
       {
         index[i] = 0;

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -88,8 +88,8 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
     auto view_a = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, u); \
     auto view_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, v); \
                                                                                \
-    static_assert(std::decay_t<decltype(u)>::rank ==                           \
-                      std::decay_t<decltype(v)>::rank,                         \
+    static_assert(unsigned(std::decay_t<decltype(u)>::rank) ==                 \
+                      unsigned(std::decay_t<decltype(v)>::rank),               \
                   "'" #VIEWA "' and '" #VIEWB "' must have the same rank");    \
                                                                                \
     std::string view_a_name(#VIEWA);                                           \

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -44,8 +44,7 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
   if (!same_dim_size)
     return;
 
-  auto const layout = u.layout();
-  Kokkos::Array<int, 8> index{0, 0, 0, 0, 0, 0, 0, 0};
+  int index[8]{0, 0, 0, 0, 0, 0, 0, 0};
   auto make_index = [&]() {
     std::stringstream sstr;
     sstr << "(";
@@ -55,7 +54,7 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
     return sstr.str();
   };
 
-  while (index[0] != layout.dimension[0])
+  while (index[0] != u.extent_int(0))
   {
     auto uval = u.access(index[0], index[1], index[2], index[3], index[4],
                          index[5], index[6], index[7]);
@@ -75,7 +74,7 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
 
     index[rank - 1]++;
     for (int i = rank - 1; i > 0; i--)
-      if (index[i] == layout.dimension[i])
+      if (index[i] == u.extent_int(i))
       {
         index[i] = 0;
         index[i - 1]++;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -235,11 +235,11 @@ target_link_libraries(ArborX_Test_BoostAdapters.exe PRIVATE ArborX Boost::unit_t
 target_compile_definitions(ArborX_Test_BoostAdapters.exe PRIVATE BOOST_TEST_DYN_LINK)
 add_test(NAME ArborX_Test_BoostAdapters COMMAND ArborX_Test_BoostAdapters.exe)
 
-add_executable(ArborX_Test_InterpDetailsSymmPInvSVD.exe tstInterpDetailsSymmPInvSVD.cpp utf_main.cpp)
-target_link_libraries(ArborX_Test_InterpDetailsSymmPInvSVD.exe PRIVATE ArborX Boost::unit_test_framework)
-target_compile_definitions(ArborX_Test_InterpDetailsSymmPInvSVD.exe PRIVATE BOOST_TEST_DYN_LINK)
-target_include_directories(ArborX_Test_InterpDetailsSymmPInvSVD.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME ArborX_Test_InterpDetailsSymmPInvSVD COMMAND ArborX_Test_InterpDetailsSymmPInvSVD.exe)
+add_executable(ArborX_Test_InterpDetailsSVD.exe tstInterpDetailsSVD.cpp utf_main.cpp)
+target_link_libraries(ArborX_Test_InterpDetailsSVD.exe PRIVATE ArborX Boost::unit_test_framework)
+target_compile_definitions(ArborX_Test_InterpDetailsSVD.exe PRIVATE BOOST_TEST_DYN_LINK)
+target_include_directories(ArborX_Test_InterpDetailsSVD.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME ArborX_Test_InterpDetailsSVD COMMAND ArborX_Test_InterpDetailsSVD.exe)
 
 if(ARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS)
   add_subdirectory(headers_self_contained)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -235,6 +235,12 @@ target_link_libraries(ArborX_Test_BoostAdapters.exe PRIVATE ArborX Boost::unit_t
 target_compile_definitions(ArborX_Test_BoostAdapters.exe PRIVATE BOOST_TEST_DYN_LINK)
 add_test(NAME ArborX_Test_BoostAdapters COMMAND ArborX_Test_BoostAdapters.exe)
 
+add_executable(ArborX_Test_InterpDetailsSymmPInvSVD.exe tstInterpDetailsSymmPInvSVD.cpp utf_main.cpp)
+target_link_libraries(ArborX_Test_InterpDetailsSymmPInvSVD.exe PRIVATE ArborX Boost::unit_test_framework)
+target_compile_definitions(ArborX_Test_InterpDetailsSymmPInvSVD.exe PRIVATE BOOST_TEST_DYN_LINK)
+target_include_directories(ArborX_Test_InterpDetailsSymmPInvSVD.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME ArborX_Test_InterpDetailsSymmPInvSVD COMMAND ArborX_Test_InterpDetailsSymmPInvSVD.exe)
+
 if(ARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS)
   add_subdirectory(headers_self_contained)
 endif()

--- a/test/tstInterpDetailsSVD.cpp
+++ b/test/tstInterpDetailsSVD.cpp
@@ -20,8 +20,7 @@ namespace tt = boost::test_tools;
 namespace axid = ArborX::Interpolation::Details;
 
 template <typename ES, typename U, typename V>
-void makeCase(ES const &es, std::size_t id, V &src_arr, V &ref_arr,
-              std::size_t n, std::size_t m = 0)
+void makeCase(ES const &es, int id, V &src_arr, V &ref_arr, int n, int m = 0)
 {
   std::string id_string = std::to_string(id);
   using host_view = typename U::HostMirror;
@@ -36,8 +35,8 @@ void makeCase(ES const &es, std::size_t id, V &src_arr, V &ref_arr,
     ref = host_view("ref" + id_string, n, n);
     inv = U("inv" + id_string, n, n);
 
-    for (std::size_t i = 0; i < n; i++)
-      for (std::size_t j = 0; j < n; j++)
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
       {
         src(i, j) = src_arr[i][j];
         ref(i, j) = ref_arr[i][j];
@@ -49,9 +48,9 @@ void makeCase(ES const &es, std::size_t id, V &src_arr, V &ref_arr,
     ref = host_view("ref" + id_string, m, n, n);
     inv = U("inv" + id_string, m, n, n);
 
-    for (std::size_t i = 0; i < m; i++)
-      for (std::size_t j = 0; j < n; j++)
-        for (std::size_t k = 0; k < n; k++)
+    for (int i = 0; i < m; i++)
+      for (int j = 0; j < n; j++)
+        for (int k = 0; k < n; k++)
         {
           src(i, j, k) = src_arr[i][j][k];
           ref(i, j, k) = ref_arr[i][j][k];
@@ -133,8 +132,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm128, DeviceType,
   // pseudo-inverse is a 128x128 matrix of 1 / (128 * 128 * -2)
   double mat[128][128] = {};
   double inv[128][128] = {};
-  for (std::size_t i = 0; i < 128; i++)
-    for (std::size_t j = 0; j < 128; j++)
+  for (int i = 0; i < 128; i++)
+    for (int j = 0; j < 128; j++)
     {
       mat[i][j] = -2;
       inv[i][j] = 1 / (128 * 128 * -2.);

--- a/test/tstInterpDetailsSVD.cpp
+++ b/test/tstInterpDetailsSVD.cpp
@@ -16,7 +16,6 @@
 #include "BoostTest_CUDA_clang_workarounds.hpp"
 #include <boost/test/unit_test.hpp>
 
-namespace tt = boost::test_tools;
 namespace axid = ArborX::Interpolation::Details;
 
 template <typename ES, typename U, typename V>

--- a/test/tstInterpDetailsSVD.cpp
+++ b/test/tstInterpDetailsSVD.cpp
@@ -16,16 +16,14 @@
 #include "BoostTest_CUDA_clang_workarounds.hpp"
 #include <boost/test/unit_test.hpp>
 
-namespace axid = ArborX::Interpolation::Details;
-
 template <typename ES, typename U, typename V>
 void makeCase(ES const &es, V &src_arr, V &ref_arr, int n, int m)
 {
   using host_view = typename U::HostMirror;
 
-  host_view src("src", m, n, n);
-  host_view ref("ref", m, n, n);
-  U inv("inv", m, n, n);
+  host_view src("Testing::src", m, n, n);
+  host_view ref("Testing::ref", m, n, n);
+  U inv("Testing::inv", m, n, n);
 
   for (int i = 0; i < m; i++)
     for (int j = 0; j < n; j++)
@@ -36,7 +34,7 @@ void makeCase(ES const &es, V &src_arr, V &ref_arr, int n, int m)
       }
 
   Kokkos::deep_copy(es, inv, src);
-  axid::symmetricPseudoInverseSVD(es, inv);
+  ArborX::Interpolation::Details::symmetricPseudoInverseSVD(es, inv);
   ARBORX_MDVIEW_TEST(ref, inv, Kokkos::Experimental::epsilon_v<float>);
 }
 
@@ -129,6 +127,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
   ExecutionSpace space{};
 
   view_t mat("mat", 0, 0, 0);
-  axid::symmetricPseudoInverseSVD(space, mat);
+  ArborX::Interpolation::Details::symmetricPseudoInverseSVD(space, mat);
   BOOST_TEST(mat.size() == 0);
 }

--- a/test/tstInterpDetailsSVD.cpp
+++ b/test/tstInterpDetailsSVD.cpp
@@ -35,7 +35,7 @@ void makeCase(ES const &es, V &src_arr, V &ref_arr, int n, int m)
 
   Kokkos::deep_copy(es, inv, src);
   ArborX::Interpolation::Details::symmetricPseudoInverseSVD(es, inv);
-  ARBORX_MDVIEW_TEST(ref, inv, Kokkos::Experimental::epsilon_v<float>);
+  ARBORX_MDVIEW_TEST_TOL(ref, inv, Kokkos::Experimental::epsilon_v<float>);
 }
 
 // Pseudo-inverses were computed using numpy's "linalg.pinv" solver and

--- a/test/tstInterpDetailsSVD.cpp
+++ b/test/tstInterpDetailsSVD.cpp
@@ -19,42 +19,21 @@
 namespace axid = ArborX::Interpolation::Details;
 
 template <typename ES, typename U, typename V>
-void makeCase(ES const &es, int id, V &src_arr, V &ref_arr, int n, int m = 0)
+void makeCase(ES const &es, V &src_arr, V &ref_arr, int n, int m)
 {
-  std::string id_string = std::to_string(id);
   using host_view = typename U::HostMirror;
 
-  host_view src;
-  host_view ref;
-  U inv;
+  host_view src("src", m, n, n);
+  host_view ref("ref", m, n, n);
+  U inv("inv", m, n, n);
 
-  if constexpr (U::rank == 2)
-  {
-    src = host_view("src" + id_string, n, n);
-    ref = host_view("ref" + id_string, n, n);
-    inv = U("inv" + id_string, n, n);
-
-    for (int i = 0; i < n; i++)
-      for (int j = 0; j < n; j++)
+  for (int i = 0; i < m; i++)
+    for (int j = 0; j < n; j++)
+      for (int k = 0; k < n; k++)
       {
-        src(i, j) = src_arr[i][j];
-        ref(i, j) = ref_arr[i][j];
+        src(i, j, k) = src_arr[i][j][k];
+        ref(i, j, k) = ref_arr[i][j][k];
       }
-  }
-  else if constexpr (U::rank == 3)
-  {
-    src = host_view("src" + id_string, m, n, n);
-    ref = host_view("ref" + id_string, m, n, n);
-    inv = U("inv" + id_string, m, n, n);
-
-    for (int i = 0; i < m; i++)
-      for (int j = 0; j < n; j++)
-        for (int k = 0; k < n; k++)
-        {
-          src(i, j, k) = src_arr[i][j][k];
-          ref(i, j, k) = ref_arr[i][j][k];
-        }
-  }
 
   Kokkos::deep_copy(es, inv, src);
   axid::symmetricPseudoInverseSVD(es, inv);
@@ -65,114 +44,6 @@ void makeCase(ES const &es, int id, V &src_arr, V &ref_arr, int n, int m = 0)
 // simplified to be ratios
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2, DeviceType, ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, MemorySpace>;
-  ExecutionSpace space{};
-
-  double mat0[2][2] = {{1, 2}, {2, 3}};
-  double inv0[2][2] = {{-3, 2}, {2, -1}};
-  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 0, mat0, inv0, 2);
-
-  double mat1[2][2] = {{4, 0}, {0, 4}};
-  double inv1[2][2] = {{1 / 4., 0}, {0, 1 / 4.}};
-  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 1, mat1, inv1, 2);
-
-  double mat2[2][2] = {{0, 5}, {5, 0}};
-  double inv2[2][2] = {{0, 1 / 5.}, {1 / 5., 0}};
-  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 2, mat2, inv2, 2);
-
-  double mat3[2][2] = {{2, 2}, {2, 2}};
-  double inv3[2][2] = {{1 / 8., 1 / 8.}, {1 / 8., 1 / 8.}};
-  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 3, mat3, inv3, 2);
-
-  double mat4[2][2] = {{1, -3}, {-3, 1}};
-  double inv4[2][2] = {{-1 / 8., -3 / 8.}, {-3 / 8., -1 / 8.}};
-  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 4, mat4, inv4, 2);
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3, DeviceType, ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, MemorySpace>;
-  ExecutionSpace space{};
-
-  double mat0[3][3] = {{2, 2, 3}, {2, 0, 1}, {3, 1, -2}};
-  double inv0[3][3] = {{-1 / 18., 7 / 18., 2 / 18.},
-                       {7 / 18., -13 / 18., 4 / 18.},
-                       {2 / 18., 4 / 18., -4 / 18.}};
-  makeCase<ExecutionSpace, view_t, double[3][3]>(space, 0, mat0, inv0, 3);
-
-  double mat1[3][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
-  double inv1[3][3] = {{-5 / 6., -1 / 6., 3 / 6.},
-                       {-1 / 6., 0, 1 / 6.},
-                       {3 / 6., 1 / 6., -1 / 6.}};
-  makeCase<ExecutionSpace, view_t, double[3][3]>(space, 1, mat1, inv1, 3);
-
-  double mat2[3][3] = {{5, 5, 5}, {5, 5, 5}, {5, 5, 5}};
-  double inv2[3][3] = {{1 / 45., 1 / 45., 1 / 45.},
-                       {1 / 45., 1 / 45., 1 / 45.},
-                       {1 / 45., 1 / 45., 1 / 45.}};
-  makeCase<ExecutionSpace, view_t, double[3][3]>(space, 2, mat2, inv2, 3);
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm128, DeviceType,
-                              ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, MemorySpace>;
-  ExecutionSpace space{};
-
-  // 128x128 matrix full of -2
-  // eigenvalues are -2*128 and 127 0s
-  // pseudo-inverse is a 128x128 matrix of 1 / (128 * 128 * -2)
-  double mat[128][128] = {};
-  double inv[128][128] = {};
-  for (int i = 0; i < 128; i++)
-    for (int j = 0; j < 128; j++)
-    {
-      mat[i][j] = -2;
-      inv[i][j] = 1 / (128 * 128 * -2.);
-    }
-  makeCase<ExecutionSpace, view_t, double[128][128]>(space, 0, mat, inv, 128);
-
-  // Case for invertible 128x128 matrix
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
-                              ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, MemorySpace>;
-  ExecutionSpace space{};
-
-  double mat0[1][1] = {{2}};
-  double inv0[1][1] = {{1 / 2.}};
-  makeCase<ExecutionSpace, view_t, double[1][1]>(space, 0, mat0, inv0, 1);
-
-  double mat1[1][1] = {{0}};
-  double inv1[1][1] = {{0}};
-  makeCase<ExecutionSpace, view_t, double[1][1]>(space, 1, mat1, inv1, 1);
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, MemorySpace>;
-  ExecutionSpace space{};
-
-  view_t mat("mat", 0, 0);
-  axid::symmetricPseudoInverseSVD(space, mat);
-  BOOST_TEST(mat.size() == 0);
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2_list, DeviceType,
-                              ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
@@ -189,11 +60,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2_list, DeviceType,
                          {{0, 1 / 5.}, {1 / 5., 0}},
                          {{1 / 8., 1 / 8.}, {1 / 8., 1 / 8.}},
                          {{-1 / 8., -3 / 8.}, {-3 / 8., -1 / 8.}}};
-  makeCase<ExecutionSpace, view_t, double[5][2][2]>(space, 0, mat, inv, 2, 5);
+  makeCase<ExecutionSpace, view_t, double[5][2][2]>(space, mat, inv, 2, 5);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3_list, DeviceType,
-                              ARBORX_DEVICE_TYPES)
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
@@ -212,5 +82,53 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3_list, DeviceType,
                          {{1 / 45., 1 / 45., 1 / 45.},
                           {1 / 45., 1 / 45., 1 / 45.},
                           {1 / 45., 1 / 45., 1 / 45.}}};
-  makeCase<ExecutionSpace, view_t, double[3][3][3]>(space, 0, mat, inv, 3, 3);
+  makeCase<ExecutionSpace, view_t, double[3][3][3]>(space, mat, inv, 3, 3);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm128, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double ***, MemorySpace>;
+  ExecutionSpace space{};
+
+  // 128x128 matrix full of -2
+  // eigenvalues are -2*128 and 127 0s
+  // pseudo-inverse is a 128x128 matrix of 1 / (128 * 128 * -2)
+  double mat[1][128][128] = {};
+  double inv[1][128][128] = {};
+  for (int i = 0; i < 128; i++)
+    for (int j = 0; j < 128; j++)
+    {
+      mat[0][i][j] = -2;
+      inv[0][i][j] = 1 / (128 * 128 * -2.);
+    }
+  makeCase<ExecutionSpace, view_t, double[1][128][128]>(space, mat, inv, 128,
+                                                        1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double ***, MemorySpace>;
+  ExecutionSpace space{};
+
+  double mat[2][1][1] = {{{2}}, {{0}}};
+  double inv[2][1][1] = {{{1 / 2.}}, {{0}}};
+  makeCase<ExecutionSpace, view_t, double[2][1][1]>(space, mat, inv, 1, 2);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double ***, MemorySpace>;
+  ExecutionSpace space{};
+
+  view_t mat("mat", 0, 0, 0);
+  axid::symmetricPseudoInverseSVD(space, mat);
+  BOOST_TEST(mat.size() == 0);
 }

--- a/test/tstInterpDetailsSymmPInvSVD.cpp
+++ b/test/tstInterpDetailsSymmPInvSVD.cpp
@@ -19,81 +19,48 @@
 namespace tt = boost::test_tools;
 namespace axid = ArborX::Interpolation::Details;
 
-// Checks for equality betweem 2D or 3D views
-template <typename U, typename V>
-void equalityCheck(U const &u, V const &v,
-                   double tol = Kokkos::Experimental::epsilon_v<float>)
+template <typename ES, typename U, typename V>
+void makeCase(ES const &es, std::size_t id, V &src_arr, V &ref_arr,
+              std::size_t n, std::size_t m = 0)
 {
-  auto u_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, u);
-  auto v_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, v);
-  BOOST_TEST(u_host == v_host, tt::tolerance(tol) << tt::per_element());
-}
+  std::string id_string = std::to_string(id);
+  using host_view = typename U::HostMirror;
 
-// Makes a view from a 2D C array
-template <typename U, std::size_t N>
-auto viewHostRef2(double (&a)[N][N])
-{
-  typename U::HostMirror r("r", N, N);
+  host_view src;
+  host_view ref;
+  U inv;
 
-  for (std::size_t i = 0; i < N; i++)
-    for (std::size_t j = 0; j < N; j++)
-      r(i, j) = a[i][j];
+  if constexpr (U::rank == 2)
+  {
+    src = host_view("src" + id_string, n, n);
+    ref = host_view("ref" + id_string, n, n);
+    inv = U("inv" + id_string, n, n);
 
-  return r;
-}
+    for (std::size_t i = 0; i < n; i++)
+      for (std::size_t j = 0; j < n; j++)
+      {
+        src(i, j) = src_arr[i][j];
+        ref(i, j) = ref_arr[i][j];
+      }
+  }
+  else if constexpr (U::rank == 3)
+  {
+    src = host_view("src" + id_string, m, n, n);
+    ref = host_view("ref" + id_string, m, n, n);
+    inv = U("inv" + id_string, m, n, n);
 
-// Makes a view from a 3D C array
-template <typename U, std::size_t M, std::size_t N>
-auto viewHostRef3(double (&a)[M][N][N])
-{
-  typename U::HostMirror r("r", M, N, N);
+    for (std::size_t i = 0; i < m; i++)
+      for (std::size_t j = 0; j < n; j++)
+        for (std::size_t k = 0; k < n; k++)
+        {
+          src(i, j, k) = src_arr[i][j][k];
+          ref(i, j, k) = ref_arr[i][j][k];
+        }
+  }
 
-  for (std::size_t i = 0; i < M; i++)
-    for (std::size_t j = 0; j < N; j++)
-      for (std::size_t k = 0; k < N; k++)
-        r(i, j, k) = a[i][j][k];
-
-  return r;
-}
-
-// Computes the pseudo-inverse from a single matrix
-template <typename ES, typename U, std::size_t N>
-auto makePseudoInverse(ES const &es, typename U::HostMirror const &a)
-{
-  U inv("inv", N, N);
-  Kokkos::deep_copy(es, inv, a);
+  Kokkos::deep_copy(es, inv, src);
   axid::symmetricPseudoInverseSVD(es, inv);
-  return inv;
-}
-
-// Computes the pseudo-inverse from a list of matrices
-template <typename ES, typename U, std::size_t M, std::size_t N>
-auto makePseudoInverseList(ES const &es, typename U::HostMirror const &a)
-{
-  U inv("inv", M, N, N);
-  Kokkos::deep_copy(es, inv, a);
-  axid::symmetricPseudoInverseSVD(es, inv);
-  return inv;
-}
-
-// Makes the case for a single matrix
-template <typename ES, typename U, std::size_t N>
-void makeCase(ES const &es, double (&src)[N][N], double (&ref)[N][N])
-{
-  auto rsrc = viewHostRef2<U, N>(src);
-  auto rref = viewHostRef2<U, N>(ref);
-  auto inv = makePseudoInverse<ES, U, N>(es, rsrc);
-  equalityCheck(rref, inv);
-}
-
-// Makes the case for a list of matrices
-template <typename ES, typename U, std::size_t M, std::size_t N>
-void makeCaseList(ES const &es, double (&src)[M][N][N], double (&ref)[M][N][N])
-{
-  auto rsrc = viewHostRef3<U, M, N>(src);
-  auto rref = viewHostRef3<U, M, N>(ref);
-  auto inv = makePseudoInverseList<ES, U, M, N>(es, rsrc);
-  equalityCheck(rref, inv);
+  ARBORX_MDVIEW_TEST(ref, inv, Kokkos::Experimental::epsilon_v<float>);
 }
 
 // Pseudo-inverses were computed using numpy's "linalg.pinv" solver and
@@ -108,23 +75,23 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2, DeviceType, ARBORX_DEVICE_TYPES)
 
   double mat0[2][2] = {{1, 2}, {2, 3}};
   double inv0[2][2] = {{-3, 2}, {2, -1}};
-  makeCase<ExecutionSpace, view_t, 2>(space, mat0, inv0);
+  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 0, mat0, inv0, 2);
 
   double mat1[2][2] = {{4, 0}, {0, 4}};
   double inv1[2][2] = {{1 / 4., 0}, {0, 1 / 4.}};
-  makeCase<ExecutionSpace, view_t, 2>(space, mat1, inv1);
+  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 1, mat1, inv1, 2);
 
   double mat2[2][2] = {{0, 5}, {5, 0}};
   double inv2[2][2] = {{0, 1 / 5.}, {1 / 5., 0}};
-  makeCase<ExecutionSpace, view_t, 2>(space, mat2, inv2);
+  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 2, mat2, inv2, 2);
 
   double mat3[2][2] = {{2, 2}, {2, 2}};
   double inv3[2][2] = {{1 / 8., 1 / 8.}, {1 / 8., 1 / 8.}};
-  makeCase<ExecutionSpace, view_t, 2>(space, mat3, inv3);
+  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 3, mat3, inv3, 2);
 
   double mat4[2][2] = {{1, -3}, {-3, 1}};
   double inv4[2][2] = {{-1 / 8., -3 / 8.}, {-3 / 8., -1 / 8.}};
-  makeCase<ExecutionSpace, view_t, 2>(space, mat4, inv4);
+  makeCase<ExecutionSpace, view_t, double[2][2]>(space, 4, mat4, inv4, 2);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3, DeviceType, ARBORX_DEVICE_TYPES)
@@ -138,19 +105,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3, DeviceType, ARBORX_DEVICE_TYPES)
   double inv0[3][3] = {{-1 / 18., 7 / 18., 2 / 18.},
                        {7 / 18., -13 / 18., 4 / 18.},
                        {2 / 18., 4 / 18., -4 / 18.}};
-  makeCase<ExecutionSpace, view_t, 3>(space, mat0, inv0);
+  makeCase<ExecutionSpace, view_t, double[3][3]>(space, 0, mat0, inv0, 3);
 
   double mat1[3][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
   double inv1[3][3] = {{-5 / 6., -1 / 6., 3 / 6.},
                        {-1 / 6., 0, 1 / 6.},
                        {3 / 6., 1 / 6., -1 / 6.}};
-  makeCase<ExecutionSpace, view_t, 3>(space, mat1, inv1);
+  makeCase<ExecutionSpace, view_t, double[3][3]>(space, 1, mat1, inv1, 3);
 
   double mat2[3][3] = {{5, 5, 5}, {5, 5, 5}, {5, 5, 5}};
   double inv2[3][3] = {{1 / 45., 1 / 45., 1 / 45.},
                        {1 / 45., 1 / 45., 1 / 45.},
                        {1 / 45., 1 / 45., 1 / 45.}};
-  makeCase<ExecutionSpace, view_t, 3>(space, mat2, inv2);
+  makeCase<ExecutionSpace, view_t, double[3][3]>(space, 2, mat2, inv2, 3);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm128, DeviceType,
@@ -172,7 +139,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm128, DeviceType,
       mat[i][j] = -2;
       inv[i][j] = 1 / (128 * 128 * -2.);
     }
-  makeCase<ExecutionSpace, view_t, 128>(space, mat, inv);
+  makeCase<ExecutionSpace, view_t, double[128][128]>(space, 0, mat, inv, 128);
 
   // Case for invertible 128x128 matrix
 }
@@ -187,11 +154,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
 
   double mat0[1][1] = {{2}};
   double inv0[1][1] = {{1 / 2.}};
-  makeCase<ExecutionSpace, view_t, 1>(space, mat0, inv0);
+  makeCase<ExecutionSpace, view_t, double[1][1]>(space, 0, mat0, inv0, 1);
 
   double mat1[1][1] = {{0}};
   double inv1[1][1] = {{0}};
-  makeCase<ExecutionSpace, view_t, 1>(space, mat1, inv1);
+  makeCase<ExecutionSpace, view_t, double[1][1]>(space, 1, mat1, inv1, 1);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
@@ -224,7 +191,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2_list, DeviceType,
                          {{0, 1 / 5.}, {1 / 5., 0}},
                          {{1 / 8., 1 / 8.}, {1 / 8., 1 / 8.}},
                          {{-1 / 8., -3 / 8.}, {-3 / 8., -1 / 8.}}};
-  makeCaseList<ExecutionSpace, view_t, 5, 2>(space, mat, inv);
+  makeCase<ExecutionSpace, view_t, double[5][2][2]>(space, 0, mat, inv, 2, 5);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3_list, DeviceType,
@@ -247,5 +214,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3_list, DeviceType,
                          {{1 / 45., 1 / 45., 1 / 45.},
                           {1 / 45., 1 / 45., 1 / 45.},
                           {1 / 45., 1 / 45., 1 / 45.}}};
-  makeCaseList<ExecutionSpace, view_t, 3, 3>(space, mat, inv);
+  makeCase<ExecutionSpace, view_t, double[3][3][3]>(space, 0, mat, inv, 3, 3);
 }

--- a/test/tstInterpDetailsSymmPInvSVD.cpp
+++ b/test/tstInterpDetailsSymmPInvSVD.cpp
@@ -29,18 +29,31 @@ void equalityCheck(U const &u, V const &v,
   BOOST_TEST(u_host == v_host, tt::tolerance(tol) << tt::per_element());
 }
 
-// Makes a unmanaged view from a 2D C array
+// Makes a view from a 2D C array
 template <typename U, std::size_t N>
 auto viewHostRef2(double (&a)[N][N])
 {
-  return typename U::HostMirror(&a[0][0], N, N);
+  typename U::HostMirror r("r", N, N);
+
+  for (std::size_t i = 0; i < N; i++)
+    for (std::size_t j = 0; j < N; j++)
+      r(i, j) = a[i][j];
+
+  return r;
 }
 
-// Makes a unmanaged view from a 3D C array
+// Makes a view from a 3D C array
 template <typename U, std::size_t M, std::size_t N>
 auto viewHostRef3(double (&a)[M][N][N])
 {
-  return typename U::HostMirror(&a[0][0][0], M, N, N);
+  typename U::HostMirror r("r", M, N, N);
+
+  for (std::size_t i = 0; i < M; i++)
+    for (std::size_t j = 0; j < N; j++)
+      for (std::size_t k = 0; k < N; k++)
+        r(i, j, k) = a[i][j][k];
+
+  return r;
 }
 
 // Computes the pseudo-inverse from a single matrix
@@ -83,16 +96,14 @@ void makeCaseList(ES const &es, double (&src)[M][N][N], double (&ref)[M][N][N])
   equalityCheck(rref, inv);
 }
 
-// Pseudo-inverses are computed using numpy's "linalg.pinv" solver
-// If possible, results will be written with their exact values (as ratios)
-// Layout is forced to be LayoutRight so that matrices are represented in the
-// same way under host and device code
+// Pseudo-inverses were computed using numpy's "linalg.pinv" solver and
+// simplified to be ratios
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  using view_t = Kokkos::View<double **, MemorySpace>;
   ExecutionSpace space{};
 
   double mat0[2][2] = {{1, 2}, {2, 3}};
@@ -120,7 +131,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  using view_t = Kokkos::View<double **, MemorySpace>;
   ExecutionSpace space{};
 
   double mat0[3][3] = {{2, 2, 3}, {2, 0, 1}, {3, 1, -2}};
@@ -147,7 +158,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm128, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  using view_t = Kokkos::View<double **, MemorySpace>;
   ExecutionSpace space{};
 
   // 128x128 matrix full of -2
@@ -171,7 +182,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  using view_t = Kokkos::View<double **, MemorySpace>;
   ExecutionSpace space{};
 
   double mat0[1][1] = {{2}};
@@ -188,7 +199,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  using view_t = Kokkos::View<double **, MemorySpace>;
   ExecutionSpace space{};
 
   view_t mat(0, 0);
@@ -202,7 +213,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2_list, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double ***, Kokkos::LayoutRight, MemorySpace>;
+  using view_t = Kokkos::View<double ***, MemorySpace>;
   ExecutionSpace space{};
 
   double mat[5][2][2] = {{{1, 2}, {2, 3}},
@@ -223,7 +234,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3_list, DeviceType,
 {
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double ***, Kokkos::LayoutRight, MemorySpace>;
+  using view_t = Kokkos::View<double ***, MemorySpace>;
   ExecutionSpace space{};
 
   double mat[3][3][3] = {{{2, 2, 3}, {2, 0, 1}, {3, 1, -2}},

--- a/test/tstInterpDetailsSymmPInvSVD.cpp
+++ b/test/tstInterpDetailsSymmPInvSVD.cpp
@@ -194,20 +194,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
   makeCase<ExecutionSpace, view_t, 1>(space, mat1, inv1);
 }
 
-#if 0
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  using MemorySpace = typename DeviceType::memory_space;
-  using view_t = Kokkos::View<double **, MemorySpace>;
-  ExecutionSpace space{};
-
-  view_t mat(0, 0);
-  axid::symmetricPseudoInverseSVD(space, mat);
-  BOOST_TEST(mat.size() == 0);
-}
-#endif
-
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2_list, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {

--- a/test/tstInterpDetailsSymmPInvSVD.cpp
+++ b/test/tstInterpDetailsSymmPInvSVD.cpp
@@ -194,6 +194,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
   makeCase<ExecutionSpace, view_t, 1>(space, mat1, inv1);
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double **, MemorySpace>;
+  ExecutionSpace space{};
+
+  view_t mat("mat", 0, 0);
+  axid::symmetricPseudoInverseSVD(space, mat);
+  BOOST_TEST(mat.size() == 0);
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2_list, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {

--- a/test/tstInterpDetailsSymmPInvSVD.cpp
+++ b/test/tstInterpDetailsSymmPInvSVD.cpp
@@ -1,0 +1,251 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborX_EnableDeviceTypes.hpp"
+#include <interpolation/details/ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+namespace tt = boost::test_tools;
+namespace axid = ArborX::Interpolation::Details;
+
+// Checks for equality betweem 2D or 3D views
+template <typename U, typename V>
+void equalityCheck(U const &u, V const &v,
+                   double tol = Kokkos::Experimental::epsilon_v<float>)
+{
+  if constexpr (U::rank == 2)
+  {
+    for (std::size_t i = 0; i < u.extent(0); i++)
+      for (std::size_t j = 0; j < u.extent(1); j++)
+        BOOST_TEST(u(i, j) == v(i, j), tt::tolerance(tol));
+  }
+  else if constexpr (U::rank == 3)
+  {
+    for (std::size_t i = 0; i < u.extent(0); i++)
+      for (std::size_t j = 0; j < u.extent(1); j++)
+        for (std::size_t k = 0; k < u.extent(2); k++)
+          BOOST_TEST(u(i, j, k) == v(i, j, k), tt::tolerance(tol));
+  }
+}
+
+// Makes a unmanaged view from a 2D C array
+template <typename U, std::size_t N>
+auto viewHostRef2(double (&a)[N][N])
+{
+  return typename U::HostMirror(&a[0][0], N, N);
+}
+
+// Makes a unmanaged view from a 3D C array
+template <typename U, std::size_t M, std::size_t N>
+auto viewHostRef3(double (&a)[M][N][N])
+{
+  return typename U::HostMirror(&a[0][0][0], M, N, N);
+}
+
+// Computes the pseudo-inverse from a single matrix
+template <typename ES, typename U, std::size_t N>
+auto makePseudoInverse(ES const &es, typename U::HostMirror const &a)
+{
+  U inv("inv", N, N);
+  Kokkos::deep_copy(es, inv, a);
+  axid::symmetricPseudoInverseSVD(es, inv);
+  return Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, inv);
+}
+
+// Computes the pseudo-inverse from a list of matrices
+template <typename ES, typename U, std::size_t M, std::size_t N>
+auto makePseudoInverseList(ES const &es, typename U::HostMirror const &a)
+{
+  U inv("inv", M, N, N);
+  Kokkos::deep_copy(es, inv, a);
+  axid::symmetricPseudoInverseSVD(es, inv);
+  return Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, inv);
+}
+
+// Makes the case for a single matrix
+template <typename ES, typename U, std::size_t N>
+void makeCase(ES const &es, double (&src)[N][N], double (&ref)[N][N])
+{
+  auto rsrc = viewHostRef2<U, N>(src);
+  auto rref = viewHostRef2<U, N>(ref);
+  auto inv = makePseudoInverse<ES, U, N>(es, rsrc);
+  equalityCheck(rref, inv);
+}
+
+// Makes the case for a list of matrices
+template <typename ES, typename U, std::size_t M, std::size_t N>
+void makeCaseList(ES const &es, double (&src)[M][N][N], double (&ref)[M][N][N])
+{
+  auto rsrc = viewHostRef3<U, M, N>(src);
+  auto rref = viewHostRef3<U, M, N>(ref);
+  auto inv = makePseudoInverseList<ES, U, M, N>(es, rsrc);
+  equalityCheck(rref, inv);
+}
+
+// Pseudo-inverses are computed using numpy's "linalg.pinv" solver
+// If possible, results will be written with their exact values (as ratios)
+// Layout is forced to be LayoutRight so that matrices are represented in the
+// same way under host and device code
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  ExecutionSpace space{};
+
+  double mat0[2][2] = {{1, 2}, {2, 3}};
+  double inv0[2][2] = {{-3, 2}, {2, -1}};
+  makeCase<ExecutionSpace, view_t, 2>(space, mat0, inv0);
+
+  double mat1[2][2] = {{4, 0}, {0, 4}};
+  double inv1[2][2] = {{1 / 4., 0}, {0, 1 / 4.}};
+  makeCase<ExecutionSpace, view_t, 2>(space, mat1, inv1);
+
+  double mat2[2][2] = {{0, 5}, {5, 0}};
+  double inv2[2][2] = {{0, 1 / 5.}, {1 / 5., 0}};
+  makeCase<ExecutionSpace, view_t, 2>(space, mat2, inv2);
+
+  double mat3[2][2] = {{2, 2}, {2, 2}};
+  double inv3[2][2] = {{1 / 8., 1 / 8.}, {1 / 8., 1 / 8.}};
+  makeCase<ExecutionSpace, view_t, 2>(space, mat3, inv3);
+
+  double mat4[2][2] = {{1, -3}, {-3, 1}};
+  double inv4[2][2] = {{-1 / 8., -3 / 8.}, {-3 / 8., -1 / 8.}};
+  makeCase<ExecutionSpace, view_t, 2>(space, mat4, inv4);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  ExecutionSpace space{};
+
+  double mat0[3][3] = {{2, 2, 3}, {2, 0, 1}, {3, 1, -2}};
+  double inv0[3][3] = {{-1 / 18., 7 / 18., 2 / 18.},
+                       {7 / 18., -13 / 18., 4 / 18.},
+                       {2 / 18., 4 / 18., -4 / 18.}};
+  makeCase<ExecutionSpace, view_t, 3>(space, mat0, inv0);
+
+  double mat1[3][3] = {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
+  double inv1[3][3] = {{-5 / 6., -1 / 6., 3 / 6.},
+                       {-1 / 6., 0, 1 / 6.},
+                       {3 / 6., 1 / 6., -1 / 6.}};
+  makeCase<ExecutionSpace, view_t, 3>(space, mat1, inv1);
+
+  double mat2[3][3] = {{5, 5, 5}, {5, 5, 5}, {5, 5, 5}};
+  double inv2[3][3] = {{1 / 45., 1 / 45., 1 / 45.},
+                       {1 / 45., 1 / 45., 1 / 45.},
+                       {1 / 45., 1 / 45., 1 / 45.}};
+  makeCase<ExecutionSpace, view_t, 3>(space, mat2, inv2);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm128, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  ExecutionSpace space{};
+
+  // 128x128 matrix full of -2
+  // eigenvalues are -2*128 and 127 0s
+  // pseudo-inverse is a 128x128 matrix of 1 / (128 * 128 * -2)
+  double mat[128][128] = {};
+  double inv[128][128] = {};
+  for (std::size_t i = 0; i < 128; i++)
+    for (std::size_t j = 0; j < 128; j++)
+    {
+      mat[i][j] = -2;
+      inv[i][j] = 1 / (128 * 128 * -2.);
+    }
+  makeCase<ExecutionSpace, view_t, 128>(space, mat, inv);
+
+  // Case for invertible 128x128 matrix
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  ExecutionSpace space{};
+
+  double mat0[1][1] = {{2}};
+  double inv0[1][1] = {{1 / 2.}};
+  makeCase<ExecutionSpace, view_t, 1>(space, mat0, inv0);
+
+  double mat1[1][1] = {{0}};
+  double inv1[1][1] = {{0}};
+  makeCase<ExecutionSpace, view_t, 1>(space, mat1, inv1);
+}
+
+#if 0
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double **, Kokkos::LayoutRight, MemorySpace>;
+  ExecutionSpace space{};
+
+  view_t mat(0, 0);
+  axid::symmetricPseudoInverseSVD(space, mat);
+  BOOST_TEST(mat.size() == 0);
+}
+#endif
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm2_list, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double ***, Kokkos::LayoutRight, MemorySpace>;
+  ExecutionSpace space{};
+
+  double mat[5][2][2] = {{{1, 2}, {2, 3}},
+                         {{4, 0}, {0, 4}},
+                         {{0, 5}, {5, 0}},
+                         {{2, 2}, {2, 2}},
+                         {{1, -3}, {-3, 1}}};
+  double inv[5][2][2] = {{{-3, 2}, {2, -1}},
+                         {{1 / 4., 0}, {0, 1 / 4.}},
+                         {{0, 1 / 5.}, {1 / 5., 0}},
+                         {{1 / 8., 1 / 8.}, {1 / 8., 1 / 8.}},
+                         {{-1 / 8., -3 / 8.}, {-3 / 8., -1 / 8.}}};
+  makeCaseList<ExecutionSpace, view_t, 5, 2>(space, mat, inv);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_symm3_list, DeviceType,
+                              ARBORX_DEVICE_TYPES)
+{
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+  using view_t = Kokkos::View<double ***, Kokkos::LayoutRight, MemorySpace>;
+  ExecutionSpace space{};
+
+  double mat[3][3][3] = {{{2, 2, 3}, {2, 0, 1}, {3, 1, -2}},
+                         {{0, 1, 2}, {1, 2, 3}, {2, 3, 4}},
+                         {{5, 5, 5}, {5, 5, 5}, {5, 5, 5}}};
+  double inv[3][3][3] = {{{-1 / 18., 7 / 18., 2 / 18.},
+                          {7 / 18., -13 / 18., 4 / 18.},
+                          {2 / 18., 4 / 18., -4 / 18.}},
+                         {{-5 / 6., -1 / 6., 3 / 6.},
+                          {-1 / 6., 0, 1 / 6.},
+                          {3 / 6., 1 / 6., -1 / 6.}},
+                         {{1 / 45., 1 / 45., 1 / 45.},
+                          {1 / 45., 1 / 45., 1 / 45.},
+                          {1 / 45., 1 / 45., 1 / 45.}}};
+  makeCaseList<ExecutionSpace, view_t, 3, 3>(space, mat, inv);
+}


### PR DESCRIPTION
In an attempt to break-up #946, this PR focuses only on the pseudo inverse used in the moving least squares algorithm. It includes the pseudo inverse itself in `src/interpolation` folder, tests and ~~an iterator for multi-dimensional views (for use in boost tests)~~ a macro to test equality on md views