### PR TITLE
Optimization for moving least squares

### DIFF
--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -157,7 +157,7 @@ private:
     CoefficientsType radius = Kokkos::Experimental::epsilon_v<CoefficientsType>;
     for (int neighbor = 0; neighbor < _num_neighbors; neighbor++)
     {
-      auto const norm =
+      CoefficientsType const norm =
           ArborX::Details::distance(source_points(neighbor), SourcePoint{});
       radius = Kokkos::max(radius, norm);
     }

--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -26,13 +26,248 @@
 namespace ArborX::Interpolation::Details
 {
 
+template <typename CRBFunc, typename PolynomialDegree, typename SourcePoints,
+          typename TargetAccess, typename Coefficients, typename ExecutionSpace>
+class MovingLeastSquaresCoefficientsKernel
+{
+private:
+  using ScratchMemorySpace = typename ExecutionSpace::scratch_memory_space;
+
+  using SourcePoint = typename SourcePoints::non_const_value_type;
+  using TargetPoint = typename TargetAccess::value_type;
+
+  using CoefficientsType = typename Coefficients::non_const_value_type;
+
+  static constexpr int dimension = GeometryTraits::dimension_v<SourcePoint>;
+  static constexpr int degree = PolynomialDegree::value;
+  static constexpr int poly_size = polynomialBasisSize<dimension, degree>();
+
+  template <typename T>
+  using UnmanagedView =
+      Kokkos::View<T, ScratchMemorySpace, Kokkos::MemoryUnmanaged>;
+
+  using LocalSourcePoints = Kokkos::Subview<SourcePoints, int, Kokkos::ALL_t>;
+  using LocalPhi = UnmanagedView<CoefficientsType *>;
+  using LocalVandermonde = UnmanagedView<CoefficientsType **>;
+  using LocalMoment = UnmanagedView<CoefficientsType **>;
+  using LocalSVDDiag = UnmanagedView<CoefficientsType *>;
+  using LocalSVDUnit = UnmanagedView<CoefficientsType **>;
+  using LocalCoefficients = Kokkos::Subview<Coefficients, int, Kokkos::ALL_t>;
+
+public:
+  MovingLeastSquaresCoefficientsKernel(ExecutionSpace const &,
+                                       TargetAccess const &target_access,
+                                       SourcePoints const &source_points,
+                                       Coefficients const &coefficients)
+      : _target_access(target_access)
+      , _source_points(source_points)
+      , _coefficients(coefficients)
+      , _num_targets(target_access.size())
+      , _num_neighbors(source_points.extent_int(1))
+  {
+    // SourcePoints is a 2D view of points
+    static_assert(Kokkos::is_view_v<SourcePoints> && SourcePoints::rank == 2,
+                  "source points must be a 2D view of points");
+    static_assert(
+        KokkosExt::is_accessible_from<typename SourcePoints::memory_space,
+                                      ExecutionSpace>::value,
+        "source points must be accessible from the execution space");
+    GeometryTraits::check_valid_geometry_traits(SourcePoint{});
+    static_assert(GeometryTraits::is_point<SourcePoint>::value,
+                  "source points elements must be points");
+    static_assert(!std::is_const_v<typename SourcePoints::value_type>,
+                  "source points must be writable");
+
+    // TargetAccess is an access values of points
+    static_assert(
+        KokkosExt::is_accessible_from<typename TargetAccess::memory_space,
+                                      ExecutionSpace>::value,
+        "target access must be accessible from the execution space");
+    GeometryTraits::check_valid_geometry_traits(TargetPoint{});
+    static_assert(GeometryTraits::is_point<TargetPoint>::value,
+                  "target access elements must be points");
+    static_assert(dimension == GeometryTraits::dimension_v<TargetPoint>,
+                  "target and source points must have the same dimension");
+
+    // Coefficients is a 2D view of values
+    static_assert(Kokkos::is_view_v<Coefficients> && Coefficients::rank == 2,
+                  "coefficients points must be a 2D view of values");
+    static_assert(
+        KokkosExt::is_accessible_from<typename Coefficients::memory_space,
+                                      ExecutionSpace>::value,
+        "coefficients must be accessible from the execution space");
+    static_assert(!std::is_const_v<typename Coefficients::value_type>,
+                  "coefficients must be writable");
+
+    // The number of source groups must be correct
+    KOKKOS_ASSERT(_num_targets == source_points.extent_int(0));
+
+    // The number of coefficients must be correct
+    KOKKOS_ASSERT(_num_targets == _coefficients.extent_int(0));
+    KOKKOS_ASSERT(_num_neighbors == _coefficients.extent_int(1));
+  }
+
+  std::size_t team_shmem_size(int const team_size) const
+  {
+    std::size_t val = 0;
+    val += LocalPhi::shmem_size(_num_neighbors);
+    val += LocalVandermonde::shmem_size(_num_neighbors, poly_size);
+    val += LocalMoment::shmem_size(poly_size, poly_size);
+    val += LocalSVDDiag::shmem_size(poly_size);
+    val += LocalSVDUnit::shmem_size(poly_size, poly_size);
+    return team_size * val;
+  }
+
+  template <typename TeamMember>
+  KOKKOS_FUNCTION void operator()(TeamMember member) const
+  {
+    int const rank = member.team_rank();
+    int const size = member.team_size();
+    auto const &scratch = member.thread_scratch(0);
+
+    int target = member.league_rank() * size + rank;
+    if (target >= _num_targets)
+      return;
+
+    auto target_point = _target_access(target);
+    auto source_points = Kokkos::subview(_source_points, target, Kokkos::ALL);
+    LocalPhi phi(scratch, _num_neighbors);
+    LocalVandermonde vandermonde(scratch, _num_neighbors, poly_size);
+    LocalMoment moment(scratch, poly_size, poly_size);
+    LocalSVDDiag svd_diag(scratch, poly_size);
+    LocalSVDUnit svd_unit(scratch, poly_size, poly_size);
+    auto coefficients = Kokkos::subview(_coefficients, target, Kokkos::ALL);
+
+    // The goal is to compute the following line vector for each target point:
+    // p(x).[P^T.PHI.P]^-1.P^T.PHI
+    // Where:
+    // - p(x) is the polynomial basis of point x (line vector).
+    // - P is the multidimensional Vandermonde matrix built from the source
+    //   points, i.e., each line is the polynomial basis of a source point.
+    // - PHI is the diagonal weight matrix / CRBF evaluated at each source
+    // point.
+
+    // We first change the origin of the evaluation to be at the target point.
+    // This lets us use p(0) which is [1 0 ... 0].
+    sourceRecenteringKernel(target_point, source_points);
+
+    // This computes PHI given the source points (radius is computed inside)
+    phiKernel(source_points, phi);
+
+    // This builds the Vandermonde (P) matrix
+    vandermondeKernel(source_points, vandermonde);
+
+    // We then create what is called the moment matrix, which is P^T.PHI.P. By
+    // construction, it is symmetric.
+    momentKernel(phi, vandermonde, moment);
+
+    // We need the inverse of P^T.PHI.P, and because it is symmetric, we can use
+    // the symmetric SVD algorithm to get it.
+    symmetricPseudoInverseSVDKernel(moment, svd_diag, svd_unit);
+    // Now, the moment has [P^T.PHI.P]^-1
+
+    // Finally, the result is produced by computing p(0).[P^T.PHI.P]^-1.P^T.PHI
+    coefficientsKernel(phi, vandermonde, moment, coefficients);
+  }
+
+  Kokkos::TeamPolicy<ExecutionSpace>
+  make_policy(ExecutionSpace const &space) const
+  {
+    Kokkos::TeamPolicy<ExecutionSpace> policy(space, 1, Kokkos::AUTO);
+    int team_rec =
+        policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
+    int div = _num_targets / team_rec;
+    int mod = _num_targets % team_rec;
+    int league_rec = div + ((mod == 0) ? 0 : 1);
+    printf("Memory per block: %ld\n", team_shmem_size(team_rec));
+    return Kokkos::TeamPolicy<ExecutionSpace>(space, league_rec, team_rec);
+  }
+
+private:
+  // Recenters the source points so that the target is at the origin
+  KOKKOS_FUNCTION void
+  sourceRecenteringKernel(TargetPoint const &target_point,
+                          LocalSourcePoints &source_points) const
+  {
+    for (int neighbor = 0; neighbor < _num_neighbors; neighbor++)
+      for (int k = 0; k < dimension; k++)
+        source_points(neighbor)[k] -= target_point[k];
+  }
+
+  // Computes the weight matrix
+  KOKKOS_FUNCTION void phiKernel(LocalSourcePoints const &source_points,
+                                 LocalPhi &phi) const
+  {
+    CoefficientsType radius = Kokkos::Experimental::epsilon_v<CoefficientsType>;
+    for (int neighbor = 0; neighbor < _num_neighbors; neighbor++)
+    {
+      auto const norm =
+          ArborX::Details::distance(source_points(neighbor), SourcePoint{});
+      radius = Kokkos::max(radius, norm);
+    }
+
+    // The one at the limit would be 0 due to how CRBFs work
+    radius *= CoefficientsType(1.1);
+
+    for (int neighbor = 0; neighbor < _num_neighbors; neighbor++)
+      phi(neighbor) = CRBF::evaluate<CRBFunc>(source_points(neighbor), radius);
+  }
+
+  // Computes the vandermonde matrix
+  KOKKOS_FUNCTION void vandermondeKernel(LocalSourcePoints const &source_points,
+                                         LocalVandermonde &vandermonde) const
+  {
+    for (int neighbor = 0; neighbor < _num_neighbors; neighbor++)
+    {
+      auto basis = evaluatePolynomialBasis<degree>(source_points(neighbor));
+      for (int k = 0; k < poly_size; k++)
+        vandermonde(neighbor, k) = basis[k];
+    }
+  }
+
+  // Computes the moment matrix
+  KOKKOS_FUNCTION void momentKernel(LocalPhi const &phi,
+                                    LocalVandermonde const &vandermonde,
+                                    LocalMoment &moment) const
+  {
+    for (int i = 0; i < poly_size; i++)
+      for (int j = 0; j < poly_size; j++)
+      {
+        moment(i, j) = 0;
+        for (int neighbor = 0; neighbor < _num_neighbors; neighbor++)
+          moment(i, j) += vandermonde(neighbor, i) * vandermonde(neighbor, j) *
+                          phi(neighbor);
+      }
+  }
+
+  // Computes the coefficients
+  KOKKOS_FUNCTION void coefficientsKernel(LocalPhi const &phi,
+                                          LocalVandermonde const &vandermonde,
+                                          LocalMoment const &moment,
+                                          LocalCoefficients &coefficients) const
+  {
+    for (int neighbor = 0; neighbor < _num_neighbors; neighbor++)
+    {
+      coefficients(neighbor) = 0;
+      for (int i = 0; i < poly_size; i++)
+        coefficients(neighbor) +=
+            moment(0, i) * vandermonde(neighbor, i) * phi(neighbor);
+    }
+  }
+
+  TargetAccess _target_access;
+  SourcePoints _source_points;
+  Coefficients _coefficients;
+  int _num_targets;
+  int _num_neighbors;
+};
+
 template <typename CRBFunc, typename PolynomialDegree,
           typename CoefficientsType, typename ExecutionSpace,
           typename SourcePoints, typename TargetAccess>
-Kokkos::View<CoefficientsType **, typename SourcePoints::memory_space>
-movingLeastSquaresCoefficients(ExecutionSpace const &space,
-                               SourcePoints const &source_points,
-                               TargetAccess const &target_access)
+auto movingLeastSquaresCoefficients(ExecutionSpace const &space,
+                                    SourcePoints const &source_points,
+                                    TargetAccess const &target_access)
 {
   auto guard =
       Kokkos::Profiling::ScopedRegion("ArborX::MovingLeastSquaresCoefficients");
@@ -40,196 +275,21 @@ movingLeastSquaresCoefficients(ExecutionSpace const &space,
   namespace KokkosExt = ::ArborX::Details::KokkosExt;
 
   using MemorySpace = typename SourcePoints::memory_space;
-  static_assert(
-      KokkosExt::is_accessible_from<MemorySpace, ExecutionSpace>::value,
-      "Memory space must be accessible from the execution space");
-
-  // SourcePoints is a 2D view of points
-  static_assert(Kokkos::is_view_v<SourcePoints> && SourcePoints::rank == 2,
-                "source points must be a 2D view of points");
-  static_assert(
-      KokkosExt::is_accessible_from<typename SourcePoints::memory_space,
-                                    ExecutionSpace>::value,
-      "source points must be accessible from the execution space");
-  using SourcePoint = typename SourcePoints::non_const_value_type;
-  GeometryTraits::check_valid_geometry_traits(SourcePoint{});
-  static_assert(GeometryTraits::is_point<SourcePoint>::value,
-                "source points elements must be points");
-  static constexpr int dimension = GeometryTraits::dimension_v<SourcePoint>;
-
-  // TargetAccess is an access values of points
-  static_assert(
-      KokkosExt::is_accessible_from<typename TargetAccess::memory_space,
-                                    ExecutionSpace>::value,
-      "target access must be accessible from the execution space");
-  using TargetPoint = typename TargetAccess::value_type;
-  GeometryTraits::check_valid_geometry_traits(TargetPoint{});
-  static_assert(GeometryTraits::is_point<TargetPoint>::value,
-                "target access elements must be points");
-  static_assert(dimension == GeometryTraits::dimension_v<TargetPoint>,
-                "target and source points must have the same dimension");
-
-  int const num_targets = target_access.size();
-  int const num_neighbors = source_points.extent(1);
-
-  // There must be a set of neighbors for each target
-  KOKKOS_ASSERT(num_targets == source_points.extent_int(0));
-
-  using Point = ExperimentalHyperGeometry::Point<dimension, CoefficientsType>;
-  static constexpr auto epsilon =
-      Kokkos::Experimental::epsilon_v<CoefficientsType>;
-  static constexpr int degree = PolynomialDegree::value;
-  static constexpr int poly_size = polynomialBasisSize<dimension, degree>();
-
-  Kokkos::Profiling::pushRegion(
-      "ArborX::MovingLeastSquaresCoefficients::source_ref_target_fill");
-
-  // The goal is to compute the following line vector for each target point:
-  // p(x).[P^T.PHI.P]^-1.P^T.PHI
-  // Where:
-  // - p(x) is the polynomial basis of point x (line vector).
-  // - P is the multidimensional Vandermonde matrix built from the source
-  //   points, i.e., each line is the polynomial basis of a source point.
-  // - PHI is the diagonal weight matrix / CRBF evaluated at each source point.
-
-  // We first change the origin of the evaluation to be at the target point.
-  // This lets us use p(0) which is [1 0 ... 0].
-  Kokkos::View<Point **, MemorySpace> source_ref_target(
-      Kokkos::view_alloc(
-          space, Kokkos::WithoutInitializing,
-          "ArborX::MovingLeastSquaresCoefficients::source_ref_target"),
-      num_targets, num_neighbors);
-  Kokkos::parallel_for(
-      "ArborX::MovingLeastSquaresCoefficients::source_ref_target_fill",
-      Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>(
-          space, {0, 0}, {num_targets, num_neighbors}),
-      KOKKOS_LAMBDA(int const i, int const j) {
-        auto src = source_points(i, j);
-        auto tgt = target_access(i);
-        Point t{};
-
-        for (int k = 0; k < dimension; k++)
-          t[k] = src[k] - tgt[k];
-
-        source_ref_target(i, j) = t;
-      });
-
-  Kokkos::Profiling::popRegion();
-  Kokkos::Profiling::pushRegion(
-      "ArborX::MovingLeastSquaresCoefficients::radii_computation");
-
-  // We then compute the radius for each target that will be used in evaluating
-  // the weight for each source point.
-  Kokkos::View<CoefficientsType *, MemorySpace> radii(
-      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
-                         "ArborX::MovingLeastSquaresCoefficients::radii"),
-      num_targets);
-  Kokkos::parallel_for(
-      "ArborX::MovingLeastSquaresCoefficients::radii_computation",
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, num_targets),
-      KOKKOS_LAMBDA(int const i) {
-        CoefficientsType radius = epsilon;
-
-        for (int j = 0; j < num_neighbors; j++)
-        {
-          CoefficientsType norm =
-              ArborX::Details::distance(source_ref_target(i, j), Point{});
-          radius = Kokkos::max(radius, norm);
-        }
-
-        // The one at the limit would be valued at 0 due to how CRBFs work
-        radii(i) = 1.1 * radius;
-      });
-
-  Kokkos::Profiling::popRegion();
-  Kokkos::Profiling::pushRegion(
-      "ArborX::MovingLeastSquaresCoefficients::phi_computation");
-
-  // This computes PHI given the source points as well as the radius
-  Kokkos::View<CoefficientsType **, MemorySpace> phi(
-      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
-                         "ArborX::MovingLeastSquaresCoefficients::phi"),
-      num_targets, num_neighbors);
-  Kokkos::parallel_for(
-      "ArborX::MovingLeastSquaresCoefficients::phi_computation",
-      Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>(
-          space, {0, 0}, {num_targets, num_neighbors}),
-      KOKKOS_LAMBDA(int const i, int const j) {
-        phi(i, j) = CRBF::evaluate<CRBFunc>(source_ref_target(i, j), radii(i));
-      });
-
-  Kokkos::Profiling::popRegion();
-  Kokkos::Profiling::pushRegion(
-      "ArborX::MovingLeastSquaresCoefficients::vandermonde");
-
-  // This builds the Vandermonde (P) matrix
-  Kokkos::View<CoefficientsType ***, MemorySpace> p(
-      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
-                         "ArborX::MovingLeastSquaresCoefficients::vandermonde"),
-      num_targets, num_neighbors, poly_size);
-  Kokkos::parallel_for(
-      "ArborX::MovingLeastSquaresCoefficients::vandermonde_computation",
-      Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>(
-          space, {0, 0}, {num_targets, num_neighbors}),
-      KOKKOS_LAMBDA(int const i, int const j) {
-        auto basis = evaluatePolynomialBasis<degree>(source_ref_target(i, j));
-        for (int k = 0; k < poly_size; k++)
-          p(i, j, k) = basis[k];
-      });
-
-  Kokkos::Profiling::popRegion();
-  Kokkos::Profiling::pushRegion(
-      "ArborX::MovingLeastSquaresCoefficients::moment");
-
-  // We then create what is called the moment matrix, which is A = P^T.PHI.P. By
-  // construction, A is symmetric.
-  Kokkos::View<CoefficientsType ***, MemorySpace> a(
-      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
-                         "ArborX::MovingLeastSquaresCoefficients::moment"),
-      num_targets, poly_size, poly_size);
-  Kokkos::parallel_for(
-      "ArborX::MovingLeastSquaresCoefficients::moment_computation",
-      Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<3>>(
-          space, {0, 0, 0}, {num_targets, poly_size, poly_size}),
-      KOKKOS_LAMBDA(int const i, int const j, int const k) {
-        CoefficientsType tmp = 0;
-        for (int l = 0; l < num_neighbors; l++)
-          tmp += p(i, l, j) * p(i, l, k) * phi(i, l);
-        a(i, j, k) = tmp;
-      });
-
-  Kokkos::Profiling::popRegion();
-  Kokkos::Profiling::pushRegion(
-      "ArborX::MovingLeastSquaresCoefficients::pseudo_inverse_svd");
-
-  // We need the inverse of A = P^T.PHI.P, and because A is symmetric, we can
-  // use the symmetric SVD algorithm to get it.
-  symmetricPseudoInverseSVD(space, a);
-  // Now, A = [P^T.PHI.P]^-1
-
-  Kokkos::Profiling::popRegion();
-  Kokkos::Profiling::pushRegion(
-      "ArborX::MovingLeastSquaresCoefficients::coefficients_computation");
-
-  // Finally, the result is produced by computing p(0).A.P^T.PHI
-  Kokkos::View<CoefficientsType **, MemorySpace> coeffs(
+  Kokkos::View<CoefficientsType **, MemorySpace> coefficients(
       Kokkos::view_alloc(
           space, Kokkos::WithoutInitializing,
           "ArborX::MovingLeastSquaresCoefficients::coefficients"),
-      num_targets, num_neighbors);
-  Kokkos::parallel_for(
-      "ArborX::MovingLeastSquaresCoefficients::coefficients_computation",
-      Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>(
-          space, {0, 0}, {num_targets, num_neighbors}),
-      KOKKOS_LAMBDA(int const i, int const j) {
-        CoefficientsType tmp = 0;
-        for (int k = 0; k < poly_size; k++)
-          tmp += a(i, 0, k) * p(i, j, k) * phi(i, j);
-        coeffs(i, j) = tmp;
-      });
+      source_points.extent_int(0), source_points.extent_int(1));
 
-  Kokkos::Profiling::popRegion();
-  return coeffs;
+  MovingLeastSquaresCoefficientsKernel<CRBFunc, PolynomialDegree, SourcePoints,
+                                       TargetAccess, decltype(coefficients),
+                                       ExecutionSpace>
+      kernel(space, target_access, source_points, coefficients);
+
+  Kokkos::parallel_for("ArborX::MovingLeastSquaresCoefficients::kernel",
+                       kernel.make_policy(space), kernel);
+
+  return coefficients;
 }
 
 } // namespace ArborX::Interpolation::Details

--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -124,9 +124,17 @@ public:
     dummy_policy.set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
     int team_size =
         dummy_policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
-    int league_size = (_num_targets + team_size - 1) / team_size;
-    return Kokkos::TeamPolicy<ExecutionSpace>(space, league_size, team_size)
-        .set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
+    if (team_size != 0)
+    {
+      int league_size = (_num_targets + team_size - 1) / team_size;
+      return Kokkos::TeamPolicy<ExecutionSpace>(space, league_size, team_size)
+          .set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
+    }
+    else
+    {
+      return Kokkos::TeamPolicy<ExecutionSpace>(space, _num_targets, 1, 1)
+          .set_scratch_size(0, Kokkos::PerTeam(perTargetMem()));
+    }
   }
 
 private:

--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -265,8 +265,7 @@ auto movingLeastSquaresCoefficients(ExecutionSpace const &space,
                 "target and source points must have the same dimension");
 
   // The number of source groups must be correct
-  KOKKOS_ASSERT(TargetAccess{target_points}.size() ==
-                source_points.extent_int(0));
+  KOKKOS_ASSERT(target_access.size() == source_points.extent_int(0));
 
   Kokkos::View<CoefficientsType **, MemorySpace> coefficients(
       Kokkos::view_alloc(

--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -135,10 +135,9 @@ public:
     Kokkos::TeamPolicy<ExecutionSpace> policy(space, 1, Kokkos::AUTO);
     int team_rec =
         policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
-    int div = _num_targets / team_rec;
     int mod = _num_targets % team_rec;
+    int div = (_num_targets - mod) / team_rec;
     int league_rec = div + ((mod == 0) ? 0 : 1);
-    printf("Memory per block: %ld\n", team_shmem_size(team_rec));
     return Kokkos::TeamPolicy<ExecutionSpace>(space, league_rec, team_rec);
   }
 

--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -49,10 +49,10 @@ private:
 
   using LocalSourcePoints = Kokkos::Subview<SourcePoints, int, Kokkos::ALL_t>;
   using LocalPhi = ScratchView<CoefficientsType *>;
-  using LocalVandermonde = ScratchView<CoefficientsType **>;
-  using LocalMoment = ScratchView<CoefficientsType **>;
-  using LocalSVDDiag = ScratchView<CoefficientsType *>;
-  using LocalSVDUnit = ScratchView<CoefficientsType **>;
+  using LocalVandermonde = ScratchView<CoefficientsType *[poly_size]>;
+  using LocalMoment = ScratchView<CoefficientsType[poly_size][poly_size]>;
+  using LocalSVDDiag = ScratchView<CoefficientsType[poly_size]>;
+  using LocalSVDUnit = ScratchView<CoefficientsType[poly_size][poly_size]>;
   using LocalCoefficients = Kokkos::Subview<Coefficients, int, Kokkos::ALL_t>;
 
 public:
@@ -79,10 +79,10 @@ public:
     auto target_point = _target_access(target);
     auto source_points = Kokkos::subview(_source_points, target, Kokkos::ALL);
     LocalPhi phi(scratch, _num_neighbors);
-    LocalVandermonde vandermonde(scratch, _num_neighbors, poly_size);
-    LocalMoment moment(scratch, poly_size, poly_size);
-    LocalSVDDiag svd_diag(scratch, poly_size);
-    LocalSVDUnit svd_unit(scratch, poly_size, poly_size);
+    LocalVandermonde vandermonde(scratch, _num_neighbors);
+    LocalMoment moment(scratch);
+    LocalSVDDiag svd_diag(scratch);
+    LocalSVDUnit svd_unit(scratch);
     auto coefficients = Kokkos::subview(_coefficients, target, Kokkos::ALL);
 
     // The goal is to compute the following line vector for each target point:
@@ -134,10 +134,10 @@ private:
   {
     std::size_t val = 0;
     val += LocalPhi::shmem_size(_num_neighbors);
-    val += LocalVandermonde::shmem_size(_num_neighbors, poly_size);
-    val += LocalMoment::shmem_size(poly_size, poly_size);
-    val += LocalSVDDiag::shmem_size(poly_size);
-    val += LocalSVDUnit::shmem_size(poly_size, poly_size);
+    val += LocalVandermonde::shmem_size(_num_neighbors);
+    val += LocalMoment::shmem_size();
+    val += LocalSVDDiag::shmem_size();
+    val += LocalSVDUnit::shmem_size();
     return val;
   }
 


### PR DESCRIPTION
This PR modifies the SVD pseudo-inverse and the coefficients computation, its main goal was to reduce the amount of global memory used, use scratch memory and compound the kernels.