### PR TITLE
`AccessValues::_values` data member should be private

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -194,10 +194,12 @@ class AccessValues
 {
 private:
   using Access = AccessTraits<Values, Tag>;
-
-public:
   Values _values;
 
+public:
+  explicit AccessValues(Values values)
+      : _values(std::move(values))
+  {}
   using memory_space = typename Access::memory_space;
   using value_type = std::decay_t<
       Kokkos::detected_t<AccessTraitsGetArchetypeExpression, Access, Values>>;

--- a/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
+++ b/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
@@ -159,7 +159,7 @@ public:
     // Compute the moving least squares coefficients
     _coeffs = Details::movingLeastSquaresCoefficients<CRBFunc, PolynomialDegree,
                                                       FloatingCalculationType>(
-        space, source_view, target_access._values);
+        space, source_view, target_access);
   }
 
   template <typename ExecutionSpace, typename SourceValues,


### PR DESCRIPTION
> Was referred to directly in MLS which hinders changing what really should be considered implementation details.

Sorry I don't know what was wrong with #1018 
I opened it as GH was having issues. I had uploaded a new version that never showed up and the CI would not trigger.