### PR TITLE
Switch HalfTraversal to APIv2

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -57,14 +57,16 @@ struct WithinRadiusGetter
 {
   float _r;
 
-  template <typename Point>
-  KOKKOS_FUNCTION auto operator()(Point const &point) const
+  template <typename Point, typename Index>
+  KOKKOS_FUNCTION auto
+  operator()(PairValueIndex<Point, Index> const &value) const
   {
     static_assert(GeometryTraits::is_point_v<Point>);
 
     constexpr int dim = GeometryTraits::dimension_v<Point>;
     auto const &hyper_point =
-        reinterpret_cast<ExperimentalHyperGeometry::Point<dim> const &>(point);
+        reinterpret_cast<ExperimentalHyperGeometry::Point<dim> const &>(
+            value.value);
     using ArborX::intersects;
     return intersects(ExperimentalHyperGeometry::Sphere<dim>{hyper_point, _r});
   }

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -59,14 +59,14 @@ struct WithinRadiusGetter
 
   template <typename Point, typename Index>
   KOKKOS_FUNCTION auto
-  operator()(PairValueIndex<Point, Index> const &value) const
+  operator()(PairValueIndex<Point, Index> const &pair) const
   {
     static_assert(GeometryTraits::is_point_v<Point>);
 
     constexpr int dim = GeometryTraits::dimension_v<Point>;
     auto const &hyper_point =
         reinterpret_cast<ExperimentalHyperGeometry::Point<dim> const &>(
-            value.value);
+            pair.value);
     using ArborX::intersects;
     return intersects(ExperimentalHyperGeometry::Sphere<dim>{hyper_point, _r});
   }

--- a/src/details/ArborX_DetailsFDBSCAN.hpp
+++ b/src/details/ArborX_DetailsFDBSCAN.hpp
@@ -14,6 +14,7 @@
 
 #include <ArborX_Callbacks.hpp>
 #include <ArborX_DetailsUnionFind.hpp>
+#include <ArborX_PairValueIndex.hpp>
 #include <ArborX_Predicates.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -49,8 +50,14 @@ struct FDBSCANCallback
   UnionFind _union_find;
   CorePointsType _is_core_point;
 
-  KOKKOS_FUNCTION auto operator()(int i, int j) const
+  template <typename Value, typename Index>
+  KOKKOS_FUNCTION auto
+  operator()(PairValueIndex<Value, Index> const &value1,
+             PairValueIndex<Value, Index> const &value2) const
   {
+    int i = value1.index;
+    int j = value2.index;
+
     bool const is_border_point = !_is_core_point(i);
     bool const neighbor_is_core_point = _is_core_point(j);
     if (is_border_point)

--- a/src/details/ArborX_DetailsHalfTraversal.hpp
+++ b/src/details/ArborX_DetailsHalfTraversal.hpp
@@ -52,7 +52,7 @@ struct HalfTraversal
 
   KOKKOS_FUNCTION void operator()(int i) const
   {
-    auto const &leaf_value = HappyTreeFriends::getValue(_bvh, i);
+    auto const leaf_value = HappyTreeFriends::getValue(_bvh, i);
     auto const predicate = _get_predicate(leaf_value);
 
     int node = HappyTreeFriends::getRope(_bvh, i);

--- a/src/details/ArborX_DetailsHalfTraversal.hpp
+++ b/src/details/ArborX_DetailsHalfTraversal.hpp
@@ -12,9 +12,7 @@
 #ifndef ARBORX_DETAILS_HALF_TRAVERSAL_HPP
 #define ARBORX_DETAILS_HALF_TRAVERSAL_HPP
 
-#include <ArborX_Callbacks.hpp> // LegacyCallbackWrapper
 #include <ArborX_DetailsHappyTreeFriends.hpp>
-#include <ArborX_DetailsLegacy.hpp>
 #include <ArborX_DetailsNode.hpp> // ROPE_SENTINEL
 
 #include <Kokkos_Core.hpp>
@@ -27,7 +25,7 @@ struct HalfTraversal
 {
   BVH _bvh;
   PredicateGetter _get_predicate;
-  LegacyCallbackWrapper<Callback> _callback;
+  Callback _callback;
 
   template <class ExecutionSpace>
   HalfTraversal(ExecutionSpace const &space, BVH const &bvh,
@@ -54,9 +52,8 @@ struct HalfTraversal
 
   KOKKOS_FUNCTION void operator()(int i) const
   {
-    auto const predicate =
-        _get_predicate(HappyTreeFriends::getIndexable(_bvh, i));
-    auto const leaf_permutation_i = HappyTreeFriends::getValue(_bvh, i).index;
+    auto const &leaf_value = HappyTreeFriends::getValue(_bvh, i);
+    auto const predicate = _get_predicate(leaf_value);
 
     int node = HappyTreeFriends::getRope(_bvh, i);
     while (node != ROPE_SENTINEL)
@@ -64,7 +61,7 @@ struct HalfTraversal
       if (HappyTreeFriends::isLeaf(_bvh, node))
       {
         if (predicate(HappyTreeFriends::getIndexable(_bvh, node)))
-          _callback(leaf_permutation_i, HappyTreeFriends::getValue(_bvh, node));
+          _callback(leaf_value, HappyTreeFriends::getValue(_bvh, node));
         node = HappyTreeFriends::getRope(_bvh, node);
       }
       else

--- a/src/details/ArborX_NeighborList.hpp
+++ b/src/details/ArborX_NeighborList.hpp
@@ -67,7 +67,9 @@ void findHalfNeighborList(ExecutionSpace const &space,
   Points points{primitives}; // NOLINT
   int const n = points.size();
 
-  BoundingVolumeHierarchy<MemorySpace, PairValueIndex<Point>> bvh(
+  using Value = PairValueIndex<Point>;
+
+  BoundingVolumeHierarchy<MemorySpace, Value> bvh(
       space, Experimental::attach_indices(points));
 
   Kokkos::Profiling::pushRegion(
@@ -77,7 +79,7 @@ void findHalfNeighborList(ExecutionSpace const &space,
   Kokkos::deep_copy(space, offsets, 0);
   HalfTraversal(
       space, bvh,
-      KOKKOS_LAMBDA(auto, auto const &value) {
+      KOKKOS_LAMBDA(Value const &, Value const &value) {
         Kokkos::atomic_increment(&offsets(value.index));
       },
       NeighborListPredicateGetter{radius});
@@ -93,7 +95,7 @@ void findHalfNeighborList(ExecutionSpace const &space,
                        "ArborX::Experimental::HalfNeighborList::counts");
   HalfTraversal(
       space, bvh,
-      KOKKOS_LAMBDA(auto const &value1, auto const &value2) {
+      KOKKOS_LAMBDA(Value const &value1, Value const &value2) {
         indices(Kokkos::atomic_fetch_inc(&counts(value2.index))) = value1.index;
       },
       NeighborListPredicateGetter{radius});
@@ -125,7 +127,9 @@ void findFullNeighborList(ExecutionSpace const &space,
   Points points{primitives}; // NOLINT
   int const n = points.size();
 
-  BoundingVolumeHierarchy<MemorySpace, PairValueIndex<Point>> bvh(
+  using Value = PairValueIndex<Point>;
+
+  BoundingVolumeHierarchy<MemorySpace, Value> bvh(
       space, Experimental::attach_indices(points));
 
   Kokkos::Profiling::pushRegion(
@@ -135,7 +139,7 @@ void findFullNeighborList(ExecutionSpace const &space,
   Kokkos::deep_copy(space, offsets, 0);
   HalfTraversal(
       space, bvh,
-      KOKKOS_LAMBDA(auto const &value1, auto const &value2) {
+      KOKKOS_LAMBDA(Value const &value1, Value const &value2) {
         Kokkos::atomic_increment(&offsets(value1.index));
         Kokkos::atomic_increment(&offsets(value2.index));
       },
@@ -152,7 +156,7 @@ void findFullNeighborList(ExecutionSpace const &space,
                        "ArborX::Experimental::FullNeighborList::counts");
   HalfTraversal(
       space, bvh,
-      KOKKOS_LAMBDA(auto const &value1, auto const &value2) {
+      KOKKOS_LAMBDA(Value const &value1, Value const &value2) {
         indices(Kokkos::atomic_fetch_inc(&counts(value2.index))) = value1.index;
       },
       NeighborListPredicateGetter{radius});

--- a/test/tstDetailsHalfTraversal.cpp
+++ b/test/tstDetailsHalfTraversal.cpp
@@ -83,7 +83,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(half_traversal, DeviceType, ARBORX_DEVICE_TYPES)
   using ArborX::Details::HalfTraversal;
   HalfTraversal(
       exec_space, bvh,
-      KOKKOS_LAMBDA(int i, int j) {
+      KOKKOS_LAMBDA(auto const &value1, auto const &value2) {
+        int i = value1.index;
+        int j = value2.index;
         auto [min_ij, max_ij] = Kokkos::minmax(i, j);
         Kokkos::atomic_increment(&count(max_ij * (max_ij + 1) / 2 + min_ij));
       },

--- a/test/tstDetailsHalfTraversal.cpp
+++ b/test/tstDetailsHalfTraversal.cpp
@@ -81,9 +81,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(half_traversal, DeviceType, ARBORX_DEVICE_TYPES)
   // [n] 1  1  1  1  1  1  1  1  1  0
 
   using ArborX::Details::HalfTraversal;
+  using Value = ArborX::PairValueIndex<ArborX::Box>;
   HalfTraversal(
       exec_space, bvh,
-      KOKKOS_LAMBDA(auto const &value1, auto const &value2) {
+      KOKKOS_LAMBDA(Value const &value1, Value const &value2) {
         int i = value1.index;
         int j = value2.index;
         auto [min_ij, max_ij] = Kokkos::minmax(i, j);


### PR DESCRIPTION
The main thing is to change half-traversal callback from `callback(int, int)` to `callback(value, value)`.

Note that this change is not backwards compatible. However, `HalfTraversal` is experimental, so it should be fine.