### PR TITLE
Make attach_indices work for both primitives and predicates

### DIFF
--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -13,6 +13,7 @@
 #define ARBORX_BRUTE_FORCE_HPP
 
 #include <ArborX_AccessTraits.hpp>
+#include <ArborX_AttachIndices.hpp>
 #include <ArborX_Box.hpp>
 #include <ArborX_CrsGraphWrapper.hpp>
 #include <ArborX_DetailsBruteForceImpl.hpp>

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -13,6 +13,7 @@
 #define ARBORX_LINEAR_BVH_HPP
 
 #include <ArborX_AccessTraits.hpp>
+#include <ArborX_AttachIndices.hpp>
 #include <ArborX_Box.hpp>
 #include <ArborX_Callbacks.hpp>
 #include <ArborX_CrsGraphWrapper.hpp>

--- a/src/details/ArborX_AttachIndices.hpp
+++ b/src/details/ArborX_AttachIndices.hpp
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef ARBORX_DETAILS_ATTACH_INDICES_HPP
+#define ARBORX_DETAILS_ATTACH_INDICES_HPP
+
+#include <ArborX_AccessTraits.hpp>
+#include <ArborX_PairValueIndex.hpp>
+#include <ArborX_Predicates.hpp>
+
+namespace ArborX
+{
+
+namespace Experimental
+{
+template <typename Values, typename Index>
+struct AttachIndices
+{
+  Values _values;
+};
+
+// Make sure the default Index matches the default in PairValueIndex
+template <typename Index = typename PairValueIndex<int>::index_type,
+          typename Values = void>
+auto attach_indices(Values const &values)
+{
+  return AttachIndices<Values, Index>{values};
+}
+} // namespace Experimental
+
+} // namespace ArborX
+
+template <typename Values, typename Index>
+struct ArborX::AccessTraits<ArborX::Experimental::AttachIndices<Values, Index>,
+                            ArborX::PrimitivesTag>
+{
+private:
+  using Self = ArborX::Experimental::AttachIndices<Values, Index>;
+  using Access = AccessTraits<Values, ArborX::PrimitivesTag>;
+  using value_type = ArborX::PairValueIndex<
+      std::decay_t<Kokkos::detected_t<
+          ArborX::Details::AccessTraitsGetArchetypeExpression, Access, Values>>,
+      Index>;
+
+public:
+  using memory_space = typename Access::memory_space;
+
+  KOKKOS_FUNCTION static auto size(Self const &self)
+  {
+    return Access::size(self._values);
+  }
+  KOKKOS_FUNCTION static auto get(Self const &self, int i)
+  {
+    return value_type{Access::get(self._values, i), Index(i)};
+  }
+};
+template <typename Values, typename Index>
+struct ArborX::AccessTraits<ArborX::Experimental::AttachIndices<Values, Index>,
+                            ArborX::PredicatesTag>
+{
+private:
+  using Self = ArborX::Experimental::AttachIndices<Values, Index>;
+  using Access = AccessTraits<Values, ArborX::PredicatesTag>;
+
+public:
+  using memory_space = typename Access::memory_space;
+
+  KOKKOS_FUNCTION static auto size(Self const &self)
+  {
+    return Access::size(self._values);
+  }
+  KOKKOS_FUNCTION static auto get(Self const &self, int i)
+  {
+    return attach(Access::get(self._values, i), Index(i));
+  }
+};
+
+#endif

--- a/src/details/ArborX_PairValueIndex.hpp
+++ b/src/details/ArborX_PairValueIndex.hpp
@@ -31,55 +31,6 @@ struct PairValueIndex
   Index index;
 };
 
-namespace Experimental
-{
-template <typename Values, typename Index>
-class AttachIndices
-{
-private:
-  using Data = Details::AccessValues<Values, PrimitivesTag>;
-
-public:
-  Data _data;
-
-  using memory_space = typename Data::memory_space;
-  using value_type = PairValueIndex<typename Data::value_type, Index>;
-
-  AttachIndices(Values const &values)
-      : _data{values}
-  {}
-
-  KOKKOS_FUNCTION
-  auto operator()(int i) const { return value_type{_data(i), Index(i)}; }
-
-  KOKKOS_FUNCTION
-  auto size() const { return _data.size(); }
-};
-
-// Make sure the default Index matches the default in PairValueIndex
-template <typename Index = typename PairValueIndex<int>::index_type,
-          typename Values = void>
-auto attach_indices(Values const &values)
-{
-  return AttachIndices<Values, Index>{values};
-}
-} // namespace Experimental
-
 } // namespace ArborX
-
-template <typename Values, typename Index>
-struct ArborX::AccessTraits<ArborX::Experimental::AttachIndices<Values, Index>,
-                            ArborX::PrimitivesTag>
-{
-  using Self = ArborX::Experimental::AttachIndices<Values, Index>;
-
-  using memory_space = typename Self::memory_space;
-
-  KOKKOS_FUNCTION static auto size(Self const &values) { return values.size(); }
-  KOKKOS_FUNCTION static decltype(auto) get(Self const &values, int i)
-  {
-    return values(i);
-  }
-};
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(ArborX_Test_CompileOnly.exe
 target_link_libraries(ArborX_Test_CompileOnly.exe PRIVATE ArborX)
 
 add_executable(ArborX_Test_DetailsUtils.exe
+  tstAttachIndices.cpp
   tstDetailsUtils.cpp
   tstDetailsKokkosExtStdAlgorithms.cpp
   tstDetailsKokkosExtMinMaxReduce.cpp

--- a/test/tstAttachIndices.cpp
+++ b/test/tstAttachIndices.cpp
@@ -16,7 +16,7 @@
 
 BOOST_AUTO_TEST_SUITE(AttachIndices)
 
-BOOST_AUTO_TEST_CASE(attach_indices)
+BOOST_AUTO_TEST_CASE(attach_indices_to_primitives)
 {
   using ArborX::Details::AccessValues;
   using ArborX::Experimental::attach_indices;
@@ -25,8 +25,15 @@ BOOST_AUTO_TEST_CASE(attach_indices)
   auto p_with_indices = attach_indices(p);
   AccessValues<decltype(p_with_indices), ArborX::PrimitivesTag> p_values{
       p_with_indices};
+  static_assert(std::is_same_v<decltype(p_values(0).index), unsigned>);
   BOOST_TEST(p_values(0).index == 0);
   BOOST_TEST(p_values(9).index == 9);
+}
+
+BOOST_AUTO_TEST_CASE(attach_indices_to_predicates)
+{
+  using ArborX::Details::AccessValues;
+  using ArborX::Experimental::attach_indices;
 
   using IntersectsPredicate = decltype(ArborX::intersects(ArborX::Point{}));
   Kokkos::View<IntersectsPredicate *, Kokkos::HostSpace> q("Testing::q", 10);

--- a/test/tstAttachIndices.cpp
+++ b/test/tstAttachIndices.cpp
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <ArborX_AccessTraits.hpp>
+#include <ArborX_AttachIndices.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(AttachIndices)
+
+BOOST_AUTO_TEST_CASE(attach_indices)
+{
+  using ArborX::Details::AccessValues;
+  using ArborX::Experimental::attach_indices;
+
+  Kokkos::View<ArborX::Point *, Kokkos::HostSpace> p("Testing::p", 10);
+  auto p_with_indices = attach_indices(p);
+  AccessValues<decltype(p_with_indices), ArborX::PrimitivesTag> p_values{
+      p_with_indices};
+  BOOST_TEST(p_values(0).index == 0);
+  BOOST_TEST(p_values(9).index == 9);
+
+  using IntersectsPredicate = decltype(ArborX::intersects(ArborX::Point{}));
+  Kokkos::View<IntersectsPredicate *, Kokkos::HostSpace> q("Testing::q", 10);
+  auto q_with_indices = attach_indices<long>(q);
+  AccessValues<decltype(q_with_indices), ArborX::PredicatesTag> q_values{
+      q_with_indices};
+  BOOST_TEST(ArborX::getData(q_values(0)) == 0);
+  BOOST_TEST(ArborX::getData(q_values(9)) == 9);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -94,6 +94,20 @@ void test_access_traits_compile_only()
           std::decay_t<decltype(ArborX::getData(std::declval<predicate>()))>,
           long>);
 
+  struct CustomIndex
+  {
+    char index;
+    CustomIndex(int i) { index = i; }
+  };
+  auto q_with_custom_indices =
+      ArborX::Experimental::attach_indices<CustomIndex>(q);
+  check_valid_access_traits(PredicatesTag{}, q_with_custom_indices);
+  using predicate_custom =
+      deduce_type_t<decltype(q_with_custom_indices), PredicatesTag>;
+  static_assert(std::is_same_v<std::decay_t<decltype(ArborX::getData(
+                                   std::declval<predicate_custom>()))>,
+                               CustomIndex>);
+
   // Uncomment to see error messages
 
   // check_valid_access_traits(PrimitivesTag{}, NoAccessTraitsSpecialization{});


### PR DESCRIPTION
Right now, `attach_indices` only works for primitives. For predicates, there is no convenient way to attach indices to predicates. The `attach` only works on a single predicate and not limited to indices.

Attaching indices to primitives and predicates result in different types and access methods. Primitives result in `PairValueIndex<Value, Index>`, while predicates result in an unspecified type that the index can be accessed by `getData()`.

I'm not sure how how much of a problem returning different types is. The function serves the same role for both primitives and predicates: conveniently adjust passed in data in some easy way for the hierarchy. Both types should really be undefined. The difference is that in the first case the argument appears in the hierarchy template specialization.

The two types should be different, though. The predicate attachment inherits from the predicate and may provide `distance()` function; the access to the data is also done on the user side, thus `getData()` function. The primitive attachment is a simple storage and will only be used internally.
