### PR TITLE
Add copyright checking

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -31,6 +31,7 @@ pipeline {
             }
             steps {
                 sh './scripts/check_format_cpp.sh'
+                sh './scripts/check_copyright.sh'
             }
         }
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, ArborX authors
+Copyright (c) 2025, ArborX authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright 2017-2022 the ArborX authors
+Copyright (c) 2024, ArborX authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.cpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/converter.cpp
+++ b/benchmarks/dbscan/converter.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/data.hpp
+++ b/benchmarks/dbscan/data.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/dbscan.cpp
+++ b/benchmarks/dbscan/dbscan.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/dbscan.hpp
+++ b/benchmarks/dbscan/dbscan.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/dbscan_timpl.hpp
+++ b/benchmarks/dbscan/dbscan_timpl.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/print_timers.cpp
+++ b/benchmarks/dbscan/print_timers.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/dbscan/print_timers.hpp
+++ b/benchmarks/dbscan/print_timers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/develop/develop.cpp
+++ b/benchmarks/develop/develop.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
+++ b/benchmarks/execution_space_instances/execution_space_instances_driver.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/triangulated_surface_distance/generator.hpp
+++ b/benchmarks/triangulated_surface_distance/generator.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
+++ b/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/union_find/union_find.cpp
+++ b/benchmarks/union_find/union_find.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/utils/ArborXBenchmark_PointClouds.hpp
+++ b/benchmarks/utils/ArborXBenchmark_PointClouds.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/benchmarks/utils/ArborXBenchmark_TimeMonitor.hpp
+++ b/benchmarks/utils/ArborXBenchmark_TimeMonitor.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/cmake/SetupVersion.cmake
+++ b/cmake/SetupVersion.cmake
@@ -1,5 +1,5 @@
 ##/****************************************************************************
-## * Copyright (c) 2017-2022 by the ArborX authors                            *
+## * Copyright (c) 2025, ArborX authors                                       *
 ## * All rights reserved.                                                     *
 ## *                                                                          *
 ## * This file is part of the ArborX library. ArborX is                       *

--- a/examples/access_traits/example_cuda_access_traits.cpp
+++ b/examples/access_traits/example_cuda_access_traits.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/access_traits/example_host_access_traits.cpp
+++ b/examples/access_traits/example_host_access_traits.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/brute_force/example_brute_force.cpp
+++ b/examples/brute_force/example_brute_force.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/dbscan/example_dbscan.cpp
+++ b/examples/dbscan/example_dbscan.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/distributed_tree/distributed_knn.cpp
+++ b/examples/distributed_tree/distributed_knn.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/molecular_dynamics/example_molecular_dynamics.cpp
+++ b/examples/molecular_dynamics/example_molecular_dynamics.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/moving_least_squares/moving_least_squares.cpp
+++ b/examples/moving_least_squares/moving_least_squares.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/simple_intersection/example_intersection.cpp
+++ b/examples/simple_intersection/example_intersection.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/examples/viz/tree_visualization.cpp
+++ b/examples/viz/tree_visualization.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+year=2025
+
+license="/****************************************************************************
+ * Copyright (c) ${year}, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/"
+header_length=$(echo "$license" | wc -l)
+
+temp_header_file="scripts/.temp_header"
+master="origin/master"
+
+n_wrong_licenses=0
+for file in $(git diff --diff-filter=AMRU --name-only ${master}... | grep -e '.*\.\(cc\|cpp\|hpp\)')
+do
+  header="$(head -n ${header_length} ${file})"
+  # header=$(echo "$header" | sed 's/[[:digit:]]\{4\}-//')
+  echo "${header}" > ${temp_header_file}
+  diff=$(diff -q "${temp_header_file}" <(echo "$license"))
+  if [[ "$diff" != "" ]]
+  then
+    echo "File \"${file}\" does not have a correct license or year"
+    diff "${temp_header_file}" <(echo "$license")
+
+    n_wrong_licenses=$((n_wrong_licenses + 1))
+  fi
+done
+rm -f ${temp_header_file}
+
+exit $n_wrong_licenses

--- a/src/ArborX.hpp
+++ b/src/ArborX.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/ArborX_Config.hpp.in
+++ b/src/ArborX_Config.hpp.in
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/ArborX_Version.hpp.in
+++ b/src/ArborX_Version.hpp.in
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/ArborX_DBSCAN.hpp
+++ b/src/cluster/ArborX_DBSCAN.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/ArborX_Dendrogram.hpp
+++ b/src/cluster/ArborX_Dendrogram.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/ArborX_HDBSCAN.hpp
+++ b/src/cluster/ArborX_HDBSCAN.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/ArborX_MinimumSpanningTree.hpp
+++ b/src/cluster/ArborX_MinimumSpanningTree.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_BoruvkaHelpers.hpp
+++ b/src/cluster/detail/ArborX_BoruvkaHelpers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_CartesianGrid.hpp
+++ b/src/cluster/detail/ArborX_CartesianGrid.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_DendrogramHelpers.hpp
+++ b/src/cluster/detail/ArborX_DendrogramHelpers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_FDBSCAN.hpp
+++ b/src/cluster/detail/ArborX_FDBSCAN.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_FDBSCANDenseBox.hpp
+++ b/src/cluster/detail/ArborX_FDBSCANDenseBox.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_MutualReachabilityDistance.hpp
+++ b/src/cluster/detail/ArborX_MutualReachabilityDistance.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_UnionFind.hpp
+++ b/src/cluster/detail/ArborX_UnionFind.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/cluster/detail/ArborX_WeightedEdge.hpp
+++ b/src/cluster/detail/ArborX_WeightedEdge.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/distributed/ArborX_DistributedTree.hpp
+++ b/src/distributed/ArborX_DistributedTree.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/distributed/detail/ArborX_DistributedTreeImpl.hpp
+++ b/src/distributed/detail/ArborX_DistributedTreeImpl.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/distributed/detail/ArborX_DistributedTreeNearest.hpp
+++ b/src/distributed/detail/ArborX_DistributedTreeNearest.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/distributed/detail/ArborX_DistributedTreeNearestHelpers.hpp
+++ b/src/distributed/detail/ArborX_DistributedTreeNearestHelpers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2024 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/distributed/detail/ArborX_DistributedTreeSpatial.hpp
+++ b/src/distributed/detail/ArborX_DistributedTreeSpatial.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/distributed/detail/ArborX_DistributedTreeUtils.hpp
+++ b/src/distributed/detail/ArborX_DistributedTreeUtils.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/distributed/detail/ArborX_Distributor.hpp
+++ b/src/distributed/detail/ArborX_Distributor.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_KDOP.hpp
+++ b/src/geometry/ArborX_KDOP.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_Point.hpp
+++ b/src/geometry/ArborX_Point.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_Segment.hpp
+++ b/src/geometry/ArborX_Segment.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_Sphere.hpp
+++ b/src/geometry/ArborX_Sphere.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_Tetrahedron.hpp
+++ b/src/geometry/ArborX_Tetrahedron.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/ArborX_Triangle.hpp
+++ b/src/geometry/ArborX_Triangle.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2024 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Centroid.hpp
+++ b/src/geometry/algorithms/ArborX_Centroid.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Convert.hpp
+++ b/src/geometry/algorithms/ArborX_Convert.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Distance.hpp
+++ b/src/geometry/algorithms/ArborX_Distance.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Equals.hpp
+++ b/src/geometry/algorithms/ArborX_Equals.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Expand.hpp
+++ b/src/geometry/algorithms/ArborX_Expand.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Intersects.hpp
+++ b/src/geometry/algorithms/ArborX_Intersects.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Reducer.hpp
+++ b/src/geometry/algorithms/ArborX_Reducer.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_TranslateAndScale.hpp
+++ b/src/geometry/algorithms/ArborX_TranslateAndScale.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/geometry/algorithms/ArborX_Valid.hpp
+++ b/src/geometry/algorithms/ArborX_Valid.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
+++ b/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/interpolation/detail/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/interpolation/detail/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtAccessibilityTraits.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtAccessibilityTraits.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtArithmeticTraits.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtArithmeticTraits.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2024 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtMinMaxReduce.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtMinMaxReduce.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtSort.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtSort.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtStdAlgorithms.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtStdAlgorithms.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtUninitializedMemoryAlgorithms.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtUninitializedMemoryAlgorithms.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtVersion.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtVersion.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/kokkos_ext/ArborX_KokkosExtViewHelpers.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtViewHelpers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_Containers.hpp
+++ b/src/misc/ArborX_Containers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_Exception.hpp
+++ b/src/misc/ArborX_Exception.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_Heap.hpp
+++ b/src/misc/ArborX_Heap.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_OperatorFunctionObjects.hpp
+++ b/src/misc/ArborX_OperatorFunctionObjects.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_PriorityQueue.hpp
+++ b/src/misc/ArborX_PriorityQueue.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_SortUtils.hpp
+++ b/src/misc/ArborX_SortUtils.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_Stack.hpp
+++ b/src/misc/ArborX_Stack.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_SymmetricSVD.hpp
+++ b/src/misc/ArborX_SymmetricSVD.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_Utils.hpp
+++ b/src/misc/ArborX_Utils.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/misc/ArborX_Vector.hpp
+++ b/src/misc/ArborX_Vector.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/ArborX_BruteForce.hpp
+++ b/src/spatial/ArborX_BruteForce.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/ArborX_CrsGraphWrapper.hpp
+++ b/src/spatial/ArborX_CrsGraphWrapper.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/ArborX_LinearBVH.hpp
+++ b/src/spatial/ArborX_LinearBVH.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_AccessTraits.hpp
+++ b/src/spatial/detail/ArborX_AccessTraits.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_AttachIndices.hpp
+++ b/src/spatial/detail/ArborX_AttachIndices.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_BruteForceImpl.hpp
+++ b/src/spatial/detail/ArborX_BruteForceImpl.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_Callbacks.hpp
+++ b/src/spatial/detail/ArborX_Callbacks.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_CrsGraphWrapperImpl.hpp
+++ b/src/spatial/detail/ArborX_CrsGraphWrapperImpl.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_ExpandHalfToFull.hpp
+++ b/src/spatial/detail/ArborX_ExpandHalfToFull.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_HalfTraversal.hpp
+++ b/src/spatial/detail/ArborX_HalfTraversal.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_HappyTreeFriends.hpp
+++ b/src/spatial/detail/ArborX_HappyTreeFriends.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_IndexableGetter.hpp
+++ b/src/spatial/detail/ArborX_IndexableGetter.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_MortonCode.hpp
+++ b/src/spatial/detail/ArborX_MortonCode.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_NearestBufferProvider.hpp
+++ b/src/spatial/detail/ArborX_NearestBufferProvider.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_NeighborList.hpp
+++ b/src/spatial/detail/ArborX_NeighborList.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_Node.hpp
+++ b/src/spatial/detail/ArborX_Node.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_PairValueIndex.hpp
+++ b/src/spatial/detail/ArborX_PairValueIndex.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_PermutedData.hpp
+++ b/src/spatial/detail/ArborX_PermutedData.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_PredicateHelpers.hpp
+++ b/src/spatial/detail/ArborX_PredicateHelpers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_Predicates.hpp
+++ b/src/spatial/detail/ArborX_Predicates.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_SpaceFillingCurves.hpp
+++ b/src/spatial/detail/ArborX_SpaceFillingCurves.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_TraversalPolicy.hpp
+++ b/src/spatial/detail/ArborX_TraversalPolicy.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_TreeConstruction.hpp
+++ b/src/spatial/detail/ArborX_TreeConstruction.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_TreeNodeLabeling.hpp
+++ b/src/spatial/detail/ArborX_TreeNodeLabeling.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_TreeTraversal.hpp
+++ b/src/spatial/detail/ArborX_TreeTraversal.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/src/spatial/detail/ArborX_TreeVisualization.hpp
+++ b/src/spatial/detail/ArborX_TreeVisualization.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborXTest_Cloud.hpp
+++ b/test/ArborXTest_Cloud.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborXTest_LegacyTree.hpp
+++ b/test/ArborXTest_LegacyTree.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborXTest_PairIndexRank.hpp
+++ b/test/ArborXTest_PairIndexRank.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborXTest_StdVectorToKokkosView.hpp
+++ b/test/ArborXTest_StdVectorToKokkosView.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborXTest_TreeTypeTraits.hpp
+++ b/test/ArborXTest_TreeTypeTraits.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborX_BoostGeometryAdapters.hpp
+++ b/test/ArborX_BoostGeometryAdapters.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborX_BoostRangeAdapters.hpp
+++ b/test/ArborX_BoostRangeAdapters.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborX_EnableDeviceTypes.hpp.in
+++ b/test/ArborX_EnableDeviceTypes.hpp.in
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/BoostTest_CUDA_clang_workarounds.hpp
+++ b/test/BoostTest_CUDA_clang_workarounds.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/Search_UnitTestHelpers.hpp
+++ b/test/Search_UnitTestHelpers.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/boost_ext/CompressedStorageComparison.hpp
+++ b/test/boost_ext/CompressedStorageComparison.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/boost_ext/KokkosPairComparison.hpp
+++ b/test/boost_ext/KokkosPairComparison.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/boost_ext/TupleComparison.hpp
+++ b/test/boost_ext/TupleComparison.hpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/headers_self_contained/tstHeader.cpp
+++ b/test/headers_self_contained/tstHeader.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstAttachIndices.cpp
+++ b/test/tstAttachIndices.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstBoostRangeAdapters.cpp
+++ b/test/tstBoostRangeAdapters.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstCompileOnlyCallbacks.cpp
+++ b/test/tstCompileOnlyCallbacks.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstCompileOnlyGeometry.cpp
+++ b/test/tstCompileOnlyGeometry.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstCompileOnlyMain.cpp
+++ b/test/tstCompileOnlyMain.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstCompileOnlyTypeRequirements.cpp
+++ b/test/tstCompileOnlyTypeRequirements.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstCompileOnlyVersionMacros.cpp
+++ b/test/tstCompileOnlyVersionMacros.cpp
@@ -1,3 +1,13 @@
+/****************************************************************************
+ * Copyright (c) 2025, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
 #include <ArborX_Config.hpp>
 
 #ifndef ARBORX_VERSION

--- a/test/tstCompileOnlyWeightedEdges.cpp
+++ b/test/tstCompileOnlyWeightedEdges.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstContainerAdaptors.cpp
+++ b/test/tstContainerAdaptors.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDBSCAN.cpp
+++ b/test/tstDBSCAN.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDendrogram.cpp
+++ b/test/tstDendrogram.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsCrsGraphWrapperImpl.cpp
+++ b/test/tstDetailsCrsGraphWrapperImpl.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsDistributedTreeImpl.cpp
+++ b/test/tstDetailsDistributedTreeImpl.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsDistributor.cpp
+++ b/test/tstDetailsDistributor.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsExpandHalfToFull.cpp
+++ b/test/tstDetailsExpandHalfToFull.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsGeometryReducer.cpp
+++ b/test/tstDetailsGeometryReducer.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2024 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsHalfTraversal.cpp
+++ b/test/tstDetailsHalfTraversal.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
+++ b/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsKokkosExtMinMaxReduce.cpp
+++ b/test/tstDetailsKokkosExtMinMaxReduce.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsKokkosExtStdAlgorithms.cpp
+++ b/test/tstDetailsKokkosExtStdAlgorithms.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsKokkosExtUninitializedMemoryAlgorithms.cpp
+++ b/test/tstDetailsKokkosExtUninitializedMemoryAlgorithms.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsKokkosExtViewHelpers.cpp
+++ b/test/tstDetailsKokkosExtViewHelpers.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsMortonCodes.cpp
+++ b/test/tstDetailsMortonCodes.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsMutualReachabilityDistance.cpp
+++ b/test/tstDetailsMutualReachabilityDistance.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsSVD.cpp
+++ b/test/tstDetailsSVD.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsTreeConstruction.cpp
+++ b/test/tstDetailsTreeConstruction.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsTreeNodeLabeling.cpp
+++ b/test/tstDetailsTreeNodeLabeling.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsUtils.cpp
+++ b/test/tstDetailsUtils.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDetailsVector.cpp
+++ b/test/tstDetailsVector.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDistributedTreeNearest.cpp
+++ b/test/tstDistributedTreeNearest.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstDistributedTreeSpatial.cpp
+++ b/test/tstDistributedTreeSpatial.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstException.cpp
+++ b/test/tstException.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstHeapOperations.cpp
+++ b/test/tstHeapOperations.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstIndexableGetter.cpp
+++ b/test/tstIndexableGetter.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstInterpDetailsCompactRadialBasisFunction.cpp
+++ b/test/tstInterpDetailsCompactRadialBasisFunction.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstInterpDetailsMLSCoefficients.cpp
+++ b/test/tstInterpDetailsMLSCoefficients.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstInterpDetailsPolyBasis.cpp
+++ b/test/tstInterpDetailsPolyBasis.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstInterpMovingLeastSquares.cpp
+++ b/test/tstInterpMovingLeastSquares.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstKDOP.cpp
+++ b/test/tstKDOP.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstKokkosToolsExecutionSpaceInstances.cpp
+++ b/test/tstKokkosToolsExecutionSpaceInstances.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstMinimumSpanningTree.cpp
+++ b/test/tstMinimumSpanningTree.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstMinimumSpanningTreeGoldenTest.cpp
+++ b/test/tstMinimumSpanningTreeGoldenTest.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstNeighborList.cpp
+++ b/test/tstNeighborList.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstPriorityQueueMiscellaneous.cpp
+++ b/test/tstPriorityQueueMiscellaneous.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeCallbackQueryPerThread.cpp
+++ b/test/tstQueryTreeCallbackQueryPerThread.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2023 by the ArborX authors                                 *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeIntersectsKDOP.cpp
+++ b/test/tstQueryTreeIntersectsKDOP.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeRay.cpp
+++ b/test/tstQueryTreeRay.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstQueryTreeTraversalPolicy.cpp
+++ b/test/tstQueryTreeTraversalPolicy.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstRay.cpp
+++ b/test/tstRay.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstSequenceContainers.cpp
+++ b/test/tstSequenceContainers.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/tstUnionFind.cpp
+++ b/test/tstUnionFind.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *

--- a/test/utf_main.cpp
+++ b/test/utf_main.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * Copyright (c) 2025, ArborX authors                                       *
  * All rights reserved.                                                     *
  *                                                                          *
  * This file is part of the ArborX library. ArborX is                       *


### PR DESCRIPTION
This adds a `scripts/check_copyright.sh` script to check whether the files in the PR have correct license. Correct license here means that it can only differ from the standard license form in one way: it could have 'XXXX-YYYY' year range, and the license file would only have 'YYYY'.

Caveats:
- Only C++ files are checked (through filtering file extensions)
- Only files that are modified, renamed or added are checked
- It may not work well with locally (as it checks against `origin/master` that could be outdated, or `origin` could be named differently)
- It only works with cloned code (as it needs `origin/master`)

I've also run the script to find all license discrepancies in the files that were modified this year (since 8d6dedb), and fixed them.