### PR TITLE
Add a check for overflow of `n_results` variable in CrsGraphWrapperImpl::queryImpl function

### DIFF
--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -210,6 +210,13 @@ void queryImpl(ExecutionSpace const &space, Tree const &tree,
 
   int const n_results = KokkosExt::lastElement(space, offset);
 
+  if(n_results < 0){
+    // overflow
+    throw std::runtime_error("The search resulted in too many neighbor pairs. "
+                             "Please ensure the primitive positions are not "
+                             "in a degenerate state.");
+  }
+
   Kokkos::Profiling::popRegion();
 
   if (n_results == 0)


### PR DESCRIPTION
Due to a failure in initialization, I had a bug where I generated too many neighbor pairs. I think this can happen anytime there are too many primitives in a small place (leading to N^2 pairs). 

This check might help a future user to quickly track down this sort of bugs.

Please feel free to edit the error message.

(I wonder if this is something kokkos should try to catch).