### PR TITLE
Remove min version requirement for rocThrust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,7 @@ add_dependencies(ArborX record_hash)
 include(CMakeDependentOption)
 cmake_dependent_option(ARBORX_ENABLE_ROCTHRUST "Enable rocThrust support" ON "Kokkos_ENABLE_HIP" OFF)
 if(Kokkos_ENABLE_HIP AND ARBORX_ENABLE_ROCTHRUST)
-  # Require at least rocThrust-2.10.5 (that comes with ROCm 3.9) because
-  # rocPRIM dependency is not set properly in exported configuration for
-  # earlier versions
-  find_package(rocthrust 2.10.5 REQUIRED CONFIG)
+  find_package(rocthrust REQUIRED CONFIG)
   target_link_libraries(ArborX INTERFACE roc::rocthrust)
 endif()
 


### PR DESCRIPTION
The min version requirement was introduced in ROCm 3.9 days. We now depend on Kokkos 4, which requires ROCm 5.2, which comes with rocThrust 2.15.

The presence of the version requirement also breaks compiling with ROCm 6, as rocThrust has `SameMajorVersion` CMake compatibility mode instead of `AnyNewerVersion`, and rocThrust coming with ROCm 6 has version 3.x.

Fix #1028.