### PR TITLE
Explicitly include `<ArborX_DetailsUtils.hpp>` from `<ArborX.hpp>`

### DIFF
--- a/src/ArborX.hpp
+++ b/src/ArborX.hpp
@@ -24,8 +24,10 @@
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Sphere.hpp>
-// for backward compatiblity for those using the now deprecated algorithms min
-// or max that used to namespace ArborX
+// FIXME: we include ArborX_DetailsUtils.hpp only for backward compatibility for
+// users using deprecated functions in ArborX namespace (min, max,
+// adjacentDifference, ...). This header should be removed when we remove those
+// functions.
 #include <ArborX_DetailsUtils.hpp>
 
 #endif

--- a/src/ArborX.hpp
+++ b/src/ArborX.hpp
@@ -24,5 +24,8 @@
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Sphere.hpp>
+// for backward compatiblity for those using the now deprecated algorithms min
+// or max that used to namespace ArborX
+#include <ArborX_DetailsUtils.hpp>
 
 #endif


### PR DESCRIPTION
Rational: backward compatibility

Andrey did too good of a job at cleaning up unnecessary header includes and this led to the current situation where `<ArborX_DetailsUtils.hpp>` is not included in the `<ArborX.hpp>` header when MPI is not enabled which broke Cabana.
