### PR TITLE
Compact radial basis functions and generic polynomial basis / Utility for moving least squares

### DIFF
--- a/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -14,42 +14,24 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace ArborX::Interpolation
+namespace ArborX::Interpolation::CRBF
 {
 
 #define CRBF_DECL(NAME)                                                        \
-  namespace Details                                                            \
-  {                                                                            \
   template <std::size_t>                                                       \
-  struct NAME;                                                                 \
-  }                                                                            \
-                                                                               \
-  namespace CRBF                                                               \
-  {                                                                            \
-  template <std::size_t I>                                                     \
-  static constexpr Details::NAME<I> NAME{};                                    \
-  }
+  struct NAME;
 
 #define CRBF_DEF(NAME, N, FUNC)                                                \
-  namespace Details                                                            \
-  {                                                                            \
   template <>                                                                  \
   struct NAME<N>                                                               \
   {                                                                            \
     template <typename T>                                                      \
-    KOKKOS_INLINE_FUNCTION static constexpr T apply(T const y)                 \
+    KOKKOS_INLINE_FUNCTION static constexpr T evaluate(T const y)              \
     {                                                                          \
       T const x = Kokkos::min(Kokkos::abs(y), T(1));                           \
       return Kokkos::abs(FUNC);                                                \
     }                                                                          \
-                                                                               \
-    template <typename T>                                                      \
-    KOKKOS_INLINE_FUNCTION constexpr T operator()(T const y) const             \
-    {                                                                          \
-      return NAME<N>::apply(y);                                                \
-    }                                                                          \
-  };                                                                           \
-  }
+  };
 
 CRBF_DECL(Wendland)
 CRBF_DEF(Wendland, 0, (1 - x) * (1 - x))
@@ -89,6 +71,6 @@ CRBF_DEF(Buhmann, 4,
 #undef CRBF_DEF
 #undef CRBF_DECL
 
-} // namespace ArborX::Interpolation
+} // namespace ArborX::Interpolation::CRBF
 
 #endif

--- a/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -14,18 +14,21 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <initializer_list>
+
 namespace ArborX::Interpolation
 {
 
 namespace Details
 {
 
-template <typename T, std::size_t N>
-KOKKOS_INLINE_FUNCTION T evaluatePolynomial(T const x, T const (&coeffs)[N])
+template <typename T>
+KOKKOS_INLINE_FUNCTION T
+evaluatePolynomial(T const x, std::initializer_list<T> const coeffs)
 {
   T eval = 0;
-  for (std::size_t i = 0; i < N; i++)
-    eval = x * eval + coeffs[i];
+  for (auto const coeff : coeffs)
+    eval = x * eval + coeff;
   return eval;
 }
 
@@ -54,14 +57,14 @@ namespace CRBF
 #define CRBF_POW(X, N) Kokkos::pow(X, N)
 
 CRBF_DECL(Wendland)
-CRBF_DEF(Wendland, 0, CRBF_POW(1 - x, 2))
-CRBF_DEF(Wendland, 2, CRBF_POW(1 - x, 4) * CRBF_POLY(4, 1))
-CRBF_DEF(Wendland, 4, CRBF_POW(1 - x, 6) * CRBF_POLY(35, 18, 3))
-CRBF_DEF(Wendland, 6, CRBF_POW(1 - x, 6) * CRBF_POLY(32, 25, 8, 1))
+CRBF_DEF(Wendland, 0, CRBF_POW(CRBF_POLY(-1, 1), 2))
+CRBF_DEF(Wendland, 2, CRBF_POW(CRBF_POLY(-1, 1), 4) * CRBF_POLY(4, 1))
+CRBF_DEF(Wendland, 4, CRBF_POW(CRBF_POLY(-1, 1), 6) * CRBF_POLY(35, 18, 3))
+CRBF_DEF(Wendland, 6, CRBF_POW(CRBF_POLY(-1, 1), 8) * CRBF_POLY(32, 25, 8, 1))
 
 CRBF_DECL(Wu)
-CRBF_DEF(Wu, 2, CRBF_POW(1 - x, 4) * CRBF_POLY(3, 12, 16, 4))
-CRBF_DEF(Wu, 4, CRBF_POW(1 - x, 6) * CRBF_POLY(5, 30, 72, 82, 36, 6))
+CRBF_DEF(Wu, 2, CRBF_POW(CRBF_POLY(-1, 1), 4) * CRBF_POLY(3, 12, 16, 4))
+CRBF_DEF(Wu, 4, CRBF_POW(CRBF_POLY(-1, 1), 6) * CRBF_POLY(5, 30, 72, 82, 36, 6))
 
 CRBF_DECL(Buhmann)
 CRBF_DEF(Buhmann, 2,

--- a/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_INTERP_DETAILS_COMPACT_RADIAL_BASIS_FUNCTION_HPP
+#define ARBORX_INTERP_DETAILS_COMPACT_RADIAL_BASIS_FUNCTION_HPP
+
+#include <Kokkos_Core.hpp>
+
+namespace ArborX::Interpolation
+{
+
+#define CRBF_DECL(NAME)                                                        \
+  namespace Details                                                            \
+  {                                                                            \
+  template <std::size_t>                                                       \
+  struct NAME;                                                                 \
+  }                                                                            \
+                                                                               \
+  namespace CRBF                                                               \
+  {                                                                            \
+  template <std::size_t I>                                                     \
+  static constexpr Details::NAME<I> NAME{};                                    \
+  }
+
+#define CRBF_DEF(NAME, N, FUNC)                                                \
+  namespace Details                                                            \
+  {                                                                            \
+  template <>                                                                  \
+  struct NAME<N>                                                               \
+  {                                                                            \
+    template <typename T>                                                      \
+    KOKKOS_INLINE_FUNCTION static constexpr T apply(T const y)                 \
+    {                                                                          \
+      T const x = Kokkos::min(Kokkos::abs(y), T(1));                           \
+      return Kokkos::abs(FUNC);                                                \
+    }                                                                          \
+                                                                               \
+    template <typename T>                                                      \
+    KOKKOS_INLINE_FUNCTION constexpr T operator()(T const y) const             \
+    {                                                                          \
+      return NAME<N>::apply(y);                                                \
+    }                                                                          \
+  };                                                                           \
+  }
+
+CRBF_DECL(Wendland)
+CRBF_DEF(Wendland, 0, (1 - x) * (1 - x))
+CRBF_DEF(Wendland, 2, (1 - x) * (1 - x) * (1 - x) * (1 - x) * (4 * x + 1))
+CRBF_DEF(Wendland, 4,
+         (1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x) *
+             (35 * x * x + 18 * x + 3))
+CRBF_DEF(Wendland, 6,
+         (1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x) *
+             (1 - x) * (32 * x * x * x + 25 * x * x + 8 * x + 1))
+
+CRBF_DECL(Wu)
+CRBF_DEF(Wu, 2,
+         (1 - x) * (1 - x) * (1 - x) * (1 - x) *
+             (3 * x * x * x + 12 * x + 16 * x + 4))
+CRBF_DEF(Wu, 4,
+         (1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x) *
+             (5 * x * x * x * x * x + 30 * x * x * x * x + 72 * x * x * x +
+              82 * x * x + 36 * x + 6))
+
+CRBF_DECL(Buhmann)
+CRBF_DEF(Buhmann, 2,
+         (x == T(0))
+             ? T(1) / 6
+             : 2 * x * x * x * x * Kokkos::log(x) - 7 * x * x * x * x / 2 +
+                   16 * x * x * x / 3 - 2 * x * x + T(1) / 6)
+CRBF_DEF(Buhmann, 3,
+         1 * x * x * x * x * x * x * x * x - 84 * x * x * x * x * x * x / 5 +
+             1024 * x * x * x * x * Kokkos::sqrt(x) / 5 - 378 * x * x * x * x +
+             1024 * x * x * x * Kokkos::sqrt(x) / 5 - 84 * x * x / 5 + 1)
+CRBF_DEF(Buhmann, 4,
+         99 * x * x * x * x * x * x * x * x / 35 - 132 * x * x * x * x * x * x +
+             9216 * x * x * x * x * x * Kokkos::sqrt(x) / 35 -
+             11264 * x * x * x * x * Kokkos::sqrt(x) / 35 +
+             198 * x * x * x * x - 396 * x * x / 35 + 1)
+
+#undef CRBF_DEF
+#undef CRBF_DECL
+
+} // namespace ArborX::Interpolation
+
+#endif

--- a/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -23,7 +23,7 @@ namespace Details
 {
 
 // Polynomials are represented with the highest coefficient first. For example,
-// x^2 - 2x + 1 would be {1, -2, 1}
+// 3x^2 - 2x + 1 would be {3, -2, 1}
 template <typename T>
 KOKKOS_INLINE_FUNCTION T
 evaluatePolynomial(T const x, std::initializer_list<T> const coeffs)

--- a/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -22,6 +22,8 @@ namespace ArborX::Interpolation
 namespace Details
 {
 
+// Polynomials are represented with the highest coefficient first. For example,
+// x^2 - 2x + 1 would be {1, -2, 1}
 template <typename T>
 KOKKOS_INLINE_FUNCTION T
 evaluatePolynomial(T const x, std::initializer_list<T> const coeffs)
@@ -48,6 +50,10 @@ namespace CRBF
     template <typename T>                                                      \
     KOKKOS_INLINE_FUNCTION static constexpr T evaluate(T const y)              \
     {                                                                          \
+      /* We force the input to be between 0 and 1.                             \
+         Because CRBF(-a) = CRBF(a) = CRBF(|a|), we take the absolute value    \
+         and clamp the range to [0, 1] before entering in the definition of    \
+         the CRBF. */                                                          \
       T const x = Kokkos::min(Kokkos::abs(y), T(1));                           \
       return Kokkos::abs(FUNC);                                                \
     }                                                                          \

--- a/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -89,20 +89,10 @@ KOKKOS_FUNCTION constexpr std::size_t polynomialBasisSize()
 {
   static_assert(DIM > 0, "Polynomial basis with no dimension is invalid");
 
-  std::size_t dim_fact = 1;
-  std::size_t deg_fact = 1;
-  std::size_t dim_deg_fact = 1;
-
-  for (std::size_t i = 2; i <= DIM; i++)
-    dim_fact *= i;
-
-  for (std::size_t i = 2; i <= Degree; i++)
-    deg_fact *= i;
-
-  for (std::size_t i = 2; i <= DIM + Degree; i++)
-    dim_deg_fact *= i;
-
-  return dim_deg_fact / (dim_fact * deg_fact);
+  std::size_t result = 1;
+  for (std::size_t k = 0; k < Kokkos::min(DIM, Degree); ++k)
+    result = result * (DIM + Degree - k) / (k + 1);
+  return result;
 }
 
 // This creates the list by building each slices in-place

--- a/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -49,11 +49,24 @@ namespace Details
 //    |   | xz |      ||    |   |    | xyy |
 //    |   | yz |      ||    |   |    | yyy |
 //    |   | zz |      ||
+//
+// This generates:    || This generates:
+// [1, x, y, z, xx,   || [1, x, y, xx, xy, yy,
+//  xy, yy, xz, yz,   ||  xxx, xxy, xyy, yyy]
+//  zz]               ||
 
 // The size of each cell is 1 if it is at degree 1 or at variable x
 // And the sum of the cells' size to the left and above. (1 alone is not
 // counted). This essentially creates Pascal's triangle where line n corresponds
 // to the "dim + deg = n"-th diagonal
+//
+// Given the previous two diagrams, the two 2D arrays would be:
+//
+// Deg \ Dim | x | y | z  || Deg \ Dim | x | y
+// ----------+---+---+--- || ----------+---+---
+//      1    | 1 | 1 | 1  ||      1    | 1 | 1
+//      2    | 1 | 2 | 3  ||      2    | 1 | 2
+//                        ||      3    | 1 | 3
 template <std::size_t Dim, std::size_t Deg>
 KOKKOS_FUNCTION constexpr auto polynomialBasisCellSizes()
 {
@@ -81,6 +94,9 @@ KOKKOS_FUNCTION constexpr auto polynomialBasisCellSizes()
 
 // This returns the size of the polynomial basis, which is the sum of all the
 // cells' sizes and 1.
+//
+// Given the previous two diagrams and 2D arrays, both the Quadratic/3D and
+// Cubic/2D would have 10 elements in total.
 template <std::size_t Dim, std::size_t Deg>
 KOKKOS_FUNCTION constexpr std::size_t polynomialBasisSize()
 {
@@ -103,7 +119,7 @@ KOKKOS_FUNCTION constexpr std::size_t polynomialBasisSize()
 
 // This builds the array as described above
 template <std::size_t Dim, std::size_t Deg, typename Point>
-KOKKOS_FUNCTION auto polynomialBasis(Point const &p)
+KOKKOS_FUNCTION auto evaluatePolynomialBasis(Point const &p)
 {
   using value_t = std::decay_t<decltype(p[0])>;
   Kokkos::Array<value_t, polynomialBasisSize<Dim, Deg>()> arr{};
@@ -111,7 +127,7 @@ KOKKOS_FUNCTION auto polynomialBasis(Point const &p)
 
   if constexpr (Deg != 0 && Dim != 0)
   {
-    // Cannot use struct binding with constexpr
+    // Cannot use structured binding with constexpr
     static constexpr auto cell_sizes_struct =
         polynomialBasisCellSizes<Dim, Deg>();
     static constexpr auto &cell_sizes = cell_sizes_struct.arr;
@@ -139,13 +155,11 @@ KOKKOS_FUNCTION auto polynomialBasis(Point const &p)
   return arr;
 }
 
+} // namespace Details
+
 template <std::size_t Deg>
 struct PolynomialDegree : std::integral_constant<std::size_t, Deg>
 {};
-
-} // namespace Details
-template <std::size_t Deg>
-static constexpr Details::PolynomialDegree<Deg> PolynomialDegree{};
 
 } // namespace ArborX::Interpolation
 

--- a/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -16,10 +16,7 @@
 
 #include <type_traits>
 
-namespace ArborX::Interpolation
-{
-
-namespace Details
+namespace ArborX::Interpolation::Details
 {
 
 // The goal of these functions is to evaluate the polynomial basis at any degree
@@ -36,7 +33,8 @@ namespace Details
 // - x*[1], y*[1] and z*[1]          at degree 1
 // - x*[x], y*[x, y] and z*[x, y, z] at degree 2
 // So, given a slice at degree n and dimension u, its values would be the
-// product of all the slices of degree n-1 and of dimension u or less.
+// product of all the slices of degree n-1 and of dimension u or less with the
+// coordinate of dimension u.
 //
 // As another example, if we can take the polynomial basis of degree 3 evaluated
 // at a point {x, y} would be [1, x, y, xx, xy, yy, xxx, xxy, xyy, yyy]. Its
@@ -50,6 +48,27 @@ namespace Details
 // - x*[1] and y*[1]           at degree 1
 // - x*[x] and y*[x, y]        at degree 2
 // - x*[xx] and y*[xx, xy, yy] at degree 3
+//
+// These examples can be represented in 2D as the following tables:
+//   Quadratic |  3D  ||        Cubic      |  2D
+// ------------+----- || ------------------+-----
+//    degree   | dim  ||       degree      | dim
+// ---+---+----+      || ---+---+----+-----+
+//  0 | 1 |  2 |      ||  0 | 1 |  2 |  3  |
+// ===o===o====o      || ===o===o====o=====o
+//  1 |        |      ||  1 |              |
+// ---+---+----+----- || ---+---+----+-----+-----
+//    | x |    |  x   ||    | x |    |     |  x
+//    |   | xx |      ||    |   | xx |     |
+//    +---+----+----- ||    |   |    | xxx |
+//    | y |    |  y   ||    +---+----+-----+-----
+//    |   | xy |      ||    | y |    |     |  y
+//    |   | yy |      ||    |   | xy |     |
+//    +---+----+----- ||    |   | yy |     |
+//    | z |    |  z   ||    |   |    | xxy |
+//    |   | xz |      ||    |   |    | xyy |
+//    |   | yz |      ||    |   |    | yyy |
+//    |   | zz |      ||
 
 // This function returns the lengths of the slices for a given maximum degree
 // and dimension.
@@ -149,12 +168,6 @@ KOKKOS_FUNCTION auto evaluatePolynomialBasis(Point const &p)
   return arr;
 }
 
-} // namespace Details
-
-template <std::size_t Deg>
-struct PolynomialDegree : std::integral_constant<std::size_t, Deg>
-{};
-
-} // namespace ArborX::Interpolation
+} // namespace ArborX::Interpolation::Details
 
 #endif

--- a/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -1,0 +1,152 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_INTERP_DETAILS_POLYNOMIAL_BASIS_HPP
+#define ARBORX_INTERP_DETAILS_POLYNOMIAL_BASIS_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <type_traits>
+
+namespace ArborX::Interpolation
+{
+
+namespace Details
+{
+
+// Polynomial basis is computed in the same way as the following example
+// diagrams. Each cell is the product of the variable times everything on the
+// left cell and above.
+//
+// For example, the "degree 3 / variable y" has size 3 because it multiplies
+// every element of "degree 2 / variable y" and "degree 2 / variable x".
+//
+//   Quadratic |  3D  ||        Cubic      |  2D
+// ------------+----- || ------------------+-----
+//    degree   | var  ||       degree      | var
+// ---+---+----+      || ---+---+----+-----+
+//  0 | 1 |  2 |      ||  0 | 1 |  2 |  3  |
+// ---+---+----+      || ---+---+----+-----+
+// ---+---+----+      || ---+---+----+-----+
+//  1 |   |    |      ||  1 |   |    |     |
+// ---+---+----+----- || ---+---+----+-----+-----
+//    | x |    |  x   ||    | x |    |     |  x
+//    |   | xx |      ||    |   | xx |     |
+//    +---+----+----- ||    |   |    | xxx |
+//    | y |    |  y   ||    +---+----+-----+-----
+//    |   | xy |      ||    | y |    |     |  y
+//    |   | yy |      ||    |   | xy |     |
+//    +---+----+----- ||    |   | yy |     |
+//    | z |    |  z   ||    |   |    | xxy |
+//    |   | xz |      ||    |   |    | xyy |
+//    |   | yz |      ||    |   |    | yyy |
+//    |   | zz |      ||
+
+// The size of each cell is 1 if it is at degree 1 or at variable x
+// And the sum of the cells' size to the left and above. (1 alone is not
+// counted). This essentially creates Pascal's triangle where line n corresponds
+// to the "dim + deg = n"-th diagonal
+template <std::size_t Dim, std::size_t Deg>
+KOKKOS_FUNCTION constexpr auto polynomialBasisCellSizes()
+{
+  static_assert(Deg != 0 && Dim != 0,
+                "Unable to compute cell sizes for a constant polynomial basis");
+
+  struct
+  {
+    std::size_t arr[Deg][Dim]{};
+  } result;
+  auto &arr = result.arr;
+
+  for (std::size_t dim = 0; dim < Dim; dim++)
+    arr[0][dim] = 1;
+
+  for (std::size_t deg = 0; deg < Deg; deg++)
+    arr[deg][0] = 1;
+
+  for (std::size_t deg = 1; deg < Deg; deg++)
+    for (std::size_t dim = 1; dim < Dim; dim++)
+      arr[deg][dim] = arr[deg - 1][dim] + arr[deg][dim - 1];
+
+  return result;
+}
+
+// This returns the size of the polynomial basis, which is the sum of all the
+// cells' sizes and 1.
+template <std::size_t Dim, std::size_t Deg>
+KOKKOS_FUNCTION constexpr std::size_t polynomialBasisSize()
+{
+  if constexpr (Deg != 0 && Dim != 0)
+  {
+    auto [arr] = polynomialBasisCellSizes<Dim, Deg>();
+    std::size_t size = 1;
+
+    for (std::size_t deg = 0; deg < Deg; deg++)
+      for (std::size_t dim = 0; dim < Dim; dim++)
+        size += arr[deg][dim];
+
+    return size;
+  }
+  else
+  {
+    return 1;
+  }
+}
+
+// This builds the array as described above
+template <std::size_t Dim, std::size_t Deg, typename Point>
+KOKKOS_FUNCTION auto polynomialBasis(Point const &p)
+{
+  using value_t = std::decay_t<decltype(p[0])>;
+  Kokkos::Array<value_t, polynomialBasisSize<Dim, Deg>()> arr{};
+  arr[0] = value_t(1);
+
+  if constexpr (Deg != 0 && Dim != 0)
+  {
+    // Cannot use struct binding with constexpr
+    static constexpr auto cell_sizes_struct =
+        polynomialBasisCellSizes<Dim, Deg>();
+    static constexpr auto &cell_sizes = cell_sizes_struct.arr;
+
+    std::size_t prev_col = 0;
+    std::size_t curr_col = 1;
+
+    for (std::size_t deg = 0; deg < Deg; deg++)
+    {
+      std::size_t loc_offset = curr_col;
+      for (std::size_t dim = 0; dim < Dim; dim++)
+      {
+        // copy the previous column and multply by p[dim]
+        for (std::size_t i = 0; i < cell_sizes[deg][dim]; i++)
+          arr[loc_offset + i] = arr[prev_col + i] * p[dim];
+
+        loc_offset += cell_sizes[deg][dim];
+      }
+
+      prev_col = curr_col;
+      curr_col = loc_offset;
+    }
+  }
+
+  return arr;
+}
+
+template <std::size_t Deg>
+struct PolynomialDegree : std::integral_constant<std::size_t, Deg>
+{};
+
+} // namespace Details
+template <std::size_t Deg>
+static constexpr Details::PolynomialDegree<Deg> PolynomialDegree{};
+
+} // namespace ArborX::Interpolation
+
+#endif

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -84,7 +84,7 @@ void arborxViewCheck(U const &u, V const &v, std::string const &u_name,
 }
 
 #define ARBORX_MDVIEW_TEST_TOL(VIEWA, VIEWB, TOL)                              \
-  [](decltype(VIEWA) const &u, decltype(VIEWB) const &v) {                     \
+  [&](decltype(VIEWA) const &u, decltype(VIEWB) const &v) {                    \
     auto view_a = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, u); \
     auto view_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, v); \
                                                                                \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -239,6 +239,7 @@ add_test(NAME ArborX_Test_BoostAdapters COMMAND ArborX_Test_BoostAdapters.exe)
 add_executable(ArborX_Test_InterpDetailsMLS.exe
   tstInterpDetailsSVD.cpp
   tstInterpDetailsCRBF.cpp
+  tstInterpDetailsPolyBasis.cpp
   utf_main.cpp)
 target_link_libraries(ArborX_Test_InterpDetailsMLS.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_Test_InterpDetailsMLS.exe PRIVATE BOOST_TEST_DYN_LINK)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -236,11 +236,14 @@ target_link_libraries(ArborX_Test_BoostAdapters.exe PRIVATE ArborX Boost::unit_t
 target_compile_definitions(ArborX_Test_BoostAdapters.exe PRIVATE BOOST_TEST_DYN_LINK)
 add_test(NAME ArborX_Test_BoostAdapters COMMAND ArborX_Test_BoostAdapters.exe)
 
-add_executable(ArborX_Test_InterpDetailsSVD.exe tstInterpDetailsSVD.cpp utf_main.cpp)
-target_link_libraries(ArborX_Test_InterpDetailsSVD.exe PRIVATE ArborX Boost::unit_test_framework)
-target_compile_definitions(ArborX_Test_InterpDetailsSVD.exe PRIVATE BOOST_TEST_DYN_LINK)
-target_include_directories(ArborX_Test_InterpDetailsSVD.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME ArborX_Test_InterpDetailsSVD COMMAND ArborX_Test_InterpDetailsSVD.exe)
+add_executable(ArborX_Test_InterpDetailsMLS.exe
+  tstInterpDetailsSVD.cpp
+  tstInterpDetailsCRBF.cpp
+  utf_main.cpp)
+target_link_libraries(ArborX_Test_InterpDetailsMLS.exe PRIVATE ArborX Boost::unit_test_framework)
+target_compile_definitions(ArborX_Test_InterpDetailsMLS.exe PRIVATE BOOST_TEST_DYN_LINK)
+target_include_directories(ArborX_Test_InterpDetailsMLS.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME ArborX_Test_InterpDetailsMLS COMMAND ArborX_Test_InterpDetailsMLS.exe)
 
 if(ARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS)
   add_subdirectory(headers_self_contained)

--- a/test/tstInterpDetailsCRBF.cpp
+++ b/test/tstInterpDetailsCRBF.cpp
@@ -43,8 +43,8 @@ void makeCase(T tol = 1e-5)
                boost::test_tools::tolerance(tol));
 
     // ]-1; 1[
-    BOOST_TEST(CRBF::evaluate(-in_unit) >= zero);
-    BOOST_TEST(CRBF::evaluate(in_unit) >= zero);
+    BOOST_TEST(CRBF::evaluate(-in_unit) > zero);
+    BOOST_TEST(CRBF::evaluate(in_unit) > zero);
     BOOST_TEST(CRBF::evaluate(in_unit) == CRBF::evaluate(-in_unit),
                boost::test_tools::tolerance(tol));
 

--- a/test/tstInterpDetailsCRBF.cpp
+++ b/test/tstInterpDetailsCRBF.cpp
@@ -9,55 +9,82 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+#include "ArborX_EnableDeviceTypes.hpp"
+#include "ArborX_EnableViewComparison.hpp"
 #include <interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp>
 
 #include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/math/tools/polynomial.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <tuple>
-
-using Functions = std::tuple<ArborX::Interpolation::CRBF::Wendland<0>,
-                             ArborX::Interpolation::CRBF::Wendland<2>,
-                             ArborX::Interpolation::CRBF::Wendland<4>,
-                             ArborX::Interpolation::CRBF::Wendland<6>,
-                             ArborX::Interpolation::CRBF::Wu<2>,
-                             ArborX::Interpolation::CRBF::Wu<4>,
-                             ArborX::Interpolation::CRBF::Buhmann<2>,
-                             ArborX::Interpolation::CRBF::Buhmann<3>,
-                             ArborX::Interpolation::CRBF::Buhmann<4>>;
-
-template <typename CRBF, typename T>
-void makeCase(T tol = 1e-5)
+template <typename T, typename ES, typename CRBF, typename TrueFunc>
+void makeCase(ES const &es, CRBF, TrueFunc const &tf, T tol = 1e-5)
 {
+  using View = Kokkos::View<T *, typename ES::memory_space>;
+  using HostView = typename View::HostMirror;
   static constexpr int range = 15;
 
-  for (int i = 0; i < range; i += 1)
+  HostView input("Testing::input", 4 * range);
+  for (int i = 0; i < range; i++)
   {
-    T in_unit = T(i) / range;
-    T out_unit = i + 1;
-    T zero = 0;
-
-    // ]-inf; -1]
-    BOOST_TEST(CRBF::evaluate(-out_unit) >= zero);
-    BOOST_TEST(CRBF::evaluate(-out_unit) == zero,
-               boost::test_tools::tolerance(tol));
-
-    // ]-1; 1[
-    BOOST_TEST(CRBF::evaluate(-in_unit) > zero);
-    BOOST_TEST(CRBF::evaluate(in_unit) > zero);
-    BOOST_TEST(CRBF::evaluate(in_unit) == CRBF::evaluate(-in_unit),
-               boost::test_tools::tolerance(tol));
-
-    // [1; +inf[
-    BOOST_TEST(CRBF::evaluate(out_unit) >= zero);
-    BOOST_TEST(CRBF::evaluate(out_unit) == zero,
-               boost::test_tools::tolerance(tol));
+    input(4 * i + 0) = -i - 1;
+    input(4 * i + 1) = -T(i) / range;
+    input(4 * i + 2) = T(i) / range;
+    input(4 * i + 3) = i + 1;
   }
+
+  View eval("Testing::eval", 4 * range);
+  Kokkos::deep_copy(es, eval, input);
+  Kokkos::parallel_for(
+      "Testing::eval_crbf", Kokkos::RangePolicy<ES>(es, 0, 4 * range),
+      KOKKOS_LAMBDA(int const i) { eval(i) = CRBF::evaluate(eval(i)); });
+
+  if constexpr (!std::is_same_v<TrueFunc, std::nullptr_t>)
+  {
+    HostView reference("Testing::reference", 4 * range);
+    for (int i = 0; i < range; i++)
+    {
+      reference(4 * i + 0) = 0;
+      reference(4 * i + 1) = tf(T(i) / range);
+      reference(4 * i + 2) = tf(T(i) / range);
+      reference(4 * i + 3) = 0;
+    }
+
+    ARBORX_MDVIEW_TEST_TOL(eval, reference, tol);
+  }
+
+  auto heval = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, eval);
+  for (int i = 0; i < 4 * range; i++)
+    BOOST_TEST(heval(i) >= T(0));
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(crbf, Func, Functions)
-{
-  makeCase<Func, float>();
-  makeCase<Func, double>();
-  makeCase<Func, long double>();
-}
+#define MAKE_TEST(F, I, TF)                                                    \
+  BOOST_AUTO_TEST_CASE_TEMPLATE(crbf_##F##_##I, DeviceType,                    \
+                                ARBORX_DEVICE_TYPES)                           \
+  {                                                                            \
+    makeCase<double>(typename DeviceType::execution_space{},                   \
+                     ArborX::Interpolation::CRBF::F<I>{}, TF);                 \
+  }
+
+#define MAKE_TEST_POLY(F, I, POLY)                                             \
+  MAKE_TEST(F, I, [](auto x) -> decltype(x) {                                  \
+    using boost::math::tools::pow;                                             \
+    using poly = boost::math::tools::polynomial<decltype(x)>;                  \
+    return (POLY)(x);                                                          \
+  })
+
+#define MAKE_TEST_NONE(F, I) MAKE_TEST(F, I, nullptr)
+
+MAKE_TEST_POLY(Wendland, 0, (pow(poly{1, -1}, 2)))
+MAKE_TEST_POLY(Wendland, 2, (pow(poly{1, -1}, 4) * poly{1, 4}))
+MAKE_TEST_POLY(Wendland, 4, (pow(poly{1, -1}, 6) * poly{3, 18, 35}))
+MAKE_TEST_POLY(Wendland, 6, (pow(poly{1, -1}, 8) * poly{1, 8, 25, 32}))
+MAKE_TEST_POLY(Wu, 2, (pow(poly{1, -1}, 4) * poly{4, 16, 12, 3}))
+MAKE_TEST_POLY(Wu, 4, (pow(poly{1, -1}, 6) * poly{6, 36, 82, 72, 30, 5}))
+MAKE_TEST_NONE(Buhmann, 2)
+MAKE_TEST_NONE(Buhmann, 3)
+MAKE_TEST_NONE(Buhmann, 4)
+
+#undef MAKE_TEST_NONE
+#undef MAKE_TEST_POLY
+#undef MAKE_TEST

--- a/test/tstInterpDetailsCRBF.cpp
+++ b/test/tstInterpDetailsCRBF.cpp
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+#include <tuple>
+
+using Functions = std::tuple<ArborX::Interpolation::Details::Wendland<0>,
+                             ArborX::Interpolation::Details::Wendland<2>,
+                             ArborX::Interpolation::Details::Wendland<4>,
+                             ArborX::Interpolation::Details::Wendland<6>,
+                             ArborX::Interpolation::Details::Wu<2>,
+                             ArborX::Interpolation::Details::Wu<4>,
+                             ArborX::Interpolation::Details::Buhmann<2>,
+                             ArborX::Interpolation::Details::Buhmann<3>,
+                             ArborX::Interpolation::Details::Buhmann<4>>;
+
+template <typename CRBF, typename T>
+void makeCase(T tol = 1e-5)
+{
+  static constexpr int range = 15;
+
+  for (int i = 0; i < range; i += 1)
+  {
+    T in_unit = T(i) / range;
+    T out_unit = i + 1;
+    T zero = 0;
+
+    // ]-inf; -1]
+    BOOST_TEST(CRBF::apply(-out_unit) >= zero);
+    BOOST_TEST(CRBF::apply(-out_unit) == zero,
+               boost::test_tools::tolerance(tol));
+
+    // ]-1; 1[
+    BOOST_TEST(CRBF::apply(-in_unit) >= zero);
+    BOOST_TEST(CRBF::apply(in_unit) >= zero);
+    BOOST_TEST(CRBF::apply(in_unit) == CRBF::apply(-in_unit),
+               boost::test_tools::tolerance(tol));
+
+    // [1; +inf[
+    BOOST_TEST(CRBF::apply(out_unit) >= zero);
+    BOOST_TEST(CRBF::apply(out_unit) == zero,
+               boost::test_tools::tolerance(tol));
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(crbf, Func, Functions)
+{
+  makeCase<Func, float>();
+  makeCase<Func, double>();
+  makeCase<Func, long double>();
+}

--- a/test/tstInterpDetailsCRBF.cpp
+++ b/test/tstInterpDetailsCRBF.cpp
@@ -16,15 +16,15 @@
 
 #include <tuple>
 
-using Functions = std::tuple<ArborX::Interpolation::Details::Wendland<0>,
-                             ArborX::Interpolation::Details::Wendland<2>,
-                             ArborX::Interpolation::Details::Wendland<4>,
-                             ArborX::Interpolation::Details::Wendland<6>,
-                             ArborX::Interpolation::Details::Wu<2>,
-                             ArborX::Interpolation::Details::Wu<4>,
-                             ArborX::Interpolation::Details::Buhmann<2>,
-                             ArborX::Interpolation::Details::Buhmann<3>,
-                             ArborX::Interpolation::Details::Buhmann<4>>;
+using Functions = std::tuple<ArborX::Interpolation::CRBF::Wendland<0>,
+                             ArborX::Interpolation::CRBF::Wendland<2>,
+                             ArborX::Interpolation::CRBF::Wendland<4>,
+                             ArborX::Interpolation::CRBF::Wendland<6>,
+                             ArborX::Interpolation::CRBF::Wu<2>,
+                             ArborX::Interpolation::CRBF::Wu<4>,
+                             ArborX::Interpolation::CRBF::Buhmann<2>,
+                             ArborX::Interpolation::CRBF::Buhmann<3>,
+                             ArborX::Interpolation::CRBF::Buhmann<4>>;
 
 template <typename CRBF, typename T>
 void makeCase(T tol = 1e-5)
@@ -38,19 +38,19 @@ void makeCase(T tol = 1e-5)
     T zero = 0;
 
     // ]-inf; -1]
-    BOOST_TEST(CRBF::apply(-out_unit) >= zero);
-    BOOST_TEST(CRBF::apply(-out_unit) == zero,
+    BOOST_TEST(CRBF::evaluate(-out_unit) >= zero);
+    BOOST_TEST(CRBF::evaluate(-out_unit) == zero,
                boost::test_tools::tolerance(tol));
 
     // ]-1; 1[
-    BOOST_TEST(CRBF::apply(-in_unit) >= zero);
-    BOOST_TEST(CRBF::apply(in_unit) >= zero);
-    BOOST_TEST(CRBF::apply(in_unit) == CRBF::apply(-in_unit),
+    BOOST_TEST(CRBF::evaluate(-in_unit) >= zero);
+    BOOST_TEST(CRBF::evaluate(in_unit) >= zero);
+    BOOST_TEST(CRBF::evaluate(in_unit) == CRBF::evaluate(-in_unit),
                boost::test_tools::tolerance(tol));
 
     // [1; +inf[
-    BOOST_TEST(CRBF::apply(out_unit) >= zero);
-    BOOST_TEST(CRBF::apply(out_unit) == zero,
+    BOOST_TEST(CRBF::evaluate(out_unit) >= zero);
+    BOOST_TEST(CRBF::evaluate(out_unit) == zero,
                boost::test_tools::tolerance(tol));
   }
 }

--- a/test/tstInterpDetailsPolyBasis.cpp
+++ b/test/tstInterpDetailsPolyBasis.cpp
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * Copyright (c) 2023 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborX_EnableViewComparison.hpp"
+#include <interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(polynomial_basis_column_sizes)
+{
+  using view = Kokkos::View<std::size_t **, Kokkos::HostSpace>;
+
+  auto [arr0] =
+      ArborX::Interpolation::Details::polynomialBasisCellSizes<5, 3>();
+  std::size_t ref0[3][5] = {
+      {1, 1, 1, 1, 1}, {1, 2, 3, 4, 5}, {1, 3, 6, 10, 15}};
+  view arr0_view(&arr0[0][0], 3, 5);
+  view ref0_view(&ref0[0][0], 3, 5);
+  ARBORX_MDVIEW_TEST(arr0_view, ref0_view);
+
+  auto [arr1] =
+      ArborX::Interpolation::Details::polynomialBasisCellSizes<2, 3>();
+  std::size_t ref1[3][2] = {{1, 1}, {1, 2}, {1, 3}};
+  view arr1_view(&arr1[0][0], 3, 2);
+  view ref1_view(&ref1[0][0], 3, 2);
+  ARBORX_MDVIEW_TEST(arr1_view, ref1_view);
+}
+
+BOOST_AUTO_TEST_CASE(polynomial_basis_size)
+{
+  auto sz0 = ArborX::Interpolation::Details::polynomialBasisSize<5, 3>();
+  BOOST_TEST(sz0 == 56);
+
+  auto sz1 = ArborX::Interpolation::Details::polynomialBasisSize<2, 3>();
+  BOOST_TEST(sz1 == 10);
+
+  auto sz2 = ArborX::Interpolation::Details::polynomialBasisSize<3, 0>();
+  BOOST_TEST(sz2 == 1);
+
+  auto sz3 = ArborX::Interpolation::Details::polynomialBasisSize<0, 3>();
+  BOOST_TEST(sz3 == 1);
+}
+
+BOOST_AUTO_TEST_CASE(polynomial_basis)
+{
+  using view = Kokkos::View<double *, Kokkos::HostSpace>;
+
+  double point0[5] = {1, 2, 3, 4, 5};
+  auto arr0 = ArborX::Interpolation::Details::polynomialBasis<5, 3>(point0);
+  double ref0[56] = {1,  1,  2,  3,  4,  5,  1,  2,  4,  3,  6,  9,  4,   8,
+                     12, 16, 5,  10, 15, 20, 25, 1,  2,  4,  8,  3,  6,   12,
+                     9,  18, 27, 4,  8,  16, 12, 24, 36, 16, 32, 48, 64,  5,
+                     10, 20, 15, 30, 45, 20, 40, 60, 80, 25, 50, 75, 100, 125};
+  view arr0_view(arr0.data(), 56);
+  view ref0_view(&ref0[0], 56);
+  ARBORX_MDVIEW_TEST(arr0_view, ref0_view);
+
+  double point1[2] = {-2, 0};
+  auto arr1 = ArborX::Interpolation::Details::polynomialBasis<2, 3>(point1);
+  double ref1[10] = {1, -2, 0, 4, 0, 0, -8, 0, 0, 0};
+  view arr1_view(arr1.data(), 10);
+  view ref1_view(&ref1[0], 10);
+  ARBORX_MDVIEW_TEST(arr1_view, ref1_view);
+}

--- a/test/tstInterpDetailsPolyBasis.cpp
+++ b/test/tstInterpDetailsPolyBasis.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include "ArborX_EnableViewComparison.hpp"
+#include <ArborX_HyperPoint.hpp>
 #include <interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp>
 
 #include <boost/test/unit_test.hpp>
@@ -36,16 +37,16 @@ BOOST_AUTO_TEST_CASE(polynomial_basis_slice_lengths)
 
 BOOST_AUTO_TEST_CASE(polynomial_basis_size)
 {
-  auto sz0 = ArborX::Interpolation::Details::polynomialBasisSize<5, 3>();
+  auto sz0 = ArborX::Interpolation::Details::polynomialBasisSize(5, 3);
   BOOST_TEST(sz0 == 56);
 
-  auto sz1 = ArborX::Interpolation::Details::polynomialBasisSize<2, 3>();
+  auto sz1 = ArborX::Interpolation::Details::polynomialBasisSize(2, 3);
   BOOST_TEST(sz1 == 10);
 
-  auto sz2 = ArborX::Interpolation::Details::polynomialBasisSize<3, 0>();
+  auto sz2 = ArborX::Interpolation::Details::polynomialBasisSize(3, 0);
   BOOST_TEST(sz2 == 1);
 
-  auto sz3 = ArborX::Interpolation::Details::polynomialBasisSize<0, 3>();
+  auto sz3 = ArborX::Interpolation::Details::polynomialBasisSize(0, 3);
   BOOST_TEST(sz3 == 1);
 }
 
@@ -53,9 +54,9 @@ BOOST_AUTO_TEST_CASE(polynomial_basis)
 {
   using view = Kokkos::View<double *, Kokkos::HostSpace>;
 
-  double point0[5] = {1, 2, 3, 4, 5};
+  ArborX::ExperimentalHyperGeometry::Point<5, double> point0 = {1, 2, 3, 4, 5};
   auto arr0 =
-      ArborX::Interpolation::Details::evaluatePolynomialBasis<5, 3>(point0);
+      ArborX::Interpolation::Details::evaluatePolynomialBasis<3>(point0);
   double ref0[56] = {1,  1,  2,  3,  4,  5,  1,  2,  4,  3,  6,  9,  4,   8,
                      12, 16, 5,  10, 15, 20, 25, 1,  2,  4,  8,  3,  6,   12,
                      9,  18, 27, 4,  8,  16, 12, 24, 36, 16, 32, 48, 64,  5,
@@ -64,9 +65,9 @@ BOOST_AUTO_TEST_CASE(polynomial_basis)
   view ref0_view(&ref0[0], 56);
   ARBORX_MDVIEW_TEST(arr0_view, ref0_view);
 
-  double point1[2] = {-2, 0};
+  ArborX::ExperimentalHyperGeometry::Point<2, double> point1 = {-2, 0};
   auto arr1 =
-      ArborX::Interpolation::Details::evaluatePolynomialBasis<2, 3>(point1);
+      ArborX::Interpolation::Details::evaluatePolynomialBasis<3>(point1);
   double ref1[10] = {1, -2, 0, 4, 0, 0, -8, 0, 0, 0};
   view arr1_view(arr1.data(), 10);
   view ref1_view(&ref1[0], 10);

--- a/test/tstInterpDetailsPolyBasis.cpp
+++ b/test/tstInterpDetailsPolyBasis.cpp
@@ -14,12 +14,12 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(polynomial_basis_column_sizes)
+BOOST_AUTO_TEST_CASE(polynomial_basis_slice_lengths)
 {
   using view = Kokkos::View<std::size_t **, Kokkos::HostSpace>;
 
   auto [arr0] =
-      ArborX::Interpolation::Details::polynomialBasisCellSizes<5, 3>();
+      ArborX::Interpolation::Details::polynomialBasisSliceLengths<5, 3>();
   std::size_t ref0[3][5] = {
       {1, 1, 1, 1, 1}, {1, 2, 3, 4, 5}, {1, 3, 6, 10, 15}};
   view arr0_view(&arr0[0][0], 3, 5);
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(polynomial_basis_column_sizes)
   ARBORX_MDVIEW_TEST(arr0_view, ref0_view);
 
   auto [arr1] =
-      ArborX::Interpolation::Details::polynomialBasisCellSizes<2, 3>();
+      ArborX::Interpolation::Details::polynomialBasisSliceLengths<2, 3>();
   std::size_t ref1[3][2] = {{1, 1}, {1, 2}, {1, 3}};
   view arr1_view(&arr1[0][0], 3, 2);
   view ref1_view(&ref1[0][0], 3, 2);

--- a/test/tstInterpDetailsPolyBasis.cpp
+++ b/test/tstInterpDetailsPolyBasis.cpp
@@ -54,7 +54,8 @@ BOOST_AUTO_TEST_CASE(polynomial_basis)
   using view = Kokkos::View<double *, Kokkos::HostSpace>;
 
   double point0[5] = {1, 2, 3, 4, 5};
-  auto arr0 = ArborX::Interpolation::Details::polynomialBasis<5, 3>(point0);
+  auto arr0 =
+      ArborX::Interpolation::Details::evaluatePolynomialBasis<5, 3>(point0);
   double ref0[56] = {1,  1,  2,  3,  4,  5,  1,  2,  4,  3,  6,  9,  4,   8,
                      12, 16, 5,  10, 15, 20, 25, 1,  2,  4,  8,  3,  6,   12,
                      9,  18, 27, 4,  8,  16, 12, 24, 36, 16, 32, 48, 64,  5,
@@ -64,7 +65,8 @@ BOOST_AUTO_TEST_CASE(polynomial_basis)
   ARBORX_MDVIEW_TEST(arr0_view, ref0_view);
 
   double point1[2] = {-2, 0};
-  auto arr1 = ArborX::Interpolation::Details::polynomialBasis<2, 3>(point1);
+  auto arr1 =
+      ArborX::Interpolation::Details::evaluatePolynomialBasis<2, 3>(point1);
   double ref1[10] = {1, -2, 0, 4, 0, 0, -8, 0, 0, 0};
   view arr1_view(arr1.data(), 10);
   view ref1_view(&ref1[0], 10);

--- a/test/tstInterpDetailsPolyBasis.cpp
+++ b/test/tstInterpDetailsPolyBasis.cpp
@@ -37,17 +37,12 @@ BOOST_AUTO_TEST_CASE(polynomial_basis_slice_lengths)
 
 BOOST_AUTO_TEST_CASE(polynomial_basis_size)
 {
-  auto sz0 = ArborX::Interpolation::Details::polynomialBasisSize(5, 3);
-  BOOST_TEST(sz0 == 56);
-
-  auto sz1 = ArborX::Interpolation::Details::polynomialBasisSize(2, 3);
-  BOOST_TEST(sz1 == 10);
-
-  auto sz2 = ArborX::Interpolation::Details::polynomialBasisSize(3, 0);
-  BOOST_TEST(sz2 == 1);
-
-  auto sz3 = ArborX::Interpolation::Details::polynomialBasisSize(0, 3);
-  BOOST_TEST(sz3 == 1);
+  BOOST_TEST(
+      (ArborX::Interpolation::Details::polynomialBasisSize<5, 3>() == 56));
+  BOOST_TEST(
+      (ArborX::Interpolation::Details::polynomialBasisSize<2, 3>() == 10));
+  BOOST_TEST(
+      (ArborX::Interpolation::Details::polynomialBasisSize<3, 0>() == 1));
 }
 
 BOOST_AUTO_TEST_CASE(polynomial_basis)


### PR DESCRIPTION
Follow-up of #946 and #950. This PR adds the set of radial basis functions that were present on DTK, a generic way of building a polynomial basis and tests for both of them.
- Adds `ArborX::Interpolation::CRBF`, a namespace containing the compact radial basis functions `Wendland`, `Wu` and `Buhmann`.