### PR TITLE
Remove workaround for getting Boost version in CMake

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,11 +31,6 @@ endif()
 configure_file(ArborX_EnableDeviceTypes.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/ArborX_EnableDeviceTypes.hpp @ONLY)
 
 find_package(Boost 1.67.0 REQUIRED COMPONENTS unit_test_framework)
-# CMake Boost version check is tricky due to multiple changes to the way Boost
-# package stores version information
-if(NOT DEFINED Boost_VERSION_MINOR)
-  set(Boost_VERSION_MINOR ${Boost_MINOR_VERSION})
-endif()
 if(Kokkos_ENABLE_CUDA AND Boost_VERSION VERSION_GREATER 1.68 AND Boost_VERSION VERSION_LESS 1.75)
   message(WARNING "Boost versions 1.69 to 1.74 are known to yield build issues with NVCC")
 endif()


### PR DESCRIPTION
We introduced the workaround in b415d366 (#286). At the time, we used CMake 3.12 or later, which had the mix. Since then, we upgraded minimum CMake version to 3.16, which automatically includes the neccessary CMake patch (see
https://gitlab.kitware.com/cmake/cmake/-/commit/24342d5ef772b9873c0f041fb422503acc06ff50, click "Tags containing commit"). So the workaround is no longer necessary.