### PR TITLE
Reenable MLS tests on HIP

### DIFF
--- a/test/tstInterpDetailsMLSCoefficients.cpp
+++ b/test/tstInterpDetailsMLSCoefficients.cpp
@@ -44,17 +44,6 @@ interpolate(ExecutionSpace const &space, SourceValues const &source_values,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};
@@ -134,17 +123,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};

--- a/test/tstInterpMovingLeastSquares.cpp
+++ b/test/tstInterpMovingLeastSquares.cpp
@@ -23,18 +23,6 @@
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
-
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};
@@ -111,18 +99,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
-
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};


### PR DESCRIPTION
Updating the OS and reinstalling the drivers, seems to have fixed the issue for Kokkos. Let's see if it also fixes the issue for ArborX.

Fixes #1029