### PR TITLE
Include ArborX_Version.hpp in ArborX.hpp

### DIFF
--- a/src/ArborX.hpp
+++ b/src/ArborX.hpp
@@ -16,6 +16,7 @@
 
 #include <ArborX_Box.hpp>
 #include <ArborX_BruteForce.hpp>
+#include <ArborX_Version.hpp>
 #ifdef ARBORX_ENABLE_MPI
 #include <ArborX_DistributedTree.hpp>
 #endif


### PR DESCRIPTION
It is expected that 
```c++
#include <ArborX.hpp>

int main()
{
  std::cout << ArborX::version() << std::endl;
  return 0;
}
```
should work. Not including `ArborX_Version.hpp` into `ArborX.hpp` was an oversight.