### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard,-modernize-concat-nested-namespaces,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-function-cognitive-complexity,-readability-redundant-string-cstr'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-noexcept-swap,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard,-modernize-concat-nested-namespaces,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-function-cognitive-complexity,-readability-redundant-string-cstr,-readability-inconsistent-declaration-parameter-name'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -236,7 +236,7 @@ pipeline {
                                     -D CMAKE_CXX_COMPILER=clang++ \
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra" \
-                                    -D CMAKE_CXX_CLANG_TIDY="$LLVM_DIR/bin/clang-tidy" \
+                                    -D CMAKE_CXX_CLANG_TIDY="$LLVM_DIR/bin/clang-tidy;-warnings-as-errors=*" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
                                     -D MPIEXEC_PREFLAGS="--allow-run-as-root" \

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -254,12 +254,12 @@ bool verifyClustersAreUnique(ExecutionSpace const &exec_space,
   }
   if (cluster_sets.size() != num_unique_cluster_indices)
   {
-    std::cerr << "Number of components does not match" << '\n';
+    std::cerr << "Number of components does not match\n";
     return false;
   }
   if (num_clusters != num_unique_cluster_indices)
   {
-    std::cerr << "Cluster IDs are not unique" << '\n';
+    std::cerr << "Cluster IDs are not unique\n";
     return false;
   }
 

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -254,12 +254,12 @@ bool verifyClustersAreUnique(ExecutionSpace const &exec_space,
   }
   if (cluster_sets.size() != num_unique_cluster_indices)
   {
-    std::cerr << "Number of components does not match" << std::endl;
+    std::cerr << "Number of components does not match" << '\n';
     return false;
   }
   if (num_clusters != num_unique_cluster_indices)
   {
-    std::cerr << "Cluster IDs are not unique" << std::endl;
+    std::cerr << "Cluster IDs are not unique" << '\n';
     return false;
   }
 
@@ -306,7 +306,7 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   ARBORX_ASSERT(eps > 0);
   ARBORX_ASSERT(core_min_size >= 2);
 
-  Points points{primitives};
+  Points const &points{primitives};
 
   using Point = typename Points::value_type;
   static_assert(GeometryTraits::is_point<Point>{});

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -306,7 +306,7 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   ARBORX_ASSERT(eps > 0);
   ARBORX_ASSERT(core_min_size >= 2);
 
-  Points const &points{primitives};
+  Points points{primitives}; // NOLINT
 
   using Point = typename Points::value_type;
   static_assert(GeometryTraits::is_point<Point>{});

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -219,7 +219,7 @@ struct ArborX::AccessTraits<NearestNeighborsSearches<DeviceType>,
 namespace bpo = boost::program_options;
 
 template <class NO>
-int main_(std::vector<std::string> const &args, const MPI_Comm comm)
+int main_(std::vector<std::string> const &args, MPI_Comm const comm)
 {
   TimeMonitor time_monitor;
 

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -275,7 +275,7 @@ int main(int argc, char *argv[])
         "Example::initialize_rays",
         Kokkos::MDRangePolicy<Kokkos::Rank<2>, ExecutionSpace>(
             exec_space, {0, 0}, {num_boxes, rays_per_box}),
-        KOKKOS_LAMBDA(const size_t i, const size_t j) {
+        KOKKOS_LAMBDA(size_t const i, size_t const j) {
           // The origins of rays are uniformly distributed in the boxes. The
           // direction vectors are uniformly sampling of a full sphere.
           GeneratorType g = rand_pool.get_state();

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -368,6 +368,6 @@ int main()
         }
       },
       Kokkos::LAnd<bool, Kokkos::HostSpace>(success));
-  std::cout << "Check " << (success ? "succeeded" : "failed") << std::endl;
+  std::cout << "Check " << (success ? "succeeded" : "failed") << '\n';
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -192,7 +192,7 @@ BruteForce<MemorySpace, Value, IndexableGetter, BoundingVolume>::BruteForce(
       PrimitivesTag{}, user_values, Details::DoNotCheckGetReturnType());
 
   using Values = Details::AccessValues<UserValues, PrimitivesTag>;
-  Values values{user_values};
+  Values const &values{user_values};
 
   static_assert(
       Details::KokkosExt::is_accessible_from<typename Values::memory_space,
@@ -229,7 +229,7 @@ void BruteForce<MemorySpace, Value, IndexableGetter, BoundingVolume>::query(
                                              ExecutionSpace>::value,
       "Predicates must be accessible from the execution space");
 
-  Predicates predicates{user_predicates};
+  Predicates const &predicates{user_predicates};
 
   using Tag = typename Predicates::value_type::Tag;
   static_assert(std::is_same<Tag, Details::SpatialPredicateTag>{},

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -192,7 +192,7 @@ BruteForce<MemorySpace, Value, IndexableGetter, BoundingVolume>::BruteForce(
       PrimitivesTag{}, user_values, Details::DoNotCheckGetReturnType());
 
   using Values = Details::AccessValues<UserValues, PrimitivesTag>;
-  Values const &values{user_values};
+  Values values{user_values}; // NOLINT
 
   static_assert(
       Details::KokkosExt::is_accessible_from<typename Values::memory_space,
@@ -229,7 +229,7 @@ void BruteForce<MemorySpace, Value, IndexableGetter, BoundingVolume>::query(
                                              ExecutionSpace>::value,
       "Predicates must be accessible from the execution space");
 
-  Predicates const &predicates{user_predicates};
+  Predicates predicates{user_predicates}; // NOLINT
 
   using Tag = typename Predicates::value_type::Tag;
   static_assert(std::is_same<Tag, Details::SpatialPredicateTag>{},

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -271,7 +271,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
 
   bool const verbose = parameters._verbose;
 
-  Points points{primitives};
+  Points const &points{primitives};
   int const n = points.size();
 
   Kokkos::View<int *, MemorySpace> num_neigh("ArborX::DBSCAN::num_neighbors",

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -271,7 +271,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
 
   bool const verbose = parameters._verbose;
 
-  Points const &points{primitives};
+  Points points{primitives}; // NOLINT
   int const n = points.size();
 
   Kokkos::View<int *, MemorySpace> num_neigh("ArborX::DBSCAN::num_neighbors",

--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -92,7 +92,7 @@ public:
                       typename Predicates::memory_space, ExecutionSpace>::value,
                   "Predicates must be accessible from the execution space");
 
-    Predicates const &predicates{user_predicates};
+    Predicates predicates{user_predicates}; // NOLINT
 
     using Tag = typename Predicates::value_type::Tag;
     Details::DistributedTreeImpl::queryDispatch(Tag{}, *this, space, predicates,
@@ -181,7 +181,7 @@ public:
                                       ExecutionSpace>::value,
         "Predicates must be accessible from the execution space");
 
-    Predicates const &predicates{user_predicates};
+    Predicates predicates{user_predicates}; // NOLINT
 
     using Tag = typename Predicates::value_type::Tag;
     if constexpr (std::is_same_v<Tag, Details::SpatialPredicateTag>)

--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -50,7 +50,6 @@ public:
   using bounding_volume_type = BoundingVolume;
   using value_type = typename BottomTree::value_type;
 
-public:
   template <typename ExecutionSpace, typename... Args>
   DistributedTreeBase(MPI_Comm comm, ExecutionSpace const &space,
                       Args &&...args);
@@ -93,7 +92,7 @@ public:
                       typename Predicates::memory_space, ExecutionSpace>::value,
                   "Predicates must be accessible from the execution space");
 
-    Predicates predicates{user_predicates};
+    Predicates const &predicates{user_predicates};
 
     using Tag = typename Predicates::value_type::Tag;
     Details::DistributedTreeImpl::queryDispatch(Tag{}, *this, space, predicates,
@@ -182,7 +181,7 @@ public:
                                       ExecutionSpace>::value,
         "Predicates must be accessible from the execution space");
 
-    Predicates predicates{user_predicates};
+    Predicates const &predicates{user_predicates};
 
     using Tag = typename Predicates::value_type::Tag;
     if constexpr (std::is_same_v<Tag, Details::SpatialPredicateTag>)

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -268,7 +268,7 @@ BoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter, BoundingVolume>::
       PrimitivesTag{}, user_values, Details::DoNotCheckGetReturnType());
 
   using Values = Details::AccessValues<UserValues, PrimitivesTag>;
-  Values const &values{user_values};
+  Values values{user_values}; // NOLINT
 
   static_assert(
       Details::KokkosExt::is_accessible_from<typename Values::memory_space,
@@ -356,7 +356,7 @@ void BoundingVolumeHierarchy<
       Details::KokkosExt::is_accessible_from<typename Predicates::memory_space,
                                              ExecutionSpace>::value,
       "Predicates must be accessible from the execution space");
-  Predicates const &predicates{user_predicates};
+  Predicates predicates{user_predicates}; // NOLINT
 
   using Tag = typename Predicates::value_type::Tag;
   std::string profiling_prefix = "ArborX::BVH::query::";

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -268,7 +268,7 @@ BoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter, BoundingVolume>::
       PrimitivesTag{}, user_values, Details::DoNotCheckGetReturnType());
 
   using Values = Details::AccessValues<UserValues, PrimitivesTag>;
-  Values values{user_values};
+  Values const &values{user_values};
 
   static_assert(
       Details::KokkosExt::is_accessible_from<typename Values::memory_space,
@@ -356,7 +356,7 @@ void BoundingVolumeHierarchy<
       Details::KokkosExt::is_accessible_from<typename Predicates::memory_space,
                                              ExecutionSpace>::value,
       "Predicates must be accessible from the execution space");
-  Predicates predicates{user_predicates};
+  Predicates const &predicates{user_predicates};
 
   using Tag = typename Predicates::value_type::Tag;
   std::string profiling_prefix = "ArborX::BVH::query::";

--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -268,7 +268,7 @@ struct AccessTraits<
     : Traits::Access<T, Tag>
 {
   template <class U>
-  static constexpr bool always_false = std::is_void<U>::value;
+  static constexpr bool always_false = std::is_void_v<U>;
   static_assert(
       always_false<T>,
       "ArborX::Traits::Access was removed. Use ArborX::AccessTraits instead");

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -64,8 +64,8 @@ struct DistributedTreeImpl
             typename Offset>
   static void deviseStrategy(ExecutionSpace const &space,
                              DistributedTree const &tree,
-                             Predicates const &queries, Distances const &,
-                             Indices &indices, Offset &offset);
+                             Predicates const &predicates, Distances const &,
+                             Indices &nearest_ranks, Offset &offset);
 
   template <typename ExecutionSpace, typename DistributedTree,
             typename Predicates, typename Distances, typename Indices,

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -64,8 +64,8 @@ struct DistributedTreeImpl
             typename Offset>
   static void deviseStrategy(ExecutionSpace const &space,
                              DistributedTree const &tree,
-                             Predicates const &predicates, Distances const &,
-                             Indices &nearest_ranks, Offset &offset);
+                             Predicates const &queries, Distances const &,
+                             Indices &indices, Offset &offset);
 
   template <typename ExecutionSpace, typename DistributedTree,
             typename Predicates, typename Distances, typename Indices,

--- a/src/details/ArborX_DetailsDistributedTreeUtils.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeUtils.hpp
@@ -30,7 +30,7 @@ namespace ArborX::Details::DistributedTree
 {
 
 template <typename ExecutionSpace, typename Distributor, typename View>
-typename std::enable_if<Kokkos::is_view<View>::value>::type
+std::enable_if_t<Kokkos::is_view<View>::value>
 sendAcrossNetwork(ExecutionSpace const &space, Distributor const &distributor,
                   View exports, typename View::non_const_type imports)
 {

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -46,9 +46,8 @@ determineBufferLayout(ExecutionSpace const &space, InputView batched_ranks,
   ARBORX_ASSERT(counts.empty());
   ARBORX_ASSERT(permutation_indices.extent_int(0) == 0);
   ARBORX_ASSERT(batched_ranks.size() + 1 == batched_offsets.size());
-  static_assert(
-      std::is_same<typename InputView::non_const_value_type, int>::value);
-  static_assert(std::is_same<typename OutputView::value_type, int>::value);
+  static_assert(std::is_same_v<typename InputView::non_const_value_type, int>);
+  static_assert(std::is_same_v<typename OutputView::value_type, int>);
 
   // In case all the batches are empty, return an empty list of unique_ranks and
   // counts, but still have one element in offsets. This is conforming with
@@ -143,9 +142,8 @@ static void sortAndDetermineBufferLayout(ExecutionSpace const &space,
   ARBORX_ASSERT(offsets.empty());
   ARBORX_ASSERT(counts.empty());
   ARBORX_ASSERT(permutation_indices.extent_int(0) == ranks.extent_int(0));
-  static_assert(
-      std::is_same<typename InputView::non_const_value_type, int>::value);
-  static_assert(std::is_same<typename OutputView::value_type, int>::value);
+  static_assert(std::is_same_v<typename InputView::non_const_value_type, int>);
+  static_assert(std::is_same_v<typename OutputView::value_type, int>);
 
   offsets.push_back(0);
 

--- a/src/details/ArborX_DetailsPriorityQueue.hpp
+++ b/src/details/ArborX_DetailsPriorityQueue.hpp
@@ -37,7 +37,7 @@ public:
   using size_type = typename Container::size_type;
   using reference = typename Container::reference;
   using const_reference = typename Container::const_reference;
-  static_assert(std::is_same<value_type, T>::value,
+  static_assert(std::is_same_v<value_type, T>,
                 "Template parameter T in PriorityQueue is not the same as "
                 "the type of the elements stored by the underlying "
                 "container Container::value_type");

--- a/src/details/ArborX_DetailsSortUtils.hpp
+++ b/src/details/ArborX_DetailsSortUtils.hpp
@@ -92,7 +92,7 @@ void applyInversePermutation(ExecutionSpace const &space,
                              InputView const &input_view,
                              OutputView const &output_view)
 {
-  static_assert(std::is_integral<typename PermutationView::value_type>::value);
+  static_assert(std::is_integral_v<typename PermutationView::value_type>);
   ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
   ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
 
@@ -112,7 +112,7 @@ void applyPermutation(ExecutionSpace const &space,
                       InputView const &input_view,
                       OutputView const &output_view)
 {
-  static_assert(std::is_integral<typename PermutationView::value_type>::value);
+  static_assert(std::is_integral_v<typename PermutationView::value_type>);
   ARBORX_ASSERT(permutation.extent(0) == input_view.extent(0));
   ARBORX_ASSERT(output_view.extent(0) == input_view.extent(0));
 
@@ -129,7 +129,7 @@ template <typename ExecutionSpace, typename PermutationView, typename View>
 void applyPermutation(ExecutionSpace const &space,
                       PermutationView const &permutation, View &view)
 {
-  static_assert(std::is_integral<typename PermutationView::value_type>::value);
+  static_assert(std::is_integral_v<typename PermutationView::value_type>);
   auto scratch_view = KokkosExt::clone(space, view);
   applyPermutation(space, permutation, scratch_view, view);
 }

--- a/src/details/ArborX_DetailsStack.hpp
+++ b/src/details/ArborX_DetailsStack.hpp
@@ -32,7 +32,7 @@ public:
   using size_type = typename Container::size_type;
   using reference = typename Container::reference;
   using const_reference = typename Container::const_reference;
-  static_assert(std::is_same<value_type, T>::value,
+  static_assert(std::is_same_v<value_type, T>,
                 "Template parameter T in Stack is not the same as "
                 "the type of the elements stored by the underlying "
                 "container Container::value_type");

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -45,8 +45,8 @@ inline void projectOntoSpaceFillingCurve(ExecutionSpace const &space,
   size_t const n = indexables.size();
   ARBORX_ASSERT(linear_ordering_indices.extent(0) == n);
   static_assert(
-      std::is_same<typename LinearOrdering::value_type,
-                   decltype(curve(scene_bounding_box, indexables(0)))>::value);
+      std::is_same_v<typename LinearOrdering::value_type,
+                     decltype(curve(scene_bounding_box, indexables(0)))>);
 
   Kokkos::parallel_for(
       "ArborX::TreeConstruction::project_primitives_onto_space_filling_curve",

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -334,7 +334,7 @@ reallocWithoutInitializing(View &v, size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
 
 template <typename View>
 [[deprecated]] void
-reallocWithoutInitializing(View &v, const typename View::array_layout &layout)
+reallocWithoutInitializing(View &v, typename View::array_layout const &layout)
 {
   using ExecutionSpace = typename View::execution_space;
   Details::KokkosExt::reallocWithoutInitializing(ExecutionSpace{}, v, layout);

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -52,7 +52,7 @@ struct MinimumSpanningTree
     using Point = typename Points::value_type;
     static_assert(GeometryTraits::is_point<Point>{});
 
-    Points const &points{primitives};
+    Points points{primitives}; // NOLINT
 
     auto const n = points.size();
 

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -52,7 +52,7 @@ struct MinimumSpanningTree
     using Point = typename Points::value_type;
     static_assert(GeometryTraits::is_point<Point>{});
 
-    Points points{primitives};
+    Points const &points{primitives};
 
     auto const n = points.size();
 

--- a/src/details/ArborX_NeighborList.hpp
+++ b/src/details/ArborX_NeighborList.hpp
@@ -63,7 +63,7 @@ void findHalfNeighborList(ExecutionSpace const &space,
   using Point = typename Points::value_type;
   static_assert(GeometryTraits::is_point<Point>{});
 
-  Points points{primitives};
+  Points const &points{primitives};
   int const n = points.size();
 
   BoundingVolumeHierarchy<MemorySpace, PairValueIndex<Point>> bvh(
@@ -119,7 +119,7 @@ void findFullNeighborList(ExecutionSpace const &space,
   using Point = typename Points::value_type;
   static_assert(GeometryTraits::is_point<Point>{});
 
-  Points points{primitives};
+  Points const &points{primitives};
   int const n = points.size();
 
   BoundingVolumeHierarchy<MemorySpace, PairValueIndex<Point>> bvh(

--- a/src/details/ArborX_NeighborList.hpp
+++ b/src/details/ArborX_NeighborList.hpp
@@ -63,7 +63,7 @@ void findHalfNeighborList(ExecutionSpace const &space,
   using Point = typename Points::value_type;
   static_assert(GeometryTraits::is_point<Point>{});
 
-  Points const &points{primitives};
+  Points points{primitives}; // NOLINT
   int const n = points.size();
 
   BoundingVolumeHierarchy<MemorySpace, PairValueIndex<Point>> bvh(
@@ -119,7 +119,7 @@ void findFullNeighborList(ExecutionSpace const &space,
   using Point = typename Points::value_type;
   static_assert(GeometryTraits::is_point<Point>{});
 
-  Points const &points{primitives};
+  Points points{primitives}; // NOLINT
   int const n = points.size();
 
   BoundingVolumeHierarchy<MemorySpace, PairValueIndex<Point>> bvh(

--- a/src/details/ArborX_SpaceFillingCurves.hpp
+++ b/src/details/ArborX_SpaceFillingCurves.hpp
@@ -87,8 +87,8 @@ void check_valid_space_filling_curve(SpaceFillingCurve const &)
 
   using OrderValueType =
       std::invoke_result_t<SpaceFillingCurve const &, Box, Point>;
-  static_assert(std::is_same<OrderValueType, unsigned int>::value ||
-                std::is_same<OrderValueType, unsigned long long>::value);
+  static_assert(std::is_same_v<OrderValueType, unsigned int> ||
+                std::is_same_v<OrderValueType, unsigned long long>);
   static_assert(std::is_same_v<
                 OrderValueType,
                 std::invoke_result_t<SpaceFillingCurve const &, Box, Box>>);

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -111,9 +111,8 @@ void check_valid_geometry_traits(Geometry const &)
           GeometryTraits::dimension_v<Geometry> > 0,
       "GeometryTraits::dimension<Geometry>::value must be a positive integral");
 
-  static_assert(
-      !std::is_same<typename tag<Geometry>::type, not_specialized>::value,
-      "GeometryTraits::tag<Geometry> must define 'type' member type");
+  static_assert(!std::is_same_v<typename tag<Geometry>::type, not_specialized>,
+                "GeometryTraits::tag<Geometry> must define 'type' member type");
   using Tag = typename tag<Geometry>::type;
   static_assert(std::is_same<Tag, PointTag>{} || std::is_same<Tag, BoxTag>{} ||
                     std::is_same<Tag, SphereTag>{} ||
@@ -122,8 +121,8 @@ void check_valid_geometry_traits(Geometry const &)
                 "GeometryTraits::tag<Geometry>::type must be PointTag, BoxTag, "
                 "SphereTag, TriangleTag or KDOPTag");
 
-  static_assert(!std::is_same<typename coordinate_type<Geometry>::type,
-                              not_specialized>::value,
+  static_assert(!std::is_same_v<typename coordinate_type<Geometry>::type,
+                                not_specialized>,
                 "GeometryTraits::coordinate_type<Geometry> must define 'type' "
                 "member type");
   using Coordinate = typename coordinate_type<Geometry>::type;

--- a/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
+++ b/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
@@ -145,8 +145,8 @@ public:
                       : Details::polynomialBasisSize<dimension,
                                                      PolynomialDegree::value>();
 
-    TargetAccess const &target_access{target_points};
-    SourceAccess const &source_access{source_points};
+    TargetAccess target_access{target_points}; // NOLINT
+    SourceAccess source_access{source_points}; // NOLINT
 
     _num_targets = target_access.size();
     _source_size = source_access.size();

--- a/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
+++ b/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
@@ -145,8 +145,8 @@ public:
                       : Details::polynomialBasisSize<dimension,
                                                      PolynomialDegree::value>();
 
-    TargetAccess target_access{target_points};
-    SourceAccess source_access{source_points};
+    TargetAccess const &target_access{target_points};
+    SourceAccess const &source_access{source_points};
 
     _num_targets = target_access.size();
     _source_size = source_access.size();

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtStdAlgorithms.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtStdAlgorithms.hpp
@@ -35,8 +35,8 @@ void exclusive_scan(ExecutionSpace const &space, SrcView const &src,
       is_accessible_from<typename DstView::memory_space, ExecutionSpace>::value,
       "Destination view must be accessible from the execution "
       "space");
-  static_assert(std::is_same<typename SrcView::value_type,
-                             typename DstView::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename SrcView::value_type,
+                               typename DstView::non_const_value_type>,
                 "exclusive_scan requires non-const destination type");
   static_assert(unsigned(DstView::rank) == unsigned(SrcView::rank) &&
                     unsigned(DstView::rank) == unsigned(1),
@@ -103,11 +103,11 @@ void adjacent_difference(ExecutionSpace const &space, SrcView const &src,
   static_assert(SrcView::rank == 1 && DstView::rank == 1,
                 "adjacent_difference operates on rank-1 views");
   static_assert(
-      std::is_same<typename DstView::value_type,
-                   typename DstView::non_const_value_type>::value,
+      std::is_same_v<typename DstView::value_type,
+                     typename DstView::non_const_value_type>,
       "adjacent_difference requires non-const destination value type");
-  static_assert(std::is_same<typename SrcView::non_const_value_type,
-                             typename DstView::value_type>::value,
+  static_assert(std::is_same_v<typename SrcView::non_const_value_type,
+                               typename DstView::value_type>,
                 "adjacent_difference requires same value type for source and "
                 "destination");
 
@@ -137,10 +137,10 @@ void iota(ExecutionSpace const &space, ViewType const &v,
                 "iota requires a View of rank 1");
 
   using ValueType = typename ViewType::value_type;
-  static_assert(std::is_arithmetic<ValueType>::value,
+  static_assert(std::is_arithmetic_v<ValueType>,
                 "iota requires a View with an arithmetic value type");
   static_assert(
-      std::is_same<ValueType, typename ViewType::non_const_value_type>::value,
+      std::is_same_v<ValueType, typename ViewType::non_const_value_type>,
       "iota requires a View with non-const value type");
 
   Kokkos::parallel_for(

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtSwap.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtSwap.hpp
@@ -22,8 +22,8 @@ namespace ArborX::Details::KokkosExt
 
 template <class T>
 KOKKOS_FUNCTION constexpr void
-swap(T &a, T &b) noexcept(std::is_nothrow_move_constructible<T>::value
-                              &&std::is_nothrow_move_assignable<T>::value)
+swap(T &a, T &b) noexcept(std::is_nothrow_move_constructible_v<T>
+                              &&std::is_nothrow_move_assignable_v<T>)
 {
   T tmp = std::move(a);
   a = std::move(b);

--- a/src/kokkos_ext/ArborX_DetailsKokkosExtViewHelpers.hpp
+++ b/src/kokkos_ext/ArborX_DetailsKokkosExtViewHelpers.hpp
@@ -61,7 +61,7 @@ void reallocWithoutInitializing(ExecutionSpace const &space, View &v,
 
 template <class ExecutionSpace, class View>
 void reallocWithoutInitializing(ExecutionSpace const &space, View &v,
-                                const typename View::array_layout &layout)
+                                typename View::array_layout const &layout)
 {
   static_assert(Kokkos::is_execution_space<ExecutionSpace>::value);
   Kokkos::realloc(Kokkos::view_alloc(space, Kokkos::WithoutInitializing), v,

--- a/test/ArborX_BoostRangeAdapters.hpp
+++ b/test/ArborX_BoostRangeAdapters.hpp
@@ -38,8 +38,8 @@ struct range_iterator<Kokkos::View<T, P...>>
 {
   using View = Kokkos::View<T, P...>;
   ARBORX_ASSERT_VIEW_COMPATIBLE(View)
-  using type = typename std::add_pointer<
-      typename Kokkos::ViewTraits<T, P...>::value_type>::type;
+  using type =
+      std::add_pointer_t<typename Kokkos::ViewTraits<T, P...>::value_type>;
 };
 
 template <typename T, typename... P>
@@ -47,8 +47,8 @@ struct range_const_iterator<Kokkos::View<T, P...>>
 {
   using View = Kokkos::View<T, P...>;
   ARBORX_ASSERT_VIEW_COMPATIBLE(View)
-  using type = typename std::add_pointer<
-      typename Kokkos::ViewTraits<T, P...>::const_value_type>::type;
+  using type = std::add_pointer_t<
+      typename Kokkos::ViewTraits<T, P...>::const_value_type>;
 };
 
 template <typename T, typename... P>

--- a/test/ArborX_EnableViewComparison.hpp
+++ b/test/ArborX_EnableViewComparison.hpp
@@ -114,12 +114,13 @@ struct is_forward_iterable<Kokkos::View<T, P...>> : public boost::mpl::true_
 {
   // NOTE Prefer static assertion to SFINAE because error message about no
   // operator== for the operands is not as clear.
-  static_assert(Kokkos::View<T, P...>::rank == 1 &&
-                    !std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                                  Kokkos::LayoutStride>::value &&
-                    ArborX::Details::KokkosExt::is_accessible_from_host<
-                        Kokkos::View<T, P...>>::value,
-                "Restricted to contiguous rank-one host-accessible views");
+  static_assert(
+      Kokkos::View<T, P...>::rank == 1 &&
+          !std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                          Kokkos::LayoutStride> &&
+          ArborX::Details::KokkosExt::is_accessible_from_host<
+              Kokkos::View<T, P...>>::value,
+      "Restricted to contiguous rank-one host-accessible views");
 };
 
 template <typename T, typename... P>
@@ -128,7 +129,7 @@ struct bt_iterator_traits<Kokkos::View<T, P...>, true>
   using view_type = Kokkos::View<T, P...>;
   using value_type = typename view_type::value_type;
   using const_iterator =
-      typename std::add_pointer<typename view_type::const_value_type>::type;
+      std::add_pointer_t<typename view_type::const_value_type>;
   static const_iterator begin(view_type const &v) { return v.data(); }
   static const_iterator end(view_type const &v) { return v.data() + v.size(); }
   static std::size_t size(view_type const &v) { return v.size(); }

--- a/test/tstDetailsDistributedTreeImpl.cpp
+++ b/test/tstDetailsDistributedTreeImpl.cpp
@@ -193,10 +193,10 @@ inline void checkViewWasNotAllocated(View1 const &v1, View2 const &v2)
   BOOST_TEST(v1.span() == v2.span());
 
   BOOST_TEST((int)View1::rank == (int)View2::rank);
-  BOOST_TEST((std::is_same<typename View1::const_value_type,
-                           typename View2::const_value_type>::value));
-  BOOST_TEST((std::is_same<typename View1::memory_space,
-                           typename View2::memory_space>::value));
+  BOOST_TEST((std::is_same_v<typename View1::const_value_type,
+                           typename View2::const_value_type>));
+  BOOST_TEST((std::is_same_v<typename View1::memory_space,
+                           typename View2::memory_space>));
 
   BOOST_TEST(v1.extent(0) == v2.extent(0));
   BOOST_TEST(v1.extent(1) == v2.extent(1));
@@ -214,8 +214,8 @@ inline void checkNewViewWasAllocated(View1 const &v1, View2 const &v2)
   BOOST_TEST(v1.data() != v2.data());
 
   BOOST_TEST((int)View1::rank == (int)View2::rank);
-  BOOST_TEST((std::is_same<typename View1::const_value_type,
-                           typename View2::const_value_type>::value));
+  BOOST_TEST((std::is_same_v<typename View1::const_value_type,
+                           typename View2::const_value_type>));
 
   BOOST_TEST(v1.extent(0) == v2.extent(0));
   BOOST_TEST(v1.extent(1) == v2.extent(1));

--- a/test/tstDetailsDistributedTreeImpl.cpp
+++ b/test/tstDetailsDistributedTreeImpl.cpp
@@ -194,9 +194,9 @@ inline void checkViewWasNotAllocated(View1 const &v1, View2 const &v2)
 
   BOOST_TEST((int)View1::rank == (int)View2::rank);
   BOOST_TEST((std::is_same_v<typename View1::const_value_type,
-                           typename View2::const_value_type>));
+                             typename View2::const_value_type>));
   BOOST_TEST((std::is_same_v<typename View1::memory_space,
-                           typename View2::memory_space>));
+                             typename View2::memory_space>));
 
   BOOST_TEST(v1.extent(0) == v2.extent(0));
   BOOST_TEST(v1.extent(1) == v2.extent(1));
@@ -215,7 +215,7 @@ inline void checkNewViewWasAllocated(View1 const &v1, View2 const &v2)
 
   BOOST_TEST((int)View1::rank == (int)View2::rank);
   BOOST_TEST((std::is_same_v<typename View1::const_value_type,
-                           typename View2::const_value_type>));
+                             typename View2::const_value_type>));
 
   BOOST_TEST(v1.extent(0) == v2.extent(0));
   BOOST_TEST(v1.extent(1) == v2.extent(1));

--- a/test/tstMinimumSpanningTreeGoldenTest.cpp
+++ b/test/tstMinimumSpanningTreeGoldenTest.cpp
@@ -52,8 +52,8 @@ auto parsePointsFromCSVFile(std::string const &filename)
     Tokenizer tok(line);
     auto first = tok.begin();
     auto const last = tok.end();
-    points.emplace_back(ArborX::Point{std::stof(*first++), std::stof(*first++),
-                                      std::stof(*first++)});
+    points.emplace_back(std::stof(*first++), std::stof(*first++),
+                        std::stof(*first++));
     assert(first == last);
   }
   return points;

--- a/test/tstSequenceContainers.cpp
+++ b/test/tstSequenceContainers.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(non_owning_view_over_dynamic_array)
   //                        ^^^^ ^^^^ ^^^^
   UnmanagedStaticVector<float> a(data + 2, 3);
 
-  BOOST_TEST(!std::is_default_constructible<decltype(a)>::value);
+  BOOST_TEST(!std::is_default_constructible_v<decltype(a)>);
   BOOST_TEST(a.data() == data + 2);
 
   BOOST_TEST(a.empty());


### PR DESCRIPTION
We don't enforce `clang-tidy` warnings anymore and there are multiple complaints.
This pull request enforces warnings by turning them into errors and fixes the current warnings.