### PR TITLE
Do not bother with printing ArborX and Kokkos versions in the examples

### DIFF
--- a/examples/molecular_dynamics/example_molecular_dynamics.cpp
+++ b/examples/molecular_dynamics/example_molecular_dynamics.cpp
@@ -10,7 +10,6 @@
  ****************************************************************************/
 
 #include <ArborX.hpp>
-#include <ArborX_Version.hpp>
 
 #include <Kokkos_Random.hpp>
 

--- a/examples/molecular_dynamics/example_molecular_dynamics.cpp
+++ b/examples/molecular_dynamics/example_molecular_dynamics.cpp
@@ -57,10 +57,6 @@ int main(int argc, char *argv[])
 {
   Kokkos::ScopeGuard guard(argc, argv);
 
-  std::cout << "ArborX version    : " << ArborX::version() << std::endl;
-  std::cout << "ArborX hash       : " << ArborX::gitCommitHash() << std::endl;
-  std::cout << "Kokkos version    : " << KokkosExt::version() << std::endl;
-
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
   using MemorySpace = ExecutionSpace::memory_space;
 


### PR DESCRIPTION
Related to the discussion in https://github.com/arborx/ArborX/pull/986#issuecomment-1866563100

Printing versions is relevant in benchmarks, it does not really belong to our examples.
This will avoid the issue about `KokkosExt::version()` that is an implementation detail.