### PR TITLE
Update code to use tag_t, coordinate_t, is_<geometry>_v

### DIFF
--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -309,7 +309,7 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   Points points{primitives}; // NOLINT
 
   using Point = typename Points::value_type;
-  static_assert(GeometryTraits::is_point<Point>{});
+  static_assert(GeometryTraits::is_point_v<Point>);
 
   ArborX::BoundingVolumeHierarchy<MemorySpace, ArborX::PairValueIndex<Point>>
       bvh(exec_space, ArborX::Experimental::attach_indices(points));

--- a/benchmarks/point_clouds/point_clouds.hpp
+++ b/benchmarks/point_clouds/point_clouds.hpp
@@ -174,7 +174,7 @@ void generatePointCloud(PointCloudType const point_cloud_type,
 {
   using namespace ArborX::GeometryTraits;
   check_valid_geometry_traits(Point{});
-  static_assert(is_point<Point>{}, "ArborX: View must contain point values");
+  static_assert(is_point_v<Point>, "ArborX: View must contain point values");
 
   auto random_points_host = Kokkos::create_mirror_view(random_points);
   switch (point_cloud_type)

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -27,14 +27,14 @@
 namespace ArborX
 {
 
-template <
-    typename MemorySpace, typename Value = Details::LegacyDefaultTemplateValue,
-    typename IndexableGetter = Details::DefaultIndexableGetter,
-    typename BoundingVolume = ExperimentalHyperGeometry::Box<
-        GeometryTraits::dimension_v<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
-        typename GeometryTraits::coordinate_type<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>::type>>
+template <typename MemorySpace,
+          typename Value = Details::LegacyDefaultTemplateValue,
+          typename IndexableGetter = Details::DefaultIndexableGetter,
+          typename BoundingVolume = ExperimentalHyperGeometry::Box<
+              GeometryTraits::dimension_v<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
+              typename GeometryTraits::coordinate_type_t<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>>>
 class BruteForce
 {
 public:

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -66,7 +66,7 @@ struct WithinRadiusGetter
   template <typename Point>
   KOKKOS_FUNCTION auto operator()(Point const &point) const
   {
-    static_assert(GeometryTraits::is_point<Point>::value);
+    static_assert(GeometryTraits::is_point_v<Point>);
 
     constexpr int dim = GeometryTraits::dimension_v<Point>;
     auto const &hyper_point =
@@ -263,7 +263,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
 #endif
 
   using Point = typename Points::value_type;
-  static_assert(GeometryTraits::is_point<Point>{});
+  static_assert(GeometryTraits::is_point_v<Point>);
   constexpr int dim = GeometryTraits::dimension_v<Point>;
   using Box = ExperimentalHyperGeometry::Box<dim>;
 

--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -116,14 +116,14 @@ private:
 
 // NOTE: query() must be called as collective over all processes in the
 // communicator passed to the constructor
-template <
-    typename MemorySpace, typename Value = Details::LegacyDefaultTemplateValue,
-    typename IndexableGetter = Details::DefaultIndexableGetter,
-    typename BoundingVolume = ExperimentalHyperGeometry::Box<
-        GeometryTraits::dimension_v<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
-        typename GeometryTraits::coordinate_type<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>::type>>
+template <typename MemorySpace,
+          typename Value = Details::LegacyDefaultTemplateValue,
+          typename IndexableGetter = Details::DefaultIndexableGetter,
+          typename BoundingVolume = ExperimentalHyperGeometry::Box<
+              GeometryTraits::dimension_v<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
+              typename GeometryTraits::coordinate_type_t<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>>>
 class DistributedTree
     : public DistributedTreeBase<BoundingVolumeHierarchy<
           MemorySpace, Value, IndexableGetter, BoundingVolume>>

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -47,14 +47,14 @@ namespace Details
 struct HappyTreeFriends;
 } // namespace Details
 
-template <
-    typename MemorySpace, typename Value = Details::LegacyDefaultTemplateValue,
-    typename IndexableGetter = Details::DefaultIndexableGetter,
-    typename BoundingVolume = ExperimentalHyperGeometry::Box<
-        GeometryTraits::dimension_v<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
-        typename GeometryTraits::coordinate_type<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>::type>>
+template <typename MemorySpace,
+          typename Value = Details::LegacyDefaultTemplateValue,
+          typename IndexableGetter = Details::DefaultIndexableGetter,
+          typename BoundingVolume = ExperimentalHyperGeometry::Box<
+              GeometryTraits::dimension_v<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
+              typename GeometryTraits::coordinate_type_t<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>>>
 class BoundingVolumeHierarchy
 {
 public:
@@ -235,14 +235,14 @@ public:
   }
 };
 
-template <
-    typename MemorySpace, typename Value = Details::LegacyDefaultTemplateValue,
-    typename IndexableGetter = Details::DefaultIndexableGetter,
-    typename BoundingVolume = ExperimentalHyperGeometry::Box<
-        GeometryTraits::dimension_v<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
-        typename GeometryTraits::coordinate_type<
-            std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>::type>>
+template <typename MemorySpace,
+          typename Value = Details::LegacyDefaultTemplateValue,
+          typename IndexableGetter = Details::DefaultIndexableGetter,
+          typename BoundingVolume = ExperimentalHyperGeometry::Box<
+              GeometryTraits::dimension_v<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>,
+              typename GeometryTraits::coordinate_type_t<
+                  std::decay_t<std::invoke_result_t<IndexableGetter, Value>>>>>
 using BVH = BoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter,
                                     BoundingVolume>;
 
@@ -304,7 +304,7 @@ BoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter, BoundingVolume>::
 
   // determine the bounding box of the scene
   ExperimentalHyperGeometry::Box<
-      DIM, typename GeometryTraits::coordinate_type<BoundingVolume>::type>
+      DIM, typename GeometryTraits::coordinate_type_t<BoundingVolume>>
       bbox{};
   Details::TreeConstruction::calculateBoundingBoxOfTheScene(space, indexables,
                                                             bbox);
@@ -389,7 +389,7 @@ void BoundingVolumeHierarchy<
     using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
     ExperimentalHyperGeometry::Box<
         GeometryTraits::dimension_v<bounding_volume_type>,
-        typename GeometryTraits::coordinate_type<bounding_volume_type>::type>
+        typename GeometryTraits::coordinate_type_t<bounding_volume_type>>
         scene_bounding_box{};
     using namespace Details;
     expand(scene_bounding_box, bounds());

--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -183,7 +183,7 @@ void check_valid_access_traits(PrimitivesTag, Primitives const &,
                                             Access, Primitives>>;
   if constexpr (CheckGetReturnType())
   {
-    static_assert(GeometryTraits::is_point<T>{} || GeometryTraits::is_box<T>{},
+    static_assert(GeometryTraits::is_point_v<T> || GeometryTraits::is_box_v<T>,
                   "AccessTraits<Primitives,PrimitivesTag>::get() return type "
                   "must decay to a point or a box type");
   }

--- a/src/details/ArborX_DetailsCartesianGrid.hpp
+++ b/src/details/ArborX_DetailsCartesianGrid.hpp
@@ -56,7 +56,7 @@ public:
   }
 
   template <typename Point, typename Enable = std::enable_if_t<
-                                GeometryTraits::is_point<Point>{}>>
+                                GeometryTraits::is_point_v<Point>>>
   KOKKOS_FUNCTION size_t cellIndex(Point const &point) const
   {
     static_assert(GeometryTraits::dimension_v<Point> == DIM);

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -387,7 +387,7 @@ queryDispatch(Tag, Tree const &tree, ExecutionSpace const &space,
     using bounding_volume_type = std::decay_t<decltype(tree.bounds())>;
     ExperimentalHyperGeometry::Box<
         GeometryTraits::dimension_v<bounding_volume_type>,
-        typename GeometryTraits::coordinate_type<bounding_volume_type>::type>
+        typename GeometryTraits::coordinate_type_t<bounding_volume_type>>
         scene_bounding_box{};
     using namespace Details;
     expand(scene_bounding_box, tree.bounds());

--- a/src/details/ArborX_DetailsMortonCode.hpp
+++ b/src/details/ArborX_DetailsMortonCode.hpp
@@ -283,7 +283,7 @@ KOKKOS_INLINE_FUNCTION unsigned long long expandBitsBy<9>(unsigned long long x)
 }
 
 template <typename Point,
-          typename Enable = std::enable_if_t<GeometryTraits::is_point<Point>{}>>
+          typename Enable = std::enable_if_t<GeometryTraits::is_point_v<Point>>>
 KOKKOS_INLINE_FUNCTION unsigned int morton32(Point const &p)
 {
   constexpr int DIM = GeometryTraits::dimension_v<Point>;
@@ -303,7 +303,7 @@ KOKKOS_INLINE_FUNCTION unsigned int morton32(Point const &p)
 }
 
 template <typename Point,
-          std::enable_if_t<GeometryTraits::is_point<Point>{} &&
+          std::enable_if_t<GeometryTraits::is_point_v<Point> &&
                            GeometryTraits::dimension_v<Point> != 2> * = nullptr>
 KOKKOS_INLINE_FUNCTION unsigned long long morton64(Point const &p)
 {
@@ -326,7 +326,7 @@ KOKKOS_INLINE_FUNCTION unsigned long long morton64(Point const &p)
 // Calculate a 62-bit Morton code for a 2D point located within [0, 1]^2.
 // Special case because it needs double.
 template <typename Point,
-          std::enable_if_t<GeometryTraits::is_point<Point>{} &&
+          std::enable_if_t<GeometryTraits::is_point_v<Point> &&
                            GeometryTraits::dimension_v<Point> == 2> * = nullptr>
 KOKKOS_INLINE_FUNCTION unsigned long long morton64(Point const &p)
 {

--- a/src/details/ArborX_IndexableGetter.hpp
+++ b/src/details/ArborX_IndexableGetter.hpp
@@ -25,8 +25,8 @@ struct DefaultIndexableGetter
   DefaultIndexableGetter() = default;
 
   template <typename Geometry, typename Enable = std::enable_if_t<
-                                   GeometryTraits::is_point<Geometry>{} ||
-                                   GeometryTraits::is_box<Geometry>{}>>
+                                   GeometryTraits::is_point_v<Geometry> ||
+                                   GeometryTraits::is_box_v<Geometry>>>
   KOKKOS_FUNCTION auto const &operator()(Geometry const &geometry) const
   {
     return geometry;

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -50,7 +50,7 @@ struct MinimumSpanningTree
 
     using Points = Details::AccessValues<Primitives, PrimitivesTag>;
     using Point = typename Points::value_type;
-    static_assert(GeometryTraits::is_point<Point>{});
+    static_assert(GeometryTraits::is_point_v<Point>);
 
     Points points{primitives}; // NOLINT
 

--- a/src/details/ArborX_NeighborList.hpp
+++ b/src/details/ArborX_NeighborList.hpp
@@ -34,7 +34,7 @@ struct NeighborListPredicateGetter
     static_assert(GeometryTraits::is_point<Point>{});
 
     constexpr int dim = GeometryTraits::dimension_v<Point>;
-    using Coordinate = typename GeometryTraits::coordinate_type<Point>::type;
+    using Coordinate = typename GeometryTraits::coordinate_type_t<Point>;
 
     auto const &hyper_point = reinterpret_cast<
         ExperimentalHyperGeometry::Point<dim, Coordinate> const &>(point);

--- a/src/details/ArborX_NeighborList.hpp
+++ b/src/details/ArborX_NeighborList.hpp
@@ -31,7 +31,7 @@ struct NeighborListPredicateGetter
   template <typename Point>
   KOKKOS_FUNCTION auto operator()(Point point) const
   {
-    static_assert(GeometryTraits::is_point<Point>{});
+    static_assert(GeometryTraits::is_point_v<Point>);
 
     constexpr int dim = GeometryTraits::dimension_v<Point>;
     using Coordinate = typename GeometryTraits::coordinate_type_t<Point>;
@@ -61,7 +61,7 @@ void findHalfNeighborList(ExecutionSpace const &space,
       "Primitives must be accessible from the execution space");
 
   using Point = typename Points::value_type;
-  static_assert(GeometryTraits::is_point<Point>{});
+  static_assert(GeometryTraits::is_point_v<Point>);
 
   Points points{primitives}; // NOLINT
   int const n = points.size();
@@ -117,7 +117,7 @@ void findFullNeighborList(ExecutionSpace const &space,
       "Primitives must be accessible from the execution space");
 
   using Point = typename Points::value_type;
-  static_assert(GeometryTraits::is_point<Point>{});
+  static_assert(GeometryTraits::is_point_v<Point>);
 
   Points points{primitives}; // NOLINT
   int const n = points.size();

--- a/src/details/ArborX_SpaceFillingCurves.hpp
+++ b/src/details/ArborX_SpaceFillingCurves.hpp
@@ -30,16 +30,16 @@ namespace Experimental
 struct Morton32
 {
   template <typename Box, typename Point,
-            std::enable_if_t<GeometryTraits::is_box<Box>{} &&
-                             GeometryTraits::is_point<Point>{}> * = nullptr>
+            std::enable_if_t<GeometryTraits::is_box_v<Box> &&
+                             GeometryTraits::is_point_v<Point>> * = nullptr>
   KOKKOS_FUNCTION auto operator()(Box const &scene_bounding_box, Point p) const
   {
     Details::translateAndScale(p, p, scene_bounding_box);
     return Details::morton32(p);
   }
   template <typename Box, typename Geometry,
-            std::enable_if_t<GeometryTraits::is_box<Box>{} &&
-                             !GeometryTraits::is_point<Geometry>{}> * = nullptr>
+            std::enable_if_t<GeometryTraits::is_box_v<Box> &&
+                             !GeometryTraits::is_point_v<Geometry>> * = nullptr>
   KOKKOS_FUNCTION auto operator()(Box const &scene_bounding_box,
                                   Geometry const &geometry) const
   {
@@ -52,16 +52,16 @@ struct Morton32
 struct Morton64
 {
   template <typename Box, typename Point,
-            std::enable_if_t<GeometryTraits::is_box<Box>{} &&
-                             GeometryTraits::is_point<Point>{}> * = nullptr>
+            std::enable_if_t<GeometryTraits::is_box_v<Box> &&
+                             GeometryTraits::is_point_v<Point>> * = nullptr>
   KOKKOS_FUNCTION auto operator()(Box const &scene_bounding_box, Point p) const
   {
     Details::translateAndScale(p, p, scene_bounding_box);
     return Details::morton64(p);
   }
   template <typename Box, class Geometry,
-            std::enable_if_t<GeometryTraits::is_box<Box>{} &&
-                             !GeometryTraits::is_point<Geometry>{}> * = nullptr>
+            std::enable_if_t<GeometryTraits::is_box_v<Box> &&
+                             !GeometryTraits::is_point_v<Geometry>> * = nullptr>
   KOKKOS_FUNCTION auto operator()(Box const &scene_bounding_box,
                                   Geometry const &geometry) const
   {

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -61,14 +61,14 @@ template <typename Geometry>
 KOKKOS_INLINE_FUNCTION constexpr bool equals(Geometry const &l,
                                              Geometry const &r)
 {
-  return Dispatch::equals<typename GeometryTraits::tag<Geometry>::type,
+  return Dispatch::equals<typename GeometryTraits::tag_t<Geometry>,
                           Geometry>::apply(l, r);
 }
 
 template <typename Geometry>
 KOKKOS_INLINE_FUNCTION constexpr bool isValid(Geometry const &geometry)
 {
-  return Dispatch::isValid<typename GeometryTraits::tag<Geometry>::type,
+  return Dispatch::isValid<typename GeometryTraits::tag_t<Geometry>,
                            Geometry>::apply(geometry);
 }
 
@@ -78,8 +78,8 @@ KOKKOS_INLINE_FUNCTION auto distance(Geometry1 const &geometry1,
 {
   static_assert(GeometryTraits::dimension_v<Geometry1> ==
                 GeometryTraits::dimension_v<Geometry2>);
-  return Dispatch::distance<typename GeometryTraits::tag<Geometry1>::type,
-                            typename GeometryTraits::tag<Geometry2>::type,
+  return Dispatch::distance<typename GeometryTraits::tag_t<Geometry1>,
+                            typename GeometryTraits::tag_t<Geometry2>,
                             Geometry1, Geometry2>::apply(geometry1, geometry2);
 }
 
@@ -89,8 +89,8 @@ KOKKOS_INLINE_FUNCTION void expand(Geometry1 &geometry1,
 {
   static_assert(GeometryTraits::dimension_v<Geometry1> ==
                 GeometryTraits::dimension_v<Geometry2>);
-  Dispatch::expand<typename GeometryTraits::tag<Geometry1>::type,
-                   typename GeometryTraits::tag<Geometry2>::type, Geometry1,
+  Dispatch::expand<typename GeometryTraits::tag_t<Geometry1>,
+                   typename GeometryTraits::tag_t<Geometry2>, Geometry1,
                    Geometry2>::apply(geometry1, geometry2);
 }
 
@@ -100,8 +100,8 @@ KOKKOS_INLINE_FUNCTION constexpr bool intersects(Geometry1 const &geometry1,
 {
   static_assert(GeometryTraits::dimension_v<Geometry1> ==
                 GeometryTraits::dimension_v<Geometry2>);
-  return Dispatch::intersects<typename GeometryTraits::tag<Geometry1>::type,
-                              typename GeometryTraits::tag<Geometry2>::type,
+  return Dispatch::intersects<typename GeometryTraits::tag_t<Geometry1>,
+                              typename GeometryTraits::tag_t<Geometry2>,
                               Geometry1, Geometry2>::apply(geometry1,
                                                            geometry2);
 }
@@ -109,7 +109,7 @@ KOKKOS_INLINE_FUNCTION constexpr bool intersects(Geometry1 const &geometry1,
 template <typename Geometry>
 KOKKOS_INLINE_FUNCTION decltype(auto) returnCentroid(Geometry const &geometry)
 {
-  return Dispatch::centroid<typename GeometryTraits::tag<Geometry>::type,
+  return Dispatch::centroid<typename GeometryTraits::tag_t<Geometry>,
                             Geometry>::apply(geometry);
 }
 
@@ -437,7 +437,7 @@ struct intersects<PointTag, TriangleTag, Point, Triangle>
     auto const &b = triangle.b;
     auto const &c = triangle.c;
 
-    using Float = typename GeometryTraits::coordinate_type<Point>::type;
+    using Float = typename GeometryTraits::coordinate_type_t<Point>;
 
     // Find coefficients alpha and beta such that
     // x = a + alpha * (b - a) + beta * (c - a)

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -512,8 +512,8 @@ struct centroid<TriangleTag, Triangle>
 // transformation that maps the unit cube into a new axis-aligned box
 // NOTE safe to perform in-place
 template <typename Point, typename Box,
-          std::enable_if_t<GeometryTraits::is_point<Point>{} &&
-                           GeometryTraits::is_box<Box>{}> * = nullptr>
+          std::enable_if_t<GeometryTraits::is_point_v<Point> &&
+                           GeometryTraits::is_box_v<Box>> * = nullptr>
 KOKKOS_FUNCTION void translateAndScale(Point const &in, Point &out,
                                        Box const &ref)
 {

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -62,7 +62,7 @@ DEFINE_GEOMETRY(sphere, SphereTag);
 DEFINE_GEOMETRY(triangle, TriangleTag);
 DEFINE_GEOMETRY(kdop, KDOPTag);
 DEFINE_GEOMETRY(ray, RayTag);
-#undef IS_GEOMETRY
+#undef DEFINE_GEOMETRY
 
 template <typename Geometry>
 inline constexpr bool

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -52,12 +52,16 @@ struct tag
 {
   using type = not_specialized;
 };
+template <typename Geometry>
+using tag_t = typename tag<Geometry>::type;
 
 template <typename Geometry>
 struct coordinate_type
 {
   using type = not_specialized;
 };
+template <typename Geometry>
+using coordinate_type_t = typename coordinate_type<Geometry>::type;
 
 template <typename Geometry>
 using DimensionNotSpecializedArchetypeAlias =
@@ -111,7 +115,7 @@ void check_valid_geometry_traits(Geometry const &)
           GeometryTraits::dimension_v<Geometry> > 0,
       "GeometryTraits::dimension<Geometry>::value must be a positive integral");
 
-  static_assert(!std::is_same_v<typename tag<Geometry>::type, not_specialized>,
+  static_assert(!std::is_same_v<tag_t<Geometry>, not_specialized>,
                 "GeometryTraits::tag<Geometry> must define 'type' member type");
   using Tag = typename tag<Geometry>::type;
   static_assert(std::is_same<Tag, PointTag>{} || std::is_same<Tag, BoxTag>{} ||
@@ -121,11 +125,10 @@ void check_valid_geometry_traits(Geometry const &)
                 "GeometryTraits::tag<Geometry>::type must be PointTag, BoxTag, "
                 "SphereTag, TriangleTag or KDOPTag");
 
-  static_assert(!std::is_same_v<typename coordinate_type<Geometry>::type,
-                                not_specialized>,
+  static_assert(!std::is_same_v<coordinate_type_t<Geometry>, not_specialized>,
                 "GeometryTraits::coordinate_type<Geometry> must define 'type' "
                 "member type");
-  using Coordinate = typename coordinate_type<Geometry>::type;
+  using Coordinate = coordinate_type_t<Geometry>;
   static_assert(
       std::is_arithmetic_v<Coordinate>,
       "GeometryTraits::coordinate_type<Geometry> must be an arithmetic type");

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -61,13 +61,14 @@ DEFINE_GEOMETRY(box, BoxTag);
 DEFINE_GEOMETRY(sphere, SphereTag);
 DEFINE_GEOMETRY(triangle, TriangleTag);
 DEFINE_GEOMETRY(kdop, KDOPTag);
+DEFINE_GEOMETRY(ray, RayTag);
 #undef IS_GEOMETRY
 
 template <typename Geometry>
 inline constexpr bool
     is_valid_geometry = (is_point_v<Geometry> || is_box_v<Geometry> ||
                          is_sphere_v<Geometry> || is_kdop_v<Geometry> ||
-                         is_triangle_v<Geometry>);
+                         is_triangle_v<Geometry> || is_ray_v<Geometry>);
 
 template <typename Geometry>
 using DimensionNotSpecializedArchetypeAlias =
@@ -109,7 +110,7 @@ void check_valid_geometry_traits(Geometry const &)
                 "GeometryTraits::tag<Geometry> must define 'type' member type");
   static_assert(is_valid_geometry<Geometry>,
                 "GeometryTraits::tag<Geometry>::type must be PointTag, BoxTag, "
-                "SphereTag, TriangleTag or KDOPTag");
+                "SphereTag, TriangleTag, KDOPTag, or RayTag");
 
   static_assert(!std::is_same_v<coordinate_type_t<Geometry>, not_specialized>,
                 "GeometryTraits::coordinate_type<Geometry> must define 'type' "

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -20,27 +20,11 @@ namespace ArborX
 namespace GeometryTraits
 {
 
-struct PointTag
-{};
-
-struct BoxTag
-{};
-
-struct SphereTag
-{};
-
-struct TriangleTag
-{};
-
-struct KDOPTag
-{};
-
 template <typename Geometry>
 struct dimension
 {
   using not_specialized = void; // tag to detect existence of a specialization
 };
-
 template <typename Geometry>
 inline constexpr int dimension_v = dimension<Geometry>::value;
 
@@ -63,6 +47,28 @@ struct coordinate_type
 template <typename Geometry>
 using coordinate_type_t = typename coordinate_type<Geometry>::type;
 
+// clang-format off
+#define DEFINE_GEOMETRY(name, name_tag)                                        \
+  struct name_tag{};                                                           \
+  template <typename Geometry>                                                 \
+  struct is_##name : std::is_same<tag_t<Geometry>, name_tag>{};              \
+  template <typename Geometry>                                                 \
+  inline constexpr bool is_##name##_v = is_##name<Geometry>::value
+// clang-format on
+
+DEFINE_GEOMETRY(point, PointTag);
+DEFINE_GEOMETRY(box, BoxTag);
+DEFINE_GEOMETRY(sphere, SphereTag);
+DEFINE_GEOMETRY(triangle, TriangleTag);
+DEFINE_GEOMETRY(kdop, KDOPTag);
+#undef IS_GEOMETRY
+
+template <typename Geometry>
+inline constexpr bool
+    is_valid_geometry = (is_point_v<Geometry> || is_box_v<Geometry> ||
+                         is_sphere_v<Geometry> || is_kdop_v<Geometry> ||
+                         is_triangle_v<Geometry>);
+
 template <typename Geometry>
 using DimensionNotSpecializedArchetypeAlias =
     typename dimension<Geometry>::not_specialized;
@@ -76,22 +82,6 @@ using CoordinateNotSpecializedArchetypeAlias =
 
 template <typename Geometry>
 using DimensionArchetypeAlias = decltype(dimension_v<Geometry>);
-
-template <typename Geometry>
-struct is_point : std::is_same<typename tag<Geometry>::type, PointTag>
-{};
-
-template <typename Geometry>
-struct is_box : std::is_same<typename tag<Geometry>::type, BoxTag>
-{};
-
-template <typename Geometry>
-struct is_sphere : std::is_same<typename tag<Geometry>::type, SphereTag>
-{};
-
-template <typename Geometry>
-struct is_triangle : std::is_same<typename tag<Geometry>::type, TriangleTag>
-{};
 
 template <typename Geometry>
 void check_valid_geometry_traits(Geometry const &)
@@ -117,11 +107,7 @@ void check_valid_geometry_traits(Geometry const &)
 
   static_assert(!std::is_same_v<tag_t<Geometry>, not_specialized>,
                 "GeometryTraits::tag<Geometry> must define 'type' member type");
-  using Tag = typename tag<Geometry>::type;
-  static_assert(std::is_same<Tag, PointTag>{} || std::is_same<Tag, BoxTag>{} ||
-                    std::is_same<Tag, SphereTag>{} ||
-                    std::is_same<Tag, TriangleTag>{} ||
-                    std::is_same<Tag, KDOPTag>{},
+  static_assert(is_valid_geometry<Geometry>,
                 "GeometryTraits::tag<Geometry>::type must be PointTag, BoxTag, "
                 "SphereTag, TriangleTag or KDOPTag");
 

--- a/src/geometry/ArborX_HyperBox.hpp
+++ b/src/geometry/ArborX_HyperBox.hpp
@@ -80,7 +80,7 @@ struct Box
   }
 
   template <typename Point,
-            std::enable_if_t<GeometryTraits::is_point<Point>{}> * = nullptr>
+            std::enable_if_t<GeometryTraits::is_point_v<Point>> * = nullptr>
   KOKKOS_FUNCTION auto &operator+=(Point const &point)
   {
     using Details::KokkosExt::max;

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -28,9 +28,7 @@
 
 #include <cmath>
 
-namespace ArborX
-{
-namespace Experimental
+namespace ArborX::Experimental
 {
 
 struct Vector : private Point
@@ -586,6 +584,22 @@ KOKKOS_INLINE_FUNCTION float overlapDistance(Ray const &ray,
   return length;
 }
 
-} // namespace Experimental
-} // namespace ArborX
+} // namespace ArborX::Experimental
+
+template <>
+struct ArborX::GeometryTraits::dimension<ArborX::Experimental::Ray>
+{
+  static constexpr int value = 3;
+};
+template <>
+struct ArborX::GeometryTraits::tag<ArborX::Experimental::Ray>
+{
+  using type = RayTag;
+};
+template <>
+struct ArborX::GeometryTraits::coordinate_type<ArborX::Experimental::Ray>
+{
+  using type = float;
+};
+
 #endif

--- a/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
+++ b/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
@@ -121,7 +121,7 @@ public:
         "Source points must be accessible from the execution space");
     using SourcePoint = typename SourceAccess::value_type;
     GeometryTraits::check_valid_geometry_traits(SourcePoint{});
-    static_assert(GeometryTraits::is_point<SourcePoint>::value,
+    static_assert(GeometryTraits::is_point_v<SourcePoint>,
                   "Source points elements must be points");
     static constexpr int dimension = GeometryTraits::dimension_v<SourcePoint>;
 
@@ -135,7 +135,7 @@ public:
         "Target points must be accessible from the execution space");
     using TargetPoint = typename TargetAccess::value_type;
     GeometryTraits::check_valid_geometry_traits(TargetPoint{});
-    static_assert(GeometryTraits::is_point<TargetPoint>::value,
+    static_assert(GeometryTraits::is_point_v<TargetPoint>,
                   "Target points elements must be points");
     static_assert(dimension == GeometryTraits::dimension_v<TargetPoint>,
                   "Target and source points must have the same dimension");

--- a/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -98,7 +98,7 @@ CRBF_DEF(Buhmann, 4,
 template <typename CRBFunc, typename Point>
 KOKKOS_INLINE_FUNCTION constexpr auto
 evaluate(Point const &point,
-         typename GeometryTraits::coordinate_type<Point>::type const radius)
+         typename GeometryTraits::coordinate_type_t<Point> const radius)
 {
   static_assert(GeometryTraits::is_point<Point>::value,
                 "point must be a point");

--- a/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsCompactRadialBasisFunction.hpp
@@ -100,8 +100,7 @@ KOKKOS_INLINE_FUNCTION constexpr auto
 evaluate(Point const &point,
          typename GeometryTraits::coordinate_type_t<Point> const radius)
 {
-  static_assert(GeometryTraits::is_point<Point>::value,
-                "point must be a point");
+  static_assert(GeometryTraits::is_point_v<Point>, "Point must be a point");
   constexpr std::size_t dim = GeometryTraits::dimension_v<Point>;
   return CRBFunc::template evaluate<dim>(
       ArborX::Details::distance(point, Point{}) / radius);

--- a/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -107,7 +107,7 @@ KOKKOS_FUNCTION auto evaluatePolynomialBasis(Point const &p)
   static_assert(GeometryTraits::is_point<Point>::value,
                 "point must be a point");
   static constexpr std::size_t DIM = GeometryTraits::dimension_v<Point>;
-  using Value = typename GeometryTraits::coordinate_type<Point>::type;
+  using Value = typename GeometryTraits::coordinate_type_t<Point>;
   static_assert(DIM > 0, "Polynomial basis with no dimension is invalid");
 
   Kokkos::Array<Value, polynomialBasisSize<DIM, Degree>()> arr{};

--- a/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -104,8 +104,7 @@ KOKKOS_FUNCTION constexpr std::size_t polynomialBasisSize()
 template <std::size_t Degree, typename Point>
 KOKKOS_FUNCTION auto evaluatePolynomialBasis(Point const &p)
 {
-  static_assert(GeometryTraits::is_point<Point>::value,
-                "point must be a point");
+  static_assert(GeometryTraits::is_point_v<Point>, "Point must be a point");
   static constexpr std::size_t DIM = GeometryTraits::dimension_v<Point>;
   using Value = typename GeometryTraits::coordinate_type_t<Point>;
   static_assert(DIM > 0, "Polynomial basis with no dimension is invalid");


### PR DESCRIPTION
I know this patch is noisy. Still, I'd like to get it in.

- Provide `is_<geometry>_v` helpers to avoid `is_<geometry>::value_type`
- Provide `coordinate_type_t<geometry>` helpers to avoid `coordinate_type<geometry>::type`
- Provide `is_valid_geometry`
- Provide `GeometryTraits` for `Ray`