### PR TITLE
Drop check_valid_geometry_traits test from evaluatePolynomialBasis

### DIFF
--- a/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -99,7 +99,6 @@ KOKKOS_FUNCTION constexpr std::size_t polynomialBasisSize()
 template <std::size_t Degree, typename Point>
 KOKKOS_FUNCTION auto evaluatePolynomialBasis(Point const &p)
 {
-  GeometryTraits::check_valid_geometry_traits(Point{});
   static_assert(GeometryTraits::is_point<Point>::value,
                 "point must be a point");
   static constexpr std::size_t DIM = GeometryTraits::dimension_v<Point>;


### PR DESCRIPTION
This should avoid some changes in https://github.com/arborx/ArborX/pull/946, like https://github.com/arborx/ArborX/pull/946/files#diff-a2fce1f8ea3d6b4f0053b59757e3a38d63072a53b10f24a2b731821423a95cb8R93. We already test
```
static_assert(GeometryTraits::is_point<Point>::value,
                "point must be a point");
```
and we use traits without further checks in other places already.