### PR TITLE
Fixup one more missing `<iostream>` header include

### DIFF
--- a/benchmarks/bvh_driver/bvh_driver.cpp
+++ b/benchmarks/bvh_driver/bvh_driver.cpp
@@ -18,6 +18,7 @@
 #include <boost/program_options.hpp>
 
 #include <cstdlib>
+#include <iostream>
 
 #include "benchmark_registration.hpp"
 


### PR DESCRIPTION
Oversight in #956 
I just noticed the GCC nightly build was still broken.
Sorry about that.