### PR TITLE
Cut down on the number of AccessTraits

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -209,6 +209,8 @@ public:
   Values _values;
 
   using memory_space = typename Access::memory_space;
+  using value_type = std::decay_t<
+      Kokkos::detected_t<AccessTraitsGetArchetypeExpression, Access, Values>>;
 
   KOKKOS_FUNCTION
   decltype(auto) operator()(int i) const { return Access::get(_values, i); }
@@ -218,6 +220,22 @@ public:
 };
 
 } // namespace Details
+
+template <typename Values>
+struct AccessTraits<Details::AccessValues<Values>, PrimitivesTag>
+{
+  using AccessValues = Details::AccessValues<Values>;
+
+  using memory_space = typename AccessValues::memory_space;
+
+  KOKKOS_FUNCTION static decltype(auto) get(AccessValues const &w, int i)
+  {
+    return w(i);
+  }
+
+  KOKKOS_FUNCTION
+  static decltype(auto) size(AccessValues const &w) { return w.size(); }
+};
 
 namespace Traits
 {

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -58,8 +58,6 @@ struct CountUpToN_DenseBox
   template <typename Query, typename Value>
   KOKKOS_FUNCTION auto operator()(Query const &query, Value const &value) const
   {
-    using Access = AccessTraits<Primitives, PrimitivesTag>;
-
     int const k = value.index;
     auto const i = getData(query);
 
@@ -68,14 +66,14 @@ struct CountUpToN_DenseBox
     int &count = _counts(i);
     if (is_dense_cell)
     {
-      auto const &query_point = Access::get(_primitives, i);
+      auto const &query_point = _primitives(i);
 
       int const cell_start = _dense_cell_offsets(k);
       int const cell_end = _dense_cell_offsets(k + 1);
       for (int jj = cell_start; jj < cell_end; ++jj)
       {
         int j = _permute(jj);
-        if (distance(query_point, Access::get(_primitives, j)) <= eps)
+        if (distance(query_point, _primitives(j)) <= eps)
         {
           Kokkos::atomic_increment(&count);
           if (count >= _n)
@@ -128,8 +126,6 @@ struct FDBSCANDenseBoxCallback
   template <typename Query, typename Value>
   KOKKOS_FUNCTION auto operator()(Query const &query, Value const &value) const
   {
-    using Access = AccessTraits<Primitives, PrimitivesTag>;
-
     int const k = value.index;
     auto const i = ArborX::getData(query);
 
@@ -149,7 +145,7 @@ struct FDBSCANDenseBoxCallback
           _union_find.representative(_permute(cell_start)))
         return ArborX::CallbackTreeTraversalControl::normal_continuation;
 
-      auto const &query_point = Access::get(_primitives, i);
+      auto const &query_point = _primitives(i);
 
       for (int jj = cell_start; jj < cell_end; ++jj)
       {
@@ -161,7 +157,7 @@ struct FDBSCANDenseBoxCallback
         if (_union_find.representative(i) == _union_find.representative(j))
           break;
 
-        if (distance(query_point, Access::get(_primitives, j)) <= eps)
+        if (distance(query_point, _primitives(j)) <= eps)
         {
           // We connected to at least one point in the dense box, thus we
           // connected to all of them, so may terminate
@@ -189,17 +185,15 @@ struct FDBSCANDenseBoxCallback
 };
 
 template <typename ExecutionSpace, typename Primitives>
-Kokkos::View<size_t *,
-             typename AccessTraits<Primitives, PrimitivesTag>::memory_space>
-computeCellIndices(
-    ExecutionSpace const &exec_space, Primitives const &primitives,
-    CartesianGrid<GeometryTraits::dimension_v<typename AccessTraitsHelper<
-        AccessTraits<Primitives, PrimitivesTag>>::type>> const &grid)
+Kokkos::View<size_t *, typename Primitives::memory_space>
+computeCellIndices(ExecutionSpace const &exec_space,
+                   Primitives const &primitives,
+                   CartesianGrid<GeometryTraits::dimension_v<
+                       typename Primitives::value_type>> const &grid)
 {
-  using Access = AccessTraits<Primitives, PrimitivesTag>;
-  using MemorySpace = typename Access::memory_space;
+  using MemorySpace = typename Primitives::memory_space;
 
-  auto const n = Access::size(primitives);
+  auto const n = primitives.size();
 
   Kokkos::View<size_t *, MemorySpace> cell_indices(
       Kokkos::view_alloc(exec_space, Kokkos::WithoutInitializing,
@@ -209,7 +203,7 @@ computeCellIndices(
       "ArborX::DBSCAN::compute_cell_indices",
       Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
       KOKKOS_LAMBDA(int i) {
-        auto const &xyz = Access::get(primitives, i);
+        auto const &xyz = primitives(i);
         cell_indices(i) = grid.cellIndex(xyz);
       });
   return cell_indices;

--- a/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
+++ b/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
@@ -29,8 +29,7 @@ struct MaxDistance
   Primitives _primitives;
   Distances _distances;
 
-  using Access = AccessTraits<Primitives, PrimitivesTag>;
-  using memory_space = typename Access::memory_space;
+  using memory_space = typename Primitives::memory_space;
   using size_type = typename memory_space::size_type;
 
   template <class Predicate, typename Value>
@@ -40,8 +39,7 @@ struct MaxDistance
     size_type const i = value.index;
     size_type const j = getData(predicate);
     using KokkosExt::max;
-    auto const distance_ij =
-        distance(Access::get(_primitives, i), Access::get(_primitives, j));
+    auto const distance_ij = distance(_primitives(i), _primitives(j));
     // NOTE using knowledge that each nearest predicate traversal is performed
     // by a single thread.  The distance update below would need to be atomic
     // otherwise.
@@ -61,17 +59,16 @@ struct NearestK
 template <class Primitives>
 struct AccessTraits<Details::NearestK<Primitives>, PredicatesTag>
 {
-  using Access = AccessTraits<Primitives, PrimitivesTag>;
-  using memory_space = typename Access::memory_space;
+  using memory_space = typename Primitives::memory_space;
   using size_type = typename memory_space::size_type;
   static KOKKOS_FUNCTION size_type size(Details::NearestK<Primitives> const &x)
   {
-    return Access::size(x.primitives);
+    return x.primitives.size();
   }
   static KOKKOS_FUNCTION auto get(Details::NearestK<Primitives> const &x,
                                   size_type i)
   {
-    return attach(nearest(Access::get(x.primitives, i), x.k), i);
+    return attach(nearest(x.primitives(i), x.k), i);
   }
 };
 

--- a/test/tstNeighborList.cpp
+++ b/test/tstNeighborList.cpp
@@ -62,17 +62,17 @@ struct AttachIndices
 template <class Points>
 struct ArborX::AccessTraits<Test::RadiusSearch<Points>, ArborX::PredicatesTag>
 {
-  using Access = AccessTraits<Points, PrimitivesTag>;
   using Self = Test::RadiusSearch<Points>;
-  using memory_space = typename Access::memory_space;
-  using size_type = decltype(Access::size(std::declval<Points const &>()));
+  using memory_space = typename Points::memory_space;
+  using size_type = typename Points::size_type;
   static KOKKOS_FUNCTION size_type size(Self const &x)
   {
-    return Access::size(x.points);
+    return x.points.size();
+    ;
   }
   static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
   {
-    return intersects(Sphere{Access::get(x.points, i), x.radius});
+    return intersects(Sphere{x.points(i), x.radius});
   }
 };
 


### PR DESCRIPTION
The goal is to avoid using `AccessTraits` internally in ArborX, only at the user interface functions. Motivated by #729, and in preparation for `RangeTraits` introduction.