### PR TITLE
Fix label for AMD GPU in the CI

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -342,7 +342,7 @@ pipeline {
                             dir "docker"
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.3.3-complete --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES} --env AMDGPU_TARGET=${AMDGPU_TARGET}'
-                            label 'rocm-docker && vega'
+                            label 'rocm-docker && AMD_Radeon_Instinct_MI100'
                         }
                     }
                     steps {

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -335,12 +335,12 @@ pipeline {
                     }
                 }
 
-                stage('HIP-5.3.3') {
+                stage('HIP-5.6') {
                     agent {
                         dockerfile {
                             filename "Dockerfile.hipcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.3.3-complete --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.6 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES} --env AMDGPU_TARGET=${AMDGPU_TARGET}'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI100'
                         }

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -90,8 +90,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 
 # Install Kokkos
 ARG KOKKOS_VERSION=4.2.00
-ARG KOKKOS_ARCH=Kokkos_ARCH_VEGA906
-ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_OPENMP=ON -D${KOKKOS_ARCH}=ON"
+ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_OPENMP=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
     KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -1,4 +1,4 @@
-ARG BASE=rocm/dev-ubuntu-20.04:5.3.3-complete
+ARG BASE=rocm/dev-ubuntu-20.04:5.6
 FROM $BASE
 
 ARG NPROCS=4

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -85,7 +85,10 @@ public:
         std::forward<View>(view), std::forward<Args>(args)...);
   }
 
-  auto const &indexable_get() const { return _indexable_getter; }
+  KOKKOS_FUNCTION auto const &indexable_get() const
+  {
+    return _indexable_getter;
+  }
 
 private:
   size_type _size{0};

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -121,7 +121,10 @@ public:
     tree_traversal(predicate);
   }
 
-  auto const &indexable_get() const { return _indexable_getter; }
+  KOKKOS_FUNCTION auto const &indexable_get() const
+  {
+    return _indexable_getter;
+  }
 
 private:
   friend struct Details::HappyTreeFriends;

--- a/test/tstInterpDetailsMLSCoefficients.cpp
+++ b/test/tstInterpDetailsMLSCoefficients.cpp
@@ -45,6 +45,11 @@ interpolate(ExecutionSpace const &space, SourceValues const &source_values,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 {
+  // FIXME_HIP: the CI fails with:
+  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
+  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
+  // HIP > could not find a valid team size.
+  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
 #ifdef KOKKOS_ENABLE_HIP
   if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
   {
@@ -132,6 +137,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  // FIXME_HIP: the CI fails with:
+  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
+  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
+  // HIP > could not find a valid team size.
+  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
 #ifdef KOKKOS_ENABLE_HIP
   if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
   {

--- a/test/tstInterpDetailsMLSCoefficients.cpp
+++ b/test/tstInterpDetailsMLSCoefficients.cpp
@@ -17,6 +17,8 @@
 #include "BoostTest_CUDA_clang_workarounds.hpp"
 #include <boost/test/unit_test.hpp>
 
+#include <type_traits>
+
 template <typename ExecutionSpace, typename SourceValues, typename Coefficients>
 Kokkos::View<double *, typename SourceValues::memory_space>
 interpolate(ExecutionSpace const &space, SourceValues const &source_values,
@@ -43,6 +45,12 @@ interpolate(ExecutionSpace const &space, SourceValues const &source_values,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 {
+#ifdef KOKKOS_ENABLE_HIP
+  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
+  {
+    return;
+  }
+#endif
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};
@@ -124,6 +132,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+#ifdef KOKKOS_ENABLE_HIP
+  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
+  {
+    return;
+  }
+#endif
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};

--- a/test/tstInterpMovingLeastSquares.cpp
+++ b/test/tstInterpMovingLeastSquares.cpp
@@ -21,6 +21,11 @@
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  // FIXME_HIP: the CI fails with:
+  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
+  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
+  // HIP > could not find a valid team size.
+  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
 #ifdef KOKKOS_ENABLE_HIP
   if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
   {
@@ -106,6 +111,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+  // FIXME_HIP: the CI fails with:
+  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
+  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
+  // HIP > could not find a valid team size.
+  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
 #ifdef KOKKOS_ENABLE_HIP
   if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
   {

--- a/test/tstInterpMovingLeastSquares.cpp
+++ b/test/tstInterpMovingLeastSquares.cpp
@@ -21,6 +21,13 @@
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+#ifdef KOKKOS_ENABLE_HIP
+  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
+  {
+    return;
+  }
+#endif
+
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};
@@ -99,6 +106,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
+#ifdef KOKKOS_ENABLE_HIP
+  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
+  {
+    return;
+  }
+#endif
+
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};


### PR DESCRIPTION
- I bumped the HIP version from 5.3 to 5.6. There was a strange permission issue with ROCm 5.3 I don't understand why we have this problem but a quick google search told me that ROCm 5.5 fixed the issue. I bumped to ROCm 5.6 because that's why we use for Kokkos.
- I added missing `KOKKOS_FUNCTION`
- We still have an issue because the new MLS tests do not pass (`fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_ Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce< HIP > could not find a valid team size.`). The issue seems similar to the problem we have in Kokkos with the memory requirement tests. Disabling these for now.