### PR TITLE
Include `<iostream>` when using it in examples and benchmaks

### DIFF
--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.cpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.cpp
@@ -15,6 +15,8 @@
 
 #include <boost/program_options.hpp>
 
+#include <iostream>
+
 int main(int argc, char *argv[])
 {
   Kokkos::ScopeGuard guard(argc, argv);

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -18,6 +18,7 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <iostream>
 #include <set>
 #include <stack>
 #include <vector>

--- a/benchmarks/dbscan/data.hpp
+++ b/benchmarks/dbscan/data.hpp
@@ -15,6 +15,7 @@
 #include <ArborX_Exception.hpp>
 #include <ArborX_HyperPoint.hpp>
 
+#include <iostream>
 #include <random>
 #include <vector>
 

--- a/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
+++ b/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <cmath> // sqrt, cbrt
 #include <iomanip>
+#include <iostream>
 #include <numeric>
 #include <random>
 #include <utility>

--- a/benchmarks/union_find/union_find.cpp
+++ b/benchmarks/union_find/union_find.cpp
@@ -20,6 +20,8 @@
 
 #include <boost/program_options.hpp>
 
+#include <iostream>
+
 #include <benchmark/benchmark.h>
 
 struct UnweightedEdge

--- a/examples/brute_force/brute_force.cpp
+++ b/examples/brute_force/brute_force.cpp
@@ -17,6 +17,8 @@
 
 #include <boost/program_options.hpp>
 
+#include <iostream>
+
 struct Dummy
 {
   int count;

--- a/examples/molecular_dynamics/example_molecular_dynamics.cpp
+++ b/examples/molecular_dynamics/example_molecular_dynamics.cpp
@@ -14,6 +14,7 @@
 
 #include <Kokkos_Random.hpp>
 
+#include <iostream>
 #include <type_traits>
 
 template <class MemorySpace>

--- a/examples/simple_intersection/example_intersection.cpp
+++ b/examples/simple_intersection/example_intersection.cpp
@@ -13,6 +13,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <iostream>
+
 // Perform intersection queries using the same objects for the queries as the
 // objects used in BVH construction that are located on a regular spaced
 // three-dimensional grid.

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -14,6 +14,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <iostream>
+
 // Perform intersection queries using 2D triangles on a regular mesh as
 // primitives and intersection with points as queries. One point per triangle.
 // __________

--- a/examples/viz/tree_visualization.cpp
+++ b/examples/viz/tree_visualization.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <random>
 
 // FIXME: this is a temporary place for loadPointCloud and writePointCloud


### PR DESCRIPTION
Nightlies are broken following the merge of kokkos/kokkos#6482