### PR TITLE
Run SYCL CI on A100

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -438,7 +438,7 @@ pipeline {
                             '''
                             sh '''
                                 . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
-                                ctest --output-on-failure
+                                ctest $CTEST_OPTIONS
                             '''
                         }
                     }

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -438,7 +438,7 @@ pipeline {
                             '''
                             sh '''
                                 . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
-                                ctest $CTEST_OPTIONS
+                                ctest --output-on-failure
                             '''
                         }
                     }

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -14,7 +14,7 @@ pipeline {
         ARBORX_DIR = '/opt/arborx'
         BENCHMARK_COLOR = 'no'
         BOOST_TEST_COLOR_OUTPUT = 'no'
-        CTEST_OPTIONS = '--timeout 180 --no-compress-output -T Test --test-output-size-passed=65536 --test-output-size-failed=1048576'
+        CTEST_OPTIONS = '--timeout 360 --no-compress-output -T Test --test-output-size-passed=65536 --test-output-size-failed=1048576'
         OMP_NUM_THREADS = 8
         OMP_PLACES = 'threads'
         OMP_PROC_BIND = 'spread'

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -407,7 +407,7 @@ pipeline {
                             filename "Dockerfile.sycl"
                             dir "docker"
                             args '-v /tmp/ccache.kokkos:/tmp/ccache'
-                            label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+                            label 'nvidia-docker && ampere'
                         }
                     }
                     steps {


### PR DESCRIPTION
Alternative to #993. We decided to also only test `Kokkos` on an A100 instead of Volta70, see https://github.com/kokkos/kokkos/pull/6270.