### PR TITLE
Switch top tree in DistributedTree to new API and do some cleanup

### DIFF
--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -62,21 +62,21 @@ struct DistributedTreeImpl
                 IndicesAndRanks &values, Offset &offset);
 
   // nearest neighbors helpers
-  template <typename DistributedTree, typename ExecutionSpace,
-            typename Predicates, typename Indices, typename Offset,
-            typename Distances>
+  template <typename ExecutionSpace, typename DistributedTree,
+            typename Predicates, typename Distances, typename Indices,
+            typename Offset>
   static void deviseStrategy(ExecutionSpace const &space,
-                             Predicates const &queries,
-                             DistributedTree const &tree, Indices &indices,
-                             Offset &offset, Distances &);
+                             DistributedTree const &tree,
+                             Predicates const &queries, Distances const &,
+                             Indices &indices, Offset &offset);
 
-  template <typename DistributedTree, typename ExecutionSpace,
-            typename Predicates, typename Indices, typename Offset,
-            typename Distances>
-  static void reassessStrategy(ExecutionSpace const &space,
-                               Predicates const &queries,
-                               DistributedTree const &tree, Indices &indices,
-                               Offset &offset, Distances &distances);
+  template <typename ExecutionSpace, typename DistributedTree,
+            typename Predicates, typename Distances, typename Indices,
+            typename Offset>
+  static void
+  reassessStrategy(ExecutionSpace const &space, DistributedTree const &tree,
+                   Predicates const &queries, Distances const &distances,
+                   Indices &indices, Offset &offset);
 };
 
 } // namespace ArborX::Details

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -19,6 +19,7 @@
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
 #include <ArborX_DetailsKokkosExtStdAlgorithms.hpp>
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
+#include <ArborX_DetailsLegacy.hpp>
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
@@ -164,15 +165,16 @@ struct CallbackWithDistance
   }
 };
 
-template <typename Tree, typename ExecutionSpace, typename Predicates,
-          typename Indices, typename Offset, typename Distances>
+template <typename ExecutionSpace, typename Tree, typename Predicates,
+          typename Distances, typename Indices, typename Offset>
 void DistributedTreeImpl::deviseStrategy(ExecutionSpace const &space,
-                                         Predicates const &queries,
-                                         Tree const &tree, Indices &indices,
-                                         Offset &offset, Distances &)
+                                         Tree const &tree,
+                                         Predicates const &predicates,
+                                         Distances const &,
+                                         Indices &nearest_ranks, Offset &offset)
 {
   Kokkos::Profiling::ScopedRegion guard(
-      "ArborX::DistributedTree::deviseStrategy");
+      "ArborX::DistributedTree::query::nearest::deviseStrategy");
 
   using namespace DistributedTree;
   using MemorySpace = typename Tree::memory_space;
@@ -181,25 +183,26 @@ void DistributedTreeImpl::deviseStrategy(ExecutionSpace const &space,
   auto const &bottom_tree_sizes = tree._bottom_tree_sizes;
 
   // Find the k nearest local trees.
-  query(top_tree, space, queries, indices, offset);
+  query(top_tree, space, predicates, LegacyDefaultCallback{}, nearest_ranks,
+        offset);
 
   // Accumulate total leave count in the local trees until it reaches k which
   // is the number of neighbors queried for.  Stop if local trees get
   // empty because it means that they are no more leaves and there is no point
-  // on forwarding queries to leafless trees.
-  auto const n_queries = queries.size();
+  // on forwarding predicates to leafless trees.
+  auto const n_predicates = predicates.size();
   Kokkos::View<int *, MemorySpace> new_offset(
-      Kokkos::view_alloc(space, offset.label()), n_queries + 1);
+      Kokkos::view_alloc(space, offset.label()), n_predicates + 1);
   Kokkos::parallel_for(
-      "ArborX::DistributedTree::query::"
+      "ArborX::DistributedTree::query::nearest::"
       "bottom_trees_with_required_cumulated_leaves_count",
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_predicates),
       KOKKOS_LAMBDA(int i) {
         int leaves_count = 0;
-        int const n_nearest_neighbors = getK(queries(i));
+        int const n_nearest_neighbors = getK(predicates(i));
         for (int j = offset(i); j < offset(i + 1); ++j)
         {
-          int const bottom_tree_size = bottom_tree_sizes(indices(j));
+          int const bottom_tree_size = bottom_tree_sizes(nearest_ranks(j));
           if ((bottom_tree_size == 0) || (leaves_count >= n_nearest_neighbors))
             break;
           leaves_count += bottom_tree_size;
@@ -209,32 +212,31 @@ void DistributedTreeImpl::deviseStrategy(ExecutionSpace const &space,
 
   KokkosExt::exclusive_scan(space, new_offset, new_offset, 0);
 
-  // Truncate results so that queries will only be forwarded to as many local
+  // Truncate results so that predicates will only be forwarded to as many local
   // trees as necessary to find k neighbors.
-  Kokkos::View<int *, MemorySpace> new_indices(
-      Kokkos::view_alloc(space, indices.label()),
+  Kokkos::View<int *, MemorySpace> new_nearest_ranks(
+      Kokkos::view_alloc(space, nearest_ranks.label()),
       KokkosExt::lastElement(space, new_offset));
   Kokkos::parallel_for(
-      "ArborX::DistributedTree::query::truncate_before_forwarding",
-      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
+      "ArborX::DistributedTree::query::nearest::truncate_before_forwarding",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_predicates),
       KOKKOS_LAMBDA(int i) {
         for (int j = 0; j < new_offset(i + 1) - new_offset(i); ++j)
-          new_indices(new_offset(i) + j) = indices(offset(i) + j);
+          new_nearest_ranks(new_offset(i) + j) = nearest_ranks(offset(i) + j);
       });
 
   offset = new_offset;
-  indices = new_indices;
+  nearest_ranks = new_nearest_ranks;
 }
 
-template <typename Tree, typename ExecutionSpace, typename Predicates,
-          typename Indices, typename Offset, typename Distances>
-void DistributedTreeImpl::reassessStrategy(ExecutionSpace const &space,
-                                           Predicates const &queries,
-                                           Tree const &tree, Indices &indices,
-                                           Offset &offset, Distances &distances)
+template <typename ExecutionSpace, typename Tree, typename Predicates,
+          typename Distances, typename Indices, typename Offset>
+void DistributedTreeImpl::reassessStrategy(
+    ExecutionSpace const &space, Tree const &tree, Predicates const &queries,
+    Distances const &distances, Indices &nearest_ranks, Offset &offset)
 {
   Kokkos::Profiling::ScopedRegion guard(
-      "ArborX::DistributedTree::reassessStrategy");
+      "ArborX::DistributedTree::query::nearest::reassessStrategy");
 
   using namespace DistributedTree;
   using MemorySpace = typename Tree::memory_space;
@@ -244,14 +246,14 @@ void DistributedTreeImpl::reassessStrategy(ExecutionSpace const &space,
 
   // Determine distance to the farthest neighbor found so far.
   Kokkos::View<float *, MemorySpace> farthest_distances(
-      Kokkos::view_alloc(
-          space, Kokkos::WithoutInitializing,
-          "ArborX::DistributedTree::query::reassessStrategy::distances"),
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                         "ArborX::DistributedTree::query::nearest::"
+                         "reassessStrategy::distances"),
       n_queries);
   // NOTE: in principle distances( j ) are arranged in ascending order for
   // offset( i ) <= j < offset( i + 1 ) so max() is not necessary.
   Kokkos::parallel_for(
-      "ArborX::DistributedTree::query::most_distant_neighbor_so_far",
+      "ArborX::DistributedTree::query::nearest::most_distant_neighbor_so_far",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
       KOKKOS_LAMBDA(int i) {
         using KokkosExt::max;
@@ -268,7 +270,7 @@ void DistributedTreeImpl::reassessStrategy(ExecutionSpace const &space,
   query(top_tree, space,
         WithinDistanceFromPredicates<Predicates, decltype(farthest_distances)>{
             queries, farthest_distances},
-        indices, offset);
+        LegacyDefaultCallback{}, nearest_ranks, offset);
   // NOTE: in principle, we could perform radius searches on the bottom_tree
   // rather than nearest queries.
 }
@@ -310,14 +312,18 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
   CallbackWithDistance<ArborX::BVH<MemorySpace>> callback_with_distance(
       space, bottom_tree);
 
+  Kokkos::View<int *, MemorySpace> nearest_ranks(
+      "ArborX::DistributedTree::query::nearest::nearest_ranks", 0);
+
   // NOTE: compiler would not deduce __range for the braced-init-list, but I
   // got it to work with the static_cast to function pointers.
-  using Strategy = void (*)(ExecutionSpace const &, Predicates const &,
-                            Tree const &, Indices &, Offset &, Distances &);
+  using Strategy =
+      void (*)(ExecutionSpace const &, Tree const &, Predicates const &,
+               Distances const &, decltype(nearest_ranks) &, Offset &);
   for (auto implementStrategy : {static_cast<Strategy>(deviseStrategy),
                                  static_cast<Strategy>(reassessStrategy)})
   {
-    implementStrategy(space, queries, tree, indices, offset, distances);
+    implementStrategy(space, tree, queries, distances, nearest_ranks, offset);
 
     {
       // NOTE_COMM_NEAREST: The communication pattern here for the nearest
@@ -333,8 +339,8 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
           "ArborX::DistributedTree::query::nearest::query_ids", 0);
       Kokkos::View<Query *, MemorySpace> fwd_queries(
           "ArborX::DistributedTree::query::nearest::fwd_queries", 0);
-      forwardQueries(comm, space, queries, indices, offset, fwd_queries, ids,
-                     ranks);
+      forwardQueries(comm, space, queries, nearest_ranks, offset, fwd_queries,
+                     ids, ranks);
 
       // Perform queries that have been received
       Kokkos::View<PairIndexDistance *, MemorySpace> out(
@@ -361,7 +367,7 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
 
       // Merge results
       Kokkos::Profiling::pushRegion(
-          "ArborX::DistributedTree::nearest::postprocess_results");
+          "ArborX::DistributedTree::query::nearest::postprocess_results");
 
       int const n_queries = queries.size();
       countResults(space, n_queries, ids, offset);

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -183,8 +183,8 @@ void DistributedTreeImpl::deviseStrategy(ExecutionSpace const &space,
   auto const &bottom_tree_sizes = tree._bottom_tree_sizes;
 
   // Find the k nearest local trees.
-  query(top_tree, space, predicates, LegacyDefaultCallback{}, nearest_ranks,
-        offset);
+  top_tree.query(space, predicates, LegacyDefaultCallback{}, nearest_ranks,
+                 offset);
 
   // Accumulate total leave count in the local trees until it reaches k which
   // is the number of neighbors queried for.  Stop if local trees get
@@ -267,10 +267,11 @@ void DistributedTreeImpl::reassessStrategy(
       WithinDistanceFromPredicates<Predicates, decltype(farthest_distances)>{
           queries, farthest_distances});
 
-  query(top_tree, space,
-        WithinDistanceFromPredicates<Predicates, decltype(farthest_distances)>{
-            queries, farthest_distances},
-        LegacyDefaultCallback{}, nearest_ranks, offset);
+  top_tree.query(
+      space,
+      WithinDistanceFromPredicates<Predicates, decltype(farthest_distances)>{
+          queries, farthest_distances},
+      LegacyDefaultCallback{}, nearest_ranks, offset);
   // NOTE: in principle, we could perform radius searches on the bottom_tree
   // rather than nearest queries.
 }
@@ -345,8 +346,8 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
       // Perform queries that have been received
       Kokkos::View<PairIndexDistance *, MemorySpace> out(
           "ArborX::DistributedTree::query::pairs_index_distance", 0);
-      query(bottom_tree, space, fwd_queries, callback_with_distance, out,
-            offset);
+      bottom_tree.query(space, fwd_queries, callback_with_distance, out,
+                        offset);
 
       // Unzip
       auto const n = out.extent(0);

--- a/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
@@ -55,8 +55,8 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
 
   Kokkos::View<int *, MemorySpace> intersected_ranks(
       "ArborX::DistributedTree::query::spatial::intersected_ranks", 0);
-  query(top_tree, space, predicates, LegacyDefaultCallback{}, intersected_ranks,
-        offset);
+  top_tree.query(space, predicates, LegacyDefaultCallback{}, intersected_ranks,
+                 offset);
 
   Kokkos::View<int *, MemorySpace> ranks(
       "ArborX::DistributedTree::query::spatial::ranks", 0);
@@ -78,7 +78,7 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                    fwd_predicates, ids, ranks);
 
     // Perform predicates that have been received
-    query(bottom_tree, space, fwd_predicates, callback, out, offset);
+    bottom_tree.query(space, fwd_predicates, callback, out, offset);
 
     // Communicate results back
     communicateResultsBack(comm, space, out, offset, ranks, ids);

--- a/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
@@ -39,7 +39,7 @@ template <typename Tree, typename ExecutionSpace, typename Predicates,
 std::enable_if_t<Kokkos::is_view<OutputView>{} && Kokkos::is_view<OffsetView>{}>
 DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                                    ExecutionSpace const &space,
-                                   Predicates const &queries,
+                                   Predicates const &predicates,
                                    Callback const &callback, OutputView &out,
                                    OffsetView &offset)
 {
@@ -55,7 +55,7 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
 
   Kokkos::View<int *, MemorySpace> intersected_ranks(
       "ArborX::DistributedTree::query::spatial::intersected_ranks", 0);
-  query(top_tree, space, queries, LegacyDefaultCallback{}, intersected_ranks,
+  query(top_tree, space, predicates, LegacyDefaultCallback{}, intersected_ranks,
         offset);
 
   Kokkos::View<int *, MemorySpace> ranks(
@@ -68,17 +68,17 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
     // - no explicit distances
     // - no results filtering
 
-    // Forward queries
+    // Forward predicates
     using Query = typename Predicates::value_type;
     Kokkos::View<int *, MemorySpace> ids(
         "ArborX::DistributedTree::query::spatial::query_ids", 0);
-    Kokkos::View<Query *, MemorySpace> fwd_queries(
-        "ArborX::DistributedTree::query::spatial::fwd_queries", 0);
-    forwardQueries(comm, space, queries, intersected_ranks, offset, fwd_queries,
-                   ids, ranks);
+    Kokkos::View<Query *, MemorySpace> fwd_predicates(
+        "ArborX::DistributedTree::query::spatial::fwd_predicates", 0);
+    forwardQueries(comm, space, predicates, intersected_ranks, offset,
+                   fwd_predicates, ids, ranks);
 
-    // Perform queries that have been received
-    query(bottom_tree, space, fwd_queries, callback, out, offset);
+    // Perform predicates that have been received
+    query(bottom_tree, space, fwd_predicates, callback, out, offset);
 
     // Communicate results back
     communicateResultsBack(comm, space, out, offset, ranks, ids);
@@ -87,8 +87,8 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
         "ArborX::DistributedTree::spatial::postprocess_results");
 
     // Merge results
-    int const n_queries = queries.size();
-    countResults(space, n_queries, ids, offset);
+    int const n_predicates = predicates.size();
+    countResults(space, n_predicates, ids, offset);
     sortResults(space, ids, out);
 
     Kokkos::Profiling::popRegion();
@@ -101,12 +101,12 @@ std::enable_if_t<Kokkos::is_view<IndicesAndRanks>{} &&
                  Kokkos::is_view<Offset>{}>
 DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                                    ExecutionSpace const &space,
-                                   Predicates const &queries,
+                                   Predicates const &predicates,
                                    IndicesAndRanks &values, Offset &offset)
 {
   int comm_rank;
   MPI_Comm_rank(tree.getComm(), &comm_rank);
-  queryDispatch(SpatialPredicateTag{}, tree, space, queries,
+  queryDispatch(SpatialPredicateTag{}, tree, space, predicates,
                 DefaultCallbackWithRank{comm_rank}, values, offset);
 }
 


### PR DESCRIPTION
- Change top tree to new API
- Change `Distances` args in `reassesStrategy` and `deviseStrategy` to const
- Change order of the args in `reassesStrategy` and `deviseStrategy` to align with query
- Introduce `BoundingVolume` alias in `DistributedTree` 
- Rename generic `indices` to `nearest_ranks` and `intersected_ranks` in DistributedTree queries implementation
- Fix several labels (regions, views, kernels) to follow the standard format