### PR TITLE
Change spatial traversal to fix perf regression from #897

### DIFF
--- a/src/details/ArborX_DetailsHalfTraversal.hpp
+++ b/src/details/ArborX_DetailsHalfTraversal.hpp
@@ -63,23 +63,18 @@ struct HalfTraversal
     {
       bool const is_leaf = HappyTreeFriends::isLeaf(_bvh, node);
 
-      if (is_leaf ? predicate(HappyTreeFriends::getIndexable(_bvh, node))
-                  : predicate(HappyTreeFriends::getInternalBoundingVolume(
-                        _bvh, node)))
+      if (is_leaf)
       {
-        if (is_leaf)
-        {
+        if (predicate(HappyTreeFriends::getIndexable(_bvh, node)))
           _callback(leaf_permutation_i, HappyTreeFriends::getValue(_bvh, node));
-          node = HappyTreeFriends::getRope(_bvh, node);
-        }
-        else
-        {
-          node = HappyTreeFriends::getLeftChild(_bvh, node);
-        }
+        node = HappyTreeFriends::getRope(_bvh, node);
       }
       else
       {
-        node = HappyTreeFriends::getRope(_bvh, node);
+        node =
+            (predicate(HappyTreeFriends::getInternalBoundingVolume(_bvh, node))
+                 ? HappyTreeFriends::getLeftChild(_bvh, node)
+                 : HappyTreeFriends::getRope(_bvh, node));
       }
     }
   }

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -106,25 +106,20 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
     {
       bool const is_leaf = HappyTreeFriends::isLeaf(_bvh, node);
 
-      if (is_leaf ? predicate(HappyTreeFriends::getIndexable(_bvh, node))
-                  : predicate(HappyTreeFriends::getInternalBoundingVolume(
-                        _bvh, node)))
+      if (is_leaf)
       {
-        if (is_leaf)
-        {
-          if (invoke_callback_and_check_early_exit(
-                  _callback, predicate, HappyTreeFriends::getValue(_bvh, node)))
-            return;
-          node = HappyTreeFriends::getRope(_bvh, node);
-        }
-        else
-        {
-          node = HappyTreeFriends::getLeftChild(_bvh, node);
-        }
+        if (predicate(HappyTreeFriends::getIndexable(_bvh, node)) &&
+            invoke_callback_and_check_early_exit(
+                _callback, predicate, HappyTreeFriends::getValue(_bvh, node)))
+          return;
+        node = HappyTreeFriends::getRope(_bvh, node);
       }
       else
       {
-        node = HappyTreeFriends::getRope(_bvh, node);
+        node =
+            (predicate(HappyTreeFriends::getInternalBoundingVolume(_bvh, node))
+                 ? HappyTreeFriends::getLeftChild(_bvh, node)
+                 : HappyTreeFriends::getRope(_bvh, node));
       }
     } while (node != ROPE_SENTINEL);
   }


### PR DESCRIPTION
On Saturn with the standard HACC 37M problem (eps=0.042), the traversal time goes down (compared to master (fbd25845)):

minpts = 2 (`query+cluster` timer):
FDBSCAN: 0.144 -> 0.114
FDBSCAN-DenseBox: 0.154 -> 0.126

minpts = 10
FDBSCAN
`neigh`: 0.058 -> 0.057
`query`: 0.137 -> 0.115

FDBSCAN-DenseBox
`neigh`: 0.057 -> 0.057
`query`: 0.161 -> 0.129
