### PR TITLE
APIv2: change signature of the 3-argument callback

### DIFF
--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
@@ -96,7 +96,8 @@ static void run_fp(int nprimitives, int nqueries, int nrepeats)
 
       Kokkos::View<int *, ExecutionSpace> indices("Benchmark::indices_ref", 0);
       Kokkos::View<int *, ExecutionSpace> offset("Benchmark::offset_ref", 0);
-      bvh.query(space, predicates, indices, offset);
+      bvh.query(space, predicates, ArborX::Details::LegacyDefaultCallback{},
+                indices, offset);
 
       space.fence();
       double time = timer.seconds();
@@ -117,7 +118,8 @@ static void run_fp(int nprimitives, int nqueries, int nrepeats)
 
       Kokkos::View<int *, ExecutionSpace> indices("Benchmark::indices", 0);
       Kokkos::View<int *, ExecutionSpace> offset("Benchmark::offset", 0);
-      brute.query(space, predicates, indices, offset);
+      brute.query(space, predicates, ArborX::Details::LegacyDefaultCallback{},
+                  indices, offset);
 
       space.fence();
       double time = timer.seconds();

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -321,7 +321,8 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
 
   Kokkos::View<int *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
   Kokkos::View<int *, MemorySpace> offset("ArborX::DBSCAN::offset", 0);
-  ArborX::query(bvh, exec_space, predicates, indices, offset);
+  ArborX::query(bvh, exec_space, predicates,
+                ArborX::Details::LegacyDefaultCallback{}, indices, offset);
 
   auto passed = Details::verifyClusters(exec_space, indices, offset, labels,
                                         core_min_size);

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -123,6 +123,7 @@ public:
   void query(ExecutionSpace const &space, Predicates const &predicates,
              Callback const &callback, Ignore = Ignore()) const
   {
+    Details::check_valid_callback<int>(callback, predicates);
     base_type::query(space, predicates,
                      Details::LegacyCallbackWrapper<Callback>{callback});
   }

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -96,8 +96,8 @@ public:
     KokkosExt::ScopedProfileRegion guard("ArborX::BVH::query_crs");
 
     Details::CrsGraphWrapperImpl::
-        check_valid_callback_if_first_argument_is_not_a_view(callback_or_view,
-                                                             predicates, view);
+        check_valid_callback_if_first_argument_is_not_a_view<value_type>(
+            callback_or_view, predicates, view);
 
     using Access = AccessTraits<Predicates, PredicatesTag>;
     using Tag = typename Details::AccessTraitsHelper<Access>::tag;
@@ -146,8 +146,6 @@ class BoundingVolumeHierarchy
                                    Details::DefaultIndexableGetter, Box>;
 
 public:
-  using legacy_tree = void;
-
   using bounding_volume_type = typename base_type::bounding_volume_type;
 
   BoundingVolumeHierarchy() = default; // build an empty tree
@@ -178,15 +176,46 @@ public:
                      policy);
   }
 
-  template <typename ExecutionSpace, typename Predicates,
-            typename CallbackOrView, typename View, typename... Args>
+  template <typename ExecutionSpace, typename Predicates, typename View,
+            typename... Args>
   std::enable_if_t<Kokkos::is_view_v<std::decay_t<View>>>
-  query(ExecutionSpace const &space, Predicates const &predicates,
-        CallbackOrView &&callback_or_view, View &&view, Args &&...args) const
+  query(ExecutionSpace const &space, Predicates const &predicates, View &&view,
+        Args &&...args) const
   {
-    base_type::query(space, predicates,
-                     std::forward<CallbackOrView>(callback_or_view),
+    base_type::query(space, predicates, Details::LegacyDefaultCallback{},
                      std::forward<View>(view), std::forward<Args>(args)...);
+  }
+
+  template <typename ExecutionSpace, typename Predicates, typename Callback,
+            typename OutputView, typename OffsetView, typename... Args>
+  std::enable_if_t<!Kokkos::is_view_v<std::decay_t<Callback>>>
+  query(ExecutionSpace const &space, Predicates const &predicates,
+        Callback &&callback, OutputView &&out, OffsetView &&offset,
+        Args &&...args) const
+  {
+    if constexpr (!Details::is_tagged_post_callback<
+                      std::decay_t<Callback>>::value)
+    {
+      Details::check_valid_callback<int>(callback, predicates, out);
+      base_type::query(space, predicates,
+                       Details::LegacyCallbackWrapper<std::decay_t<Callback>>{
+                           std::forward<Callback>(callback)},
+                       std::forward<OutputView>(out),
+                       std::forward<OffsetView>(offset),
+                       std::forward<Args>(args)...);
+    }
+    else
+    {
+      KokkosExt::ScopedProfileRegion guard("ArborX::BVH::query_crs");
+
+      Kokkos::View<int *, MemorySpace> indices(
+          "ArborX::CrsGraphWrapper::query::indices", 0);
+      base_type::query(space, predicates, Details::LegacyDefaultCallback{},
+                       indices, std::forward<OffsetView>(offset),
+                       std::forward<Args>(args)...);
+      callback(predicates, std::forward<OffsetView>(offset), indices,
+               std::forward<OutputView>(out));
+    }
   }
 
   template <typename Predicate, typename Callback>

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -172,6 +172,7 @@ public:
              Experimental::TraversalPolicy const &policy =
                  Experimental::TraversalPolicy()) const
   {
+    Details::check_valid_callback<int>(callback, predicates);
     base_type::query(space, predicates,
                      Details::LegacyCallbackWrapper<Callback>{callback},
                      policy);

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -39,18 +39,18 @@ struct PostCallbackTag
 
 struct DefaultCallback
 {
-  template <typename Query, typename OutputFunctor>
-  KOKKOS_FUNCTION void operator()(Query const &, int index,
+  template <typename Query, typename Value, typename OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Query const &, Value const &value,
                                   OutputFunctor const &output) const
   {
-    output(index);
+    output(value);
   }
 };
 
 // archetypal expression for user callbacks
-template <typename Callback, typename Predicate, typename Out>
+template <typename Callback, typename Predicate, typename Value, typename Out>
 using InlineCallbackArchetypeExpression =
-    std::invoke_result_t<Callback, Predicate, int, Out>;
+    std::invoke_result_t<Callback, Predicate, Value, Out>;
 
 // legacy nearest predicate archetypal expression for user callbacks
 template <typename Callback, typename Predicate, typename Out>
@@ -88,7 +88,8 @@ void check_generic_lambda_support(Callback const &)
 #endif
 }
 
-template <typename Callback, typename Predicates, typename OutputView>
+template <typename Value, typename Callback, typename Predicates,
+          typename OutputView>
 void check_valid_callback(Callback const &callback, Predicates const &,
                           OutputView const &)
 {
@@ -106,16 +107,16 @@ void check_valid_callback(Callback const &callback, Predicates const &,
 See https://github.com/arborx/ArborX/pull/366 for more details.
 Sorry!)error");
 
-  static_assert(
-      is_valid_predicate_tag<PredicateTag>::value &&
-          Kokkos::is_detected<InlineCallbackArchetypeExpression, Callback,
-                              Predicate, OutputFunctorHelper<OutputView>>{},
-      "Callback 'operator()' does not have the correct signature");
+  static_assert(is_valid_predicate_tag<PredicateTag>::value &&
+                    Kokkos::is_detected<InlineCallbackArchetypeExpression,
+                                        Callback, Predicate, Value,
+                                        OutputFunctorHelper<OutputView>>{},
+                "Callback 'operator()' does not have the correct signature");
 
   static_assert(
-      std::is_void<
-          Kokkos::detected_t<InlineCallbackArchetypeExpression, Callback,
-                             Predicate, OutputFunctorHelper<OutputView>>>{},
+      std::is_void<Kokkos::detected_t<InlineCallbackArchetypeExpression,
+                                      Callback, Predicate, Value,
+                                      OutputFunctorHelper<OutputView>>>{},
       "Callback 'operator()' return type must be void");
 }
 

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -66,6 +66,25 @@ struct LegacyCallbackWrapper
   {
     return _callback(predicate, value.index);
   }
+
+  template <typename Predicate, typename Geometry, typename Output>
+  KOKKOS_FUNCTION auto operator()(Predicate const &predicate,
+                                  PairIndexVolume<Geometry> const &value,
+                                  Output const &out) const
+  {
+    return _callback(predicate, value.index, out);
+  }
+};
+
+struct LegacyDefaultCallback
+{
+  template <typename Query, typename Geometry, typename OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Query const &,
+                                  PairIndexVolume<Geometry> const &value,
+                                  OutputFunctor const &output) const
+  {
+    output(value.index);
+  }
 };
 
 } // namespace ArborX::Details

--- a/test/ArborXTest_LegacyTree.hpp
+++ b/test/ArborXTest_LegacyTree.hpp
@@ -27,6 +27,52 @@ public:
                                            typename Tree::bounding_volume_type>{
                  primitives})
   {}
+
+  template <typename ExecutionSpace, typename Predicates, typename Callback>
+  void query(ExecutionSpace const &space, Predicates const &predicates,
+             Callback const &callback) const
+  {
+    Tree::query(space, predicates, callback);
+  }
+
+  template <typename ExecutionSpace, typename Predicates, typename View,
+            typename... Args>
+  std::enable_if_t<Kokkos::is_view_v<std::decay_t<View>>>
+  query(ExecutionSpace const &space, Predicates const &predicates, View &&view,
+        Args &&...args) const
+  {
+    Tree::query(space, predicates, ArborX::Details::LegacyDefaultCallback{},
+                std::forward<View>(view), std::forward<Args>(args)...);
+  }
+
+  template <typename ExecutionSpace, typename Predicates, typename Callback,
+            typename OutputView, typename OffsetView, typename... Args>
+  std::enable_if_t<!Kokkos::is_view_v<std::decay_t<Callback>>>
+  query(ExecutionSpace const &space, Predicates const &predicates,
+        Callback &&callback, OutputView &&out, OffsetView &&offset,
+        Args &&...args) const
+  {
+    if constexpr (!ArborX::Details::is_tagged_post_callback<
+                      std::decay_t<Callback>>::value)
+    {
+      Tree::query(
+          space, predicates,
+          ArborX::Details::LegacyCallbackWrapper<std::decay_t<Callback>>{
+              std::forward<Callback>(callback)},
+          std::forward<OutputView>(out), std::forward<OffsetView>(offset),
+          std::forward<Args>(args)...);
+    }
+    else
+    {
+      Kokkos::View<int *, typename Tree::memory_space> indices(
+          "Testing::indices", 0);
+      Tree::query(space, predicates, ArborX::Details::LegacyDefaultCallback{},
+                  indices, std::forward<OffsetView>(offset),
+                  std::forward<Args>(args)...);
+      callback(predicates, std::forward<OffsetView>(offset), indices,
+               std::forward<OutputView>(out));
+    }
+  }
 };
 
 #endif

--- a/test/tstCompileOnlyCallbacks.cpp
+++ b/test/tstCompileOnlyCallbacks.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include <ArborX_AccessTraits.hpp>
+#include <ArborX_Box.hpp>
 #include <ArborX_Callbacks.hpp>
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
@@ -94,27 +95,27 @@ void test_callbacks_compile_only()
   // view type does not matter as long as we do not call the output functor
   Kokkos::View<float *> v;
 
-  check_valid_callback(ArborX::Details::DefaultCallback{}, SpatialPredicates{},
-                       v);
-  check_valid_callback(ArborX::Details::DefaultCallback{}, NearestPredicates{},
-                       v);
+  check_valid_callback<int>(ArborX::Details::DefaultCallback{},
+                            SpatialPredicates{}, v);
+  check_valid_callback<int>(ArborX::Details::DefaultCallback{},
+                            NearestPredicates{}, v);
 
   // not required to tag inline callbacks anymore
-  check_valid_callback(CallbackMissingTag{}, SpatialPredicates{}, v);
-  check_valid_callback(CallbackMissingTag{}, NearestPredicates{}, v);
+  check_valid_callback<int>(CallbackMissingTag{}, SpatialPredicates{}, v);
+  check_valid_callback<int>(CallbackMissingTag{}, NearestPredicates{}, v);
 
   check_valid_callback<int>(CustomCallback{}, SpatialPredicates{});
   check_valid_callback<int>(CustomCallback{}, NearestPredicates{});
 
   // generic lambdas are supported if not using NVCC
 #ifndef __NVCC__
-  check_valid_callback([](auto const & /*predicate*/, int /*primitive*/,
-                          auto const & /*out*/) {},
-                       SpatialPredicates{}, v);
+  check_valid_callback<int>([](auto const & /*predicate*/, int /*primitive*/,
+                               auto const & /*out*/) {},
+                            SpatialPredicates{}, v);
 
-  check_valid_callback([](auto const & /*predicate*/, int /*primitive*/,
-                          auto const & /*out*/) {},
-                       NearestPredicates{}, v);
+  check_valid_callback<int>([](auto const & /*predicate*/, int /*primitive*/,
+                               auto const & /*out*/) {},
+                            NearestPredicates{}, v);
 
   check_valid_callback<int>(
       [](auto const & /*predicate*/, int /*primitive*/) {},
@@ -127,10 +128,11 @@ void test_callbacks_compile_only()
 
   // Uncomment to see error messages
 
-  // check_valid_callback(LegacyNearestPredicateCallback{}, NearestPredicates{},
+  // check_valid_callback<int>(LegacyNearestPredicateCallback{},
+  // NearestPredicates{},
   //                      v);
 
-  // check_valid_callback(CallbackDoesNotTakeCorrectArgument{},
+  // check_valid_callback<int>(CallbackDoesNotTakeCorrectArgument{},
   //                      SpatialPredicates{}, v);
 
   // check_valid_callback<int>(CustomCallbackNonVoidReturnType{},


### PR DESCRIPTION
Change the signature of the callback:
```diff
-callback(Predicate const &predicate, int primitive_index, OutputFunctor &functor);
+callback(Predicate const &predicate, Value const &value, OutputFunctor &functor);
```