### PR TITLE
Fix clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard,-modernize-concat-nested-namespaces,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-function-cognitive-complexity'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard,-modernize-concat-nested-namespaces,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-function-cognitive-complexity,-readability-redundant-string-cstr'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package(Boost 1.56.0 REQUIRED COMPONENTS program_options)
 
+# FIXME: when we start requiring benchmark >= 1.8.0, reenable
+# "readability-redundant-string-cstr" check in .clang-tidy
 find_package(benchmark 1.5.4 REQUIRED)
 message(STATUS "Found benchmark: ${benchmark_DIR} (version \"${benchmark_VERSION}\")")
 

--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -130,11 +130,8 @@ public:
       return Kokkos::TeamPolicy<ExecutionSpace>(space, league_size, team_size)
           .set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
     }
-    else
-    {
-      return Kokkos::TeamPolicy<ExecutionSpace>(space, _num_targets, 1, 1)
-          .set_scratch_size(0, Kokkos::PerTeam(perTargetMem()));
-    }
+    return Kokkos::TeamPolicy<ExecutionSpace>(space, _num_targets, 1, 1)
+        .set_scratch_size(0, Kokkos::PerTeam(perTargetMem()));
   }
 
 private:


### PR DESCRIPTION
I think after redoing CI, we are no longer able to see clang-tidy warnings (possibly, warnings at all). This PR fixes one of the recent ones that creeped in, together with a more outstanding one.