### PR TITLE
Refactor DistributedTree to support APIv2

### DIFF
--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -85,6 +85,8 @@ public:
         std::forward<View>(view), std::forward<Args>(args)...);
   }
 
+  auto const &indexable_get() const { return _indexable_getter; }
+
 private:
   size_type _size{0};
   bounding_volume_type _bounds;

--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -100,6 +100,8 @@ public:
                                                 std::forward<Args>(args)...);
   }
 
+  auto const &indexable_get() const { return _bottom_tree.indexable_get(); }
+
 protected:
   MPI_Comm getComm() const { return *_comm_ptr; }
 

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -45,8 +45,6 @@ struct PerThread
 namespace Details
 {
 struct HappyTreeFriends;
-template <typename Tree>
-struct CallbackWithDistance;
 } // namespace Details
 
 template <
@@ -127,8 +125,6 @@ public:
 
 private:
   friend struct Details::HappyTreeFriends;
-  template <typename Tree>
-  friend struct Details::CallbackWithDistance;
 
   using indexable_type =
       std::decay_t<std::invoke_result_t<IndexableGetter, Value>>;

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -123,6 +123,8 @@ public:
     tree_traversal(predicate);
   }
 
+  auto const &indexable_get() const { return _indexable_getter; }
+
 private:
   friend struct Details::HappyTreeFriends;
   template <typename Tree>

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -45,6 +45,8 @@ struct PerThread
 namespace Details
 {
 struct HappyTreeFriends;
+template <typename Tree>
+struct CallbackWithDistance;
 } // namespace Details
 
 template <
@@ -123,6 +125,8 @@ public:
 
 private:
   friend struct Details::HappyTreeFriends;
+  template <typename Tree>
+  friend struct Details::CallbackWithDistance;
 
   using indexable_type =
       std::decay_t<std::invoke_result_t<IndexableGetter, Value>>;

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -25,8 +25,8 @@ struct DistributedTreeImpl
   // spatial queries
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename IndicesAndRanks, typename Offset>
-  static std::enable_if_t<Kokkos::is_view<IndicesAndRanks>{} &&
-                          Kokkos::is_view<Offset>{}>
+  static std::enable_if_t<Kokkos::is_view_v<IndicesAndRanks> &&
+                          Kokkos::is_view_v<Offset>>
   queryDispatch(SpatialPredicateTag, DistributedTree const &tree,
                 ExecutionSpace const &space, Predicates const &queries,
                 IndicesAndRanks &values, Offset &offset);
@@ -34,8 +34,8 @@ struct DistributedTreeImpl
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename OutputView, typename OffsetView,
             typename Callback>
-  static std::enable_if_t<Kokkos::is_view<OutputView>{} &&
-                          Kokkos::is_view<OffsetView>{}>
+  static std::enable_if_t<Kokkos::is_view_v<OutputView> &&
+                          Kokkos::is_view_v<OffsetView>>
   queryDispatch(SpatialPredicateTag, DistributedTree const &tree,
                 ExecutionSpace const &space, Predicates const &queries,
                 Callback const &callback, OutputView &out, OffsetView &offset);
@@ -44,16 +44,16 @@ struct DistributedTreeImpl
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename Indices, typename Offset,
             typename Ranks>
-  static std::enable_if_t<Kokkos::is_view<Indices>{} &&
-                          Kokkos::is_view<Offset>{} && Kokkos::is_view<Ranks>{}>
+  static std::enable_if_t<Kokkos::is_view_v<Indices> &&
+                          Kokkos::is_view_v<Offset> && Kokkos::is_view_v<Ranks>>
   queryDispatchImpl(NearestPredicateTag, DistributedTree const &tree,
                     ExecutionSpace const &space, Predicates const &queries,
                     Indices &indices, Offset &offset, Ranks &ranks);
 
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename IndicesAndRanks, typename Offset>
-  static std::enable_if_t<Kokkos::is_view<IndicesAndRanks>{} &&
-                          Kokkos::is_view<Offset>{}>
+  static std::enable_if_t<Kokkos::is_view_v<IndicesAndRanks> &&
+                          Kokkos::is_view_v<Offset>>
   queryDispatch(NearestPredicateTag tag, DistributedTree const &tree,
                 ExecutionSpace const &space, Predicates const &queries,
                 IndicesAndRanks &values, Offset &offset);

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -43,12 +43,9 @@ struct DistributedTreeImpl
   // nearest neighbors queries
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename Indices, typename Offset,
-            typename Ranks,
-            typename Distances =
-                Kokkos::View<float *, typename DistributedTree::memory_space>>
-  static std::enable_if_t<
-      Kokkos::is_view<Indices>{} && Kokkos::is_view<Offset>{} &&
-      Kokkos::is_view<Ranks>{} && Kokkos::is_view<Distances>{}>
+            typename Ranks>
+  static std::enable_if_t<Kokkos::is_view<Indices>{} &&
+                          Kokkos::is_view<Offset>{} && Kokkos::is_view<Ranks>{}>
   queryDispatchImpl(NearestPredicateTag, DistributedTree const &tree,
                     ExecutionSpace const &space, Predicates const &queries,
                     Indices &indices, Offset &offset, Ranks &ranks);

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -303,8 +303,8 @@ void DistributedTreeImpl::reassessStrategy(
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,
           typename Values, typename Offset, typename Ranks>
-std::enable_if_t<Kokkos::is_view<Values>{} && Kokkos::is_view<Offset>{} &&
-                 Kokkos::is_view<Ranks>{}>
+std::enable_if_t<Kokkos::is_view_v<Values> && Kokkos::is_view_v<Offset> &&
+                 Kokkos::is_view_v<Ranks>>
 DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
                                        ExecutionSpace const &space,
                                        Predicates const &queries,
@@ -405,7 +405,7 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,
           typename Values, typename Offset>
-std::enable_if_t<Kokkos::is_view<Values>{} && Kokkos::is_view<Offset>{}>
+std::enable_if_t<Kokkos::is_view_v<Values> && Kokkos::is_view_v<Offset>>
 DistributedTreeImpl::queryDispatch(NearestPredicateTag tag, Tree const &tree,
                                    ExecutionSpace const &space,
                                    Predicates const &queries, Values &values,

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -128,8 +128,7 @@ struct CallbackWithDistance
   KOKKOS_FUNCTION void operator()(Query const &query, Value const &value,
                                   Output const &out) const
   {
-    // FIXME no access to indexable getter
-    out({value, distance(getGeometry(query), _tree._indexable_getter(value))});
+    out({value, distance(getGeometry(query), _tree.indexable_get()(value))});
   }
 };
 

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -303,9 +303,9 @@ void DistributedTreeImpl::reassessStrategy(
 }
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,
-          typename Values, typename Offset, typename Ranks, typename Distances>
+          typename Values, typename Offset, typename Ranks>
 std::enable_if_t<Kokkos::is_view<Values>{} && Kokkos::is_view<Offset>{} &&
-                 Kokkos::is_view<Ranks>{} && Kokkos::is_view<Distances>{}>
+                 Kokkos::is_view<Ranks>{}>
 DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
                                        ExecutionSpace const &space,
                                        Predicates const &queries,
@@ -322,6 +322,7 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
   auto const &bottom_tree = tree._bottom_tree;
   auto comm = tree.getComm();
 
+  using Distances = Kokkos::View<float *, MemorySpace>;
   Distances distances("ArborX::DistributedTree::query::nearest::distances", 0);
 
   // "Strategy" is used to determine what ranks to forward queries to.  In

--- a/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
@@ -27,7 +27,7 @@ namespace ArborX::Details
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,
           typename Values, typename Offset, typename Callback>
-std::enable_if_t<Kokkos::is_view<Values>{} && Kokkos::is_view<Offset>{}>
+std::enable_if_t<Kokkos::is_view_v<Values> && Kokkos::is_view_v<Offset>>
 DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                                    ExecutionSpace const &space,
                                    Predicates const &predicates,
@@ -88,7 +88,7 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,
           typename Values, typename Offset>
-std::enable_if_t<Kokkos::is_view<Values>{} && Kokkos::is_view<Offset>{}>
+std::enable_if_t<Kokkos::is_view_v<Values> && Kokkos::is_view_v<Offset>>
 DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                                    ExecutionSpace const &space,
                                    Predicates const &predicates, Values &values,

--- a/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
@@ -11,6 +11,7 @@
 #ifndef ARBORX_DETAILS_DISTRIBUTED_TREE_SPATIAL_HPP
 #define ARBORX_DETAILS_DISTRIBUTED_TREE_SPATIAL_HPP
 
+#include <ArborX_Callbacks.hpp>
 #include <ArborX_DetailsDistributedTreeImpl.hpp>
 #include <ArborX_DetailsDistributedTreeUtils.hpp>
 #include <ArborX_DetailsLegacy.hpp>
@@ -23,25 +24,15 @@
 
 namespace ArborX::Details
 {
-struct DefaultCallbackWithRank
-{
-  int _rank;
-  template <typename Predicate, typename OutputFunctor>
-  KOKKOS_FUNCTION void operator()(Predicate const &, int primitive_index,
-                                  OutputFunctor const &out) const
-  {
-    out({primitive_index, _rank});
-  }
-};
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,
-          typename OutputView, typename OffsetView, typename Callback>
-std::enable_if_t<Kokkos::is_view<OutputView>{} && Kokkos::is_view<OffsetView>{}>
+          typename Values, typename Offset, typename Callback>
+std::enable_if_t<Kokkos::is_view<Values>{} && Kokkos::is_view<Offset>{}>
 DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                                    ExecutionSpace const &space,
                                    Predicates const &predicates,
-                                   Callback const &callback, OutputView &out,
-                                   OffsetView &offset)
+                                   Callback const &callback, Values &values,
+                                   Offset &offset)
 {
   Kokkos::Profiling::ScopedRegion guard(
       "ArborX::DistributedTree::query::spatial");
@@ -78,10 +69,10 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                    fwd_predicates, ids, ranks);
 
     // Perform predicates that have been received
-    bottom_tree.query(space, fwd_predicates, callback, out, offset);
+    bottom_tree.query(space, fwd_predicates, callback, values, offset);
 
     // Communicate results back
-    communicateResultsBack(comm, space, out, offset, ranks, ids);
+    communicateResultsBack(comm, space, values, offset, ranks, ids);
 
     Kokkos::Profiling::pushRegion(
         "ArborX::DistributedTree::spatial::postprocess_results");
@@ -89,25 +80,22 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
     // Merge results
     int const n_predicates = predicates.size();
     countResults(space, n_predicates, ids, offset);
-    sortResults(space, ids, out);
+    sortResults(space, ids, values);
 
     Kokkos::Profiling::popRegion();
   }
 }
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,
-          typename IndicesAndRanks, typename Offset>
-std::enable_if_t<Kokkos::is_view<IndicesAndRanks>{} &&
-                 Kokkos::is_view<Offset>{}>
+          typename Values, typename Offset>
+std::enable_if_t<Kokkos::is_view<Values>{} && Kokkos::is_view<Offset>{}>
 DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
                                    ExecutionSpace const &space,
-                                   Predicates const &predicates,
-                                   IndicesAndRanks &values, Offset &offset)
+                                   Predicates const &predicates, Values &values,
+                                   Offset &offset)
 {
-  int comm_rank;
-  MPI_Comm_rank(tree.getComm(), &comm_rank);
   queryDispatch(SpatialPredicateTag{}, tree, space, predicates,
-                DefaultCallbackWithRank{comm_rank}, values, offset);
+                DefaultCallback{}, values, offset);
 }
 
 } // namespace ArborX::Details

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -12,6 +12,8 @@
 #ifndef ARBORX_DETAILS_LEGACY_HPP
 #define ARBORX_DETAILS_LEGACY_HPP
 
+#include <ArborX_Config.hpp>
+
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_PairValueIndex.hpp>
 
@@ -90,6 +92,7 @@ struct LegacyDefaultCallback
   }
 };
 
+#ifdef ARBORX_ENABLE_MPI
 struct LegacyDefaultCallbackWithRank
 {
   int _rank;
@@ -101,6 +104,7 @@ struct LegacyDefaultCallbackWithRank
     out({primitive_index, _rank});
   }
 };
+#endif
 
 struct LegacyDefaultTemplateValue
 {};

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -90,6 +90,18 @@ struct LegacyDefaultCallback
   }
 };
 
+struct LegacyDefaultCallbackWithRank
+{
+  int _rank;
+
+  template <typename Predicate, typename OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Predicate const &, int primitive_index,
+                                  OutputFunctor const &out) const
+  {
+    out({primitive_index, _rank});
+  }
+};
+
 struct LegacyDefaultTemplateValue
 {};
 


### PR DESCRIPTION
- Refactor by introducing `DistributedTreeBase`
- Update distributed benchmark to take advantage of the new interface

This should also satisfy the requirements for #907, though the interface may be a bit hard to use initially.

I opted to go for the base templated on the bottom tree because all other methods were too intrusive between spatial implementation and wrapping the post callback.