### PR TITLE
Drop `Details::AccessTraitsHelper`

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -102,19 +102,6 @@ using AccessTraitsGetArchetypeExpression =
 template <typename P>
 using PredicateTagArchetypeAlias = typename P::Tag;
 
-template <typename Access>
-struct AccessTraitsHelper;
-
-template <typename X, typename Tag>
-struct AccessTraitsHelper<AccessTraits<X, Tag>>
-{
-  // Deduce return type of get()
-  using type =
-      std::decay_t<Kokkos::detected_t<AccessTraitsGetArchetypeExpression,
-                                      AccessTraits<X, Tag>, X>>;
-  using tag = Kokkos::detected_t<PredicateTagArchetypeAlias, type>;
-};
-
 template <typename Predicates>
 void check_valid_access_traits(PredicatesTag, Predicates const &)
 {
@@ -148,7 +135,10 @@ void check_valid_access_traits(PredicatesTag, Predicates const &)
       "AccessTraits<Predicates,PredicatesTag> must define 'get()' static "
       "member function");
 
-  using Tag = typename AccessTraitsHelper<Access>::tag;
+  using Predicate =
+      std::decay_t<Kokkos::detected_t<AccessTraitsGetArchetypeExpression,
+                                      Access, Predicates>>;
+  using Tag = Kokkos::detected_t<PredicateTagArchetypeAlias, Predicate>;
   static_assert(is_valid_predicate_tag<Tag>::value,
                 "Invalid tag for the predicates");
 }

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -85,9 +85,9 @@ void check_valid_callback(Callback const &callback, Predicates const &,
 {
   check_generic_lambda_support(callback);
 
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-  using PredicateTag = typename AccessTraitsHelper<Access>::tag;
-  using Predicate = typename AccessTraitsHelper<Access>::type;
+  using Predicate =
+      typename AccessValues<Predicates, PredicatesTag>::value_type;
+  using PredicateTag = typename Predicate::Tag;
 
   static_assert(!(std::is_same_v<PredicateTag, NearestPredicateTag> &&
                   std::is_invocable_v<Callback const &, Predicate, int, float,
@@ -137,9 +137,9 @@ void check_valid_callback(Callback const &callback, Predicates const &)
 {
   check_generic_lambda_support(callback);
 
-  using Access = AccessTraits<Predicates, PredicatesTag>;
-  using PredicateTag = typename AccessTraitsHelper<Access>::tag;
-  using Predicate = typename AccessTraitsHelper<Access>::type;
+  using Predicate =
+      typename AccessValues<Predicates, PredicatesTag>::value_type;
+  using PredicateTag = typename Predicate::Tag;
 
   static_assert(is_valid_predicate_tag<PredicateTag>::value,
                 "The predicate tag is not valid");

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -39,8 +39,8 @@ public:
   KOKKOS_FUNCTION
   auto operator()(size_type i) const
   {
-    if constexpr (std::is_same_v<BoundingVolume,
-                                 typename AccessTraitsHelper<Access>::type>)
+    using Primitive = std::decay_t<decltype(Access::get(_primitives, i))>;
+    if constexpr (std::is_same_v<BoundingVolume, Primitive>)
     {
       return value_type{Access::get(_primitives, i), (index_type)i};
     }


### PR DESCRIPTION
Rational: we introduced `AccessValues` (still not liking that name) which adapts the user input and effectively we have duplicated facility.  The new intended way should be to assume an adapted user input that provides dependent types.  This PR purges the old facility.