### PR TITLE
Do not initialize the value we reduce to

### DIFF
--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -38,7 +38,7 @@ bool verifyCorePointsNonnegativeIndex(ExecutionSpace const &exec_space,
 {
   int n = labels.size();
 
-  int num_incorrect = 0;
+  int num_incorrect;
   Kokkos::parallel_reduce(
       "ArborX::DBSCAN::verify_core_points_nonnegative",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
@@ -68,7 +68,7 @@ bool verifyConnectedCorePointsShareIndex(ExecutionSpace const &exec_space,
 {
   int n = labels.size();
 
-  int num_incorrect = 0;
+  int num_incorrect;
   Kokkos::parallel_reduce(
       "ArborX::DBSCAN::verify_connected_core_points",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
@@ -111,7 +111,7 @@ bool verifyBorderAndNoisePoints(ExecutionSpace const &exec_space,
 {
   int n = labels.size();
 
-  int num_incorrect = 0;
+  int num_incorrect;
   Kokkos::parallel_reduce(
       "ArborX::DBSCAN::verify_connected_border_points",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -394,7 +394,7 @@ int main(int argc, char *argv[])
   // Now check that the results we got are the same apart from numerical errors
   // introduced by depositing energy to a particular cell from separate rays
   // in different order.
-  int n_errors = 0;
+  int n_errors;
   float rel_tol = 1.e-5;
   Kokkos::parallel_reduce(
       "Example::compare",

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -339,7 +339,7 @@ int main()
                                                        coefficients});
 
   // Check the results
-  bool success = true;
+  bool success;
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy<ExecutionSpace>(execution_space, 0, n),
       KOKKOS_LAMBDA(int i, bool &update) {

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -175,7 +175,7 @@ void queryImpl(ExecutionSpace const &space, Tree const &tree,
     // Detecting overflow is a local operation that needs to be done for every
     // index. We allow individual buffer sizes to differ, so it's not as easy
     // as computing max counts.
-    int overflow_int = 0;
+    int overflow_int;
     Kokkos::parallel_reduce(
         "ArborX::CrsGraphWrapper::compute_overflow",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
@@ -189,7 +189,7 @@ void queryImpl(ExecutionSpace const &space, Tree const &tree,
 
     if (!overflow)
     {
-      int n_results = 0;
+      int n_results;
       Kokkos::parallel_reduce(
           "ArborX::CrsGraphWrapper::compute_underflow",
           Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -232,7 +232,7 @@ int reorderDenseAndSparseCells(ExecutionSpace const &exec_space,
   auto const num_nonempty_cells = cell_offsets.size() - 1;
 
   // Count the number of points in the dense cells
-  int num_points_in_dense_cells = 0;
+  int num_points_in_dense_cells;
   Kokkos::parallel_reduce(
       "ArborX::DBSCAN::count_points_in_dense_cells",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, num_nonempty_cells),

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -451,7 +451,7 @@ accumulate(ExecutionSpace &&space, ViewType const &v,
   // Rather than going through the hassle of defining a custom functor for
   // the reduction, introduce here a temporary variable and add it to init
   // before returning.
-  typename ViewType::non_const_value_type tmp = 0;
+  typename ViewType::non_const_value_type tmp;
   Kokkos::RangePolicy<std::decay_t<ExecutionSpace>> policy(
       std::forward<ExecutionSpace>(space), 0, n);
   Kokkos::parallel_reduce(


### PR DESCRIPTION
(from the [comment](https://github.com/arborx/ArborX/pull/946#discussion_r1362183134))

Kokkos developers suggest not to initialize the value one reduces into because it may give the wrong impression to users, that the reduced value will be contributed to an initial value or whatnot, when Kokkos will actually ignore that value and overwrite it with the result of the reduction.