### PR TITLE
Revert "Update Kokkos to 4.2 in the SYCL build"

### DIFF
--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -109,7 +109,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     rm -rf ${SCRATCH_DIR}
 
 # Install Kokkos
-ARG KOKKOS_VERSION=4.2.00
+ARG KOKKOS_VERSION=4.1.00
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SYCL=ON -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF -DKokkos_ARCH_VOLTA70=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS=-w"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \


### PR DESCRIPTION
This reverts commit c47f38f002cc9dfa08466acdd58bd2537bc99402.

SYCL has been broken since #973. This PR is to try to make the CI pass again. We either downgrade, or figure out what's happening.