### PR TITLE
Fix missing tag within AttachIndices

### DIFF
--- a/src/details/ArborX_PairValueIndex.hpp
+++ b/src/details/ArborX_PairValueIndex.hpp
@@ -37,7 +37,7 @@ template <typename Values, typename Index>
 class AttachIndices
 {
 private:
-  using Data = Details::AccessValues<Values>;
+  using Data = Details::AccessValues<Values, PrimitivesTag>;
 
 public:
   Data _data;


### PR DESCRIPTION
This was an oversight. Combining #978 and #969 resulted in a problem, while each one on their own was fine.
We don't test the merged commit, just the branch one.

We only use `AttachIndices` during the construction, not traversal. Thus, we can hardcode the `PrimitivesTag`.