### PR TITLE
Add KOKKOS_FUNCTION macro to Details::Sink::operator()

### DIFF
--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -61,7 +61,7 @@ struct is_tagged_post_callback
 template <typename T>
 struct Sink
 {
-  void operator()(T const &) const {}
+  KOKKOS_FUNCTION void operator()(T const &) const {}
 };
 
 template <typename OutputView>


### PR DESCRIPTION
While compiling ArborX for cuda, I had this warning:
```
warning #20014-D: calling a __host__ function from a __host__ __device__ function is not allowed
        out(i);
        ^
          detected during:
            instantiation of "void ExcludeSelfCollision::operator()(const Predicate &, int, const OutputFunctor &) const [with Predicate=ArborX::PredicateWithAttachment<ArborX::Intersects<ArborX::Sphere>, int>, OutputFunctor=ArborX::Details::Sink<int>]" at line 3261 of /usr/include/c++/11/type_traits
```
This small change got rid of that. 

The `ExcludeSelfCollision` callback is defined as:
```
struct ExcludeSelfCollision
{
  template <class Predicate, class OutputFunctor>
  KOKKOS_FUNCTION void operator()(Predicate const &predicate, int i,
                                  OutputFunctor const &out) const
  {
    int const j = ArborX::getData(predicate);
    if (i != j)
    {
      out(i);
    }
  }
};
```

