### PR TITLE
Use Kokkos::printf for Kokkos >= 4.2.00

### DIFF
--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -46,7 +46,7 @@ bool verifyCorePointsNonnegativeIndex(ExecutionSpace const &exec_space,
         bool self_is_core_point = (offset(i + 1) - offset(i) >= core_min_size);
         if (self_is_core_point && labels(i) < 0)
         {
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
           using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;
@@ -84,7 +84,7 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
 
             if (neigh_is_core_point && labels(i) != labels(j))
             {
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
               using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
               using sycl::ext::oneapi::experimental::printf;
@@ -138,7 +138,7 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
             }
           }
 
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
           using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -46,7 +46,9 @@ bool verifyCorePointsNonnegativeIndex(ExecutionSpace const &exec_space,
         bool self_is_core_point = (offset(i + 1) - offset(i) >= core_min_size);
         if (self_is_core_point && labels(i) < 0)
         {
-#ifdef __SYCL_DEVICE_ONLY__
+#if KOKKOS_VERSION >= 40199
+          using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;
 #endif
           printf("Core point is marked as noise: %d [%d]\n", i, labels(i));
@@ -82,7 +84,9 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
 
             if (neigh_is_core_point && labels(i) != labels(j))
             {
-#ifdef __SYCL_DEVICE_ONLY__
+#if KOKKOS_VERSION >= 40199
+              using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
               using sycl::ext::oneapi::experimental::printf;
 #endif
               printf("Connected cores do not belong to the same cluster: "
@@ -134,12 +138,15 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
             }
           }
 
+#if KOKKOS_VERSION >= 40199
+          using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
+          using sycl::ext::oneapi::experimental::printf;
+#endif
+
           // Border point must be connected to a core point
           if (is_border && !have_shared_core)
           {
-#ifdef __SYCL_DEVICE_ONLY__
-            using sycl::ext::oneapi::experimental::printf;
-#endif
             printf("Border point does not belong to a cluster: %d [%d]\n", i,
                    labels(i));
             update++;
@@ -147,9 +154,6 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
           // Noise points must have index -1
           if (!is_border && labels(i) != -1)
           {
-#ifdef __SYCL_DEVICE_ONLY__
-            using sycl::ext::oneapi::experimental::printf;
-#endif
             printf("Noise point does not have index -1: %d [%d]\n", i,
                    labels(i));
             update++;

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -56,7 +56,9 @@ struct PrintfCallback
   KOKKOS_FUNCTION void operator()(Predicate, int primitive,
                                   OutputFunctor const &out) const
   {
-#ifdef __SYCL_DEVICE_ONLY__
+#if KOKKOS_VERSION >= 40199
+    using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
     using sycl::ext::oneapi::experimental::printf;
 #endif
     printf("Found %d from functor\n", primitive);
@@ -95,7 +97,9 @@ int main(int argc, char *argv[])
         bvh, ExecutionSpace{}, FirstOctant{},
         KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                       auto /*output_functor*/) {
-#ifdef __SYCL_DEVICE_ONLY__
+#if KOKKOS_VERSION >= 40199
+          using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;
 #endif
           printf("Found %d from generic lambda\n", primitive);
@@ -115,7 +119,9 @@ int main(int argc, char *argv[])
         bvh, ExecutionSpace{}, NearestToOrigin{k},
         KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                       auto /*output_functor*/) {
-#ifdef __SYCL_DEVICE_ONLY__
+#if KOKKOS_VERSION >= 40199
+          using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;
 #endif
           printf("Found %d from generic lambda\n", primitive);
@@ -133,7 +139,9 @@ int main(int argc, char *argv[])
     bvh.query(
         ExecutionSpace{}, FirstOctant{},
         KOKKOS_LAMBDA(auto /*predicate*/, int j) {
-#ifdef __SYCL_DEVICE_ONLY__
+#if KOKKOS_VERSION >= 40199
+          using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;
 #endif
           printf("%d %d %d\n", ++c(), -1, j);

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -56,7 +56,7 @@ struct PrintfCallback
   KOKKOS_FUNCTION void operator()(Predicate, int primitive,
                                   OutputFunctor const &out) const
   {
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
     using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
     using sycl::ext::oneapi::experimental::printf;
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
         bvh, ExecutionSpace{}, FirstOctant{},
         KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                       auto /*output_functor*/) {
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
           using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
         bvh, ExecutionSpace{}, NearestToOrigin{k},
         KOKKOS_LAMBDA(auto /*predicate*/, int primitive,
                       auto /*output_functor*/) {
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
           using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     bvh.query(
         ExecutionSpace{}, FirstOctant{},
         KOKKOS_LAMBDA(auto /*predicate*/, int j) {
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
           using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -406,11 +406,14 @@ int main(int argc, char *argv[])
             fabs(energy_intersects(i));
         if (abs_error > rel_tol * fabs(energy_intersects(i)))
         {
-#ifndef KOKKOS_ENABLE_SYCL
+#if KOKKOS_VERSION >= 40199
+          using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
+          using sycl::ext::oneapi::experimental::printf;
+#endif
           printf("%d: %f != %f, relative error: %f\n", i,
                  energy_ordered_intersects(i), energy_intersects(i),
                  abs_error / fabs(energy_intersects(i)));
-#endif
           ++error;
         }
       },

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -406,7 +406,7 @@ int main(int argc, char *argv[])
             fabs(energy_intersects(i));
         if (abs_error > rel_tol * fabs(energy_intersects(i)))
         {
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
           using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
           using sycl::ext::oneapi::experimental::printf;

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -345,12 +345,14 @@ int main()
       KOKKOS_LAMBDA(int i, bool &update) {
         constexpr float eps = 1.e-3;
 
+#if KOKKOS_VERSION >= 40199
+        using Kokkos::printf;
+#elif defined(__SYCL_DEVICE_ONLY__)
+        using sycl::ext::oneapi::experimental::printf;
+#endif
         if (offsets(i) != i)
         {
-// FIXME_SYCL doesn't support printf
-#ifndef KOKKOS_ENABLE_SYCL
           printf("Offsets are wrong for query %d.\n", i);
-#endif
           update = false;
         }
         auto const &c = coefficients(i);
@@ -361,10 +363,7 @@ int main()
         if ((Kokkos::abs(p[0] - p_ref[0]) > eps) ||
             Kokkos::abs(p[1] - p_ref[1]) > eps)
         {
-// FIXME_SYCL doesn't support printf
-#ifndef KOKKOS_ENABLE_SYCL
           printf("Coefficients are wrong for query %d.\n", i);
-#endif
           update = false;
         }
       },

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -345,7 +345,7 @@ int main()
       KOKKOS_LAMBDA(int i, bool &update) {
         constexpr float eps = 1.e-3;
 
-#if KOKKOS_VERSION >= 40199
+#if KOKKOS_VERSION >= 40200
         using Kokkos::printf;
 #elif defined(__SYCL_DEVICE_ONLY__)
         using sycl::ext::oneapi::experimental::printf;


### PR DESCRIPTION
The header file (`impl/Kokkos_Printf.hpp`) is not public so we are relying on `Kokkos_Core.hpp` for now.
Maybe, we can promote the header before the release, see https://github.com/kokkos/kokkos/pull/6506.