### PR TITLE
An attempt to cleanup symbols for values and predicates

### DIFF
--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -56,6 +56,14 @@ public:
   size_type size() const { return Access::size(_primitives); }
 };
 
+template <typename Primitives, typename BoundingVolume>
+class AccessValuesI<LegacyValues<Primitives, BoundingVolume>, PrimitivesTag>
+    : public LegacyValues<Primitives, BoundingVolume>
+{
+public:
+  using self_type = LegacyValues<Primitives, BoundingVolume>;
+};
+
 template <typename Callback>
 struct LegacyCallbackWrapper
 {


### PR DESCRIPTION
The recent refactors makes us generate symbol names that are getting really nasty.  This is an attempt to "collapse" nested template template classes when possible to clean things up.  My fancy debugger does not let me copy/paste symbol name and I am too lazy/tired to type it down before and after but I think you will get the picture.

This is meant as a basis for discussion.  I went for minimal changes, I am not suggesting that aliasing `AccessValues` to some implementation class is a good design.

I implemented the following contractions
`AccessValues<AccessValues<...>> -> AccessValues<...>`
`AccessValues<Kokkos::View<...>> -> Kokkos::View<...>`
`AccessValues<PermutedData<...>> -> PermutedData<...>`
`AccessValues<LegacyValues<...>> -> LegacyValues<...>`

