### PR TITLE
Add helper functions to construct predicates

### DIFF
--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -314,7 +314,8 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   ArborX::BoundingVolumeHierarchy<MemorySpace, ArborX::PairValueIndex<Point>>
       bvh(exec_space, ArborX::Experimental::attach_indices(points));
 
-  auto const predicates = Details::PrimitivesWithRadius<Points>{points, eps};
+  auto const predicates = ArborX::Experimental::attach_indices(
+      ArborX::Experimental::intersect_geometries_with_radius(points, eps));
 
   Kokkos::View<int *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
   Kokkos::View<int *, MemorySpace> offset("ArborX::DBSCAN::offset", 0);

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -170,52 +170,6 @@ public:
   }
 };
 
-template <typename DeviceType>
-struct NearestNeighborsSearches
-{
-  Kokkos::View<ArborX::Point *, DeviceType> points;
-  int k;
-};
-template <typename DeviceType>
-struct RadiusSearches
-{
-  Kokkos::View<ArborX::Point *, DeviceType> points;
-  double radius;
-};
-
-template <typename DeviceType>
-struct ArborX::AccessTraits<RadiusSearches<DeviceType>, ArborX::PredicatesTag>
-{
-  using memory_space = typename DeviceType::memory_space;
-  static KOKKOS_FUNCTION std::size_t
-  size(RadiusSearches<DeviceType> const &pred)
-  {
-    return pred.points.extent(0);
-  }
-  static KOKKOS_FUNCTION auto get(RadiusSearches<DeviceType> const &pred,
-                                  std::size_t i)
-  {
-    return ArborX::intersects(ArborX::Sphere{pred.points(i), pred.radius});
-  }
-};
-
-template <typename DeviceType>
-struct ArborX::AccessTraits<NearestNeighborsSearches<DeviceType>,
-                            ArborX::PredicatesTag>
-{
-  using memory_space = typename DeviceType::memory_space;
-  static KOKKOS_FUNCTION std::size_t
-  size(NearestNeighborsSearches<DeviceType> const &pred)
-  {
-    return pred.points.extent(0);
-  }
-  static KOKKOS_FUNCTION auto
-  get(NearestNeighborsSearches<DeviceType> const &pred, std::size_t i)
-  {
-    return ArborX::nearest(pred.points(i), pred.k);
-  }
-};
-
 namespace bpo = boost::program_options;
 
 template <class NO>
@@ -421,8 +375,8 @@ int main_(std::vector<std::string> const &args, MPI_Comm const comm)
     knn->start();
     distributed_tree.query(
         ExecutionSpace{},
-        NearestNeighborsSearches<DeviceType>{random_queries, n_neighbors},
-        values, offsets);
+        ArborX::Experimental::nearest_k(random_queries, n_neighbors), values,
+        offsets);
     knn->stop();
 
     if (comm_rank == 0)
@@ -457,9 +411,11 @@ int main_(std::vector<std::string> const &args, MPI_Comm const comm)
     auto radius = time_monitor.getNewTimer("radius");
     MPI_Barrier(comm);
     radius->start();
-    distributed_tree.query(ExecutionSpace{},
-                           RadiusSearches<DeviceType>{random_queries, r},
-                           values, offsets);
+    distributed_tree.query(
+        ExecutionSpace{},
+        ArborX::Experimental::intersect_geometries_with_radius(random_queries,
+                                                               r),
+        values, offsets);
     radius->stop();
 
     if (comm_rank == 0)

--- a/src/ArborX.hpp
+++ b/src/ArborX.hpp
@@ -23,6 +23,7 @@
 #include <ArborX_Exception.hpp>
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_Point.hpp>
+#include <ArborX_PredicateHelpers.hpp>
 #include <ArborX_Predicates.hpp>
 #include <ArborX_Sphere.hpp>
 // FIXME: we include ArborX_DetailsUtils.hpp only for backward compatibility for

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -22,6 +22,7 @@
 #include <ArborX_DetailsLegacy.hpp>
 #include <ArborX_IndexableGetter.hpp>
 #include <ArborX_PairValueIndex.hpp>
+#include <ArborX_PredicateHelpers.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -29,6 +29,7 @@
 #include <ArborX_HyperBox.hpp>
 #include <ArborX_IndexableGetter.hpp>
 #include <ArborX_PairValueIndex.hpp>
+#include <ArborX_PredicateHelpers.hpp>
 #include <ArborX_SpaceFillingCurves.hpp>
 #include <ArborX_TraversalPolicy.hpp>
 

--- a/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
+++ b/src/details/ArborX_DetailsFDBSCANDenseBox.hpp
@@ -167,7 +167,7 @@ struct FDBSCANDenseBoxCallback
     }
     else
     {
-      int j = _permute(_num_points_in_dense_cells + (k - _num_dense_cells));
+      auto j = _permute(_num_points_in_dense_cells + (k - _num_dense_cells));
 
       // No need to check the distance here, as the fact that we are inside the
       // callback guarantees that it is <= eps

--- a/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
+++ b/src/details/ArborX_DetailsMutualReachabilityDistance.hpp
@@ -47,34 +47,6 @@ struct MaxDistance
   }
 };
 
-template <class Primitives>
-struct NearestK
-{
-  Primitives primitives;
-  int k; // including self-collisions
-};
-
-} // namespace Details
-
-template <class Primitives>
-struct AccessTraits<Details::NearestK<Primitives>, PredicatesTag>
-{
-  using memory_space = typename Primitives::memory_space;
-  using size_type = typename memory_space::size_type;
-  static KOKKOS_FUNCTION size_type size(Details::NearestK<Primitives> const &x)
-  {
-    return x.primitives.size();
-  }
-  static KOKKOS_FUNCTION auto get(Details::NearestK<Primitives> const &x,
-                                  size_type i)
-  {
-    return attach(nearest(x.primitives(i), x.k), i);
-  }
-};
-
-namespace Details
-{
-
 template <class CoreDistances>
 struct MutualReachability
 {

--- a/src/details/ArborX_MinimumSpanningTree.hpp
+++ b/src/details/ArborX_MinimumSpanningTree.hpp
@@ -20,6 +20,7 @@
 #include <ArborX_DetailsTreeNodeLabeling.hpp>
 #include <ArborX_DetailsWeightedEdge.hpp>
 #include <ArborX_LinearBVH.hpp>
+#include <ArborX_PredicateHelpers.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
@@ -66,9 +67,11 @@ struct MinimumSpanningTree
       Kokkos::Profiling::pushRegion("ArborX::MST::compute_core_distances");
       Kokkos::View<float *, MemorySpace> core_distances(
           "ArborX::MST::core_distances", n);
-      bvh.query(space, NearestK<Points>{points, k},
-                MaxDistance<Points, decltype(core_distances)>{points,
-                                                              core_distances});
+      bvh.query(
+          space,
+          Experimental::attach_indices(Experimental::nearest_k(points, k)),
+          MaxDistance<Points, decltype(core_distances)>{points,
+                                                        core_distances});
       Kokkos::Profiling::popRegion();
 
       MutualReachability<decltype(core_distances)> mutual_reachability{

--- a/src/details/ArborX_PredicateHelpers.hpp
+++ b/src/details/ArborX_PredicateHelpers.hpp
@@ -58,10 +58,13 @@ struct PrimitivesNearestK
 {
 private:
   using Primitives = Details::AccessValues<UserPrimitives, PrimitivesTag>;
+  // FIXME:
+  // using Geometry = typename Primitives::value_type;
+  // static_assert(GeometryTraits::is_valid_geometry<Geometry>{});
 
 public:
   Primitives _primitives;
-  int _k; // not including self-collisions
+  int _k;
 };
 
 template <typename Primitives>
@@ -83,7 +86,8 @@ auto intersect_geometries_with_radius(Primitives const &primitives,
 template <typename Primitives>
 auto nearest_k(Primitives const &primitives, int k)
 {
-  Details::check_valid_access_traits(PrimitivesTag{}, primitives);
+  Details::check_valid_access_traits(PrimitivesTag{}, primitives,
+                                     Details::DoNotCheckGetReturnType());
   return PrimitivesNearestK<Primitives>{primitives, k};
 }
 

--- a/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
+++ b/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
@@ -21,6 +21,7 @@
 #include <ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp>
 #include <ArborX_InterpDetailsPolynomialBasis.hpp>
 #include <ArborX_LinearBVH.hpp>
+#include <ArborX_PredicateHelpers.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
@@ -29,14 +30,6 @@
 
 namespace ArborX::Interpolation::Details
 {
-
-// This is done to avoid a clash with another predicates access trait
-template <typename TargetAccess>
-struct MLSPredicateWrapper
-{
-  TargetAccess target_access;
-  int num_neighbors;
-};
 
 // Functor used in the tree query to create the 2D source view and indices
 template <typename SourceView, typename IndicesView, typename CounterView>
@@ -62,30 +55,6 @@ struct MLSSearchNeighborsCallback
 };
 
 } // namespace ArborX::Interpolation::Details
-
-namespace ArborX
-{
-
-template <typename TargetAccess>
-struct AccessTraits<Interpolation::Details::MLSPredicateWrapper<TargetAccess>,
-                    PredicatesTag>
-{
-  using Self = Interpolation::Details::MLSPredicateWrapper<TargetAccess>;
-
-  KOKKOS_FUNCTION static auto size(Self const &tp)
-  {
-    return tp.target_access.size();
-  }
-
-  KOKKOS_FUNCTION static auto get(Self const &tp, int const i)
-  {
-    return attach(nearest(tp.target_access(i), tp.num_neighbors), i);
-  }
-
-  using memory_space = typename TargetAccess::memory_space;
-};
-
-} // namespace ArborX
 
 namespace ArborX::Interpolation
 {
@@ -231,8 +200,8 @@ private:
         source_tree(space, ArborX::Experimental::attach_indices(source_access));
 
     // Create the predicates
-    Details::MLSPredicateWrapper<TargetAccess> predicates{target_access,
-                                                          _num_neighbors};
+    auto predicates = Experimental::attach_indices(
+        Experimental::nearest_k(target_access, _num_neighbors));
 
     // Create the callback
     Kokkos::View<SourcePoint **, MemorySpace> source_view(

--- a/test/tstDetailsMutualReachabilityDistance.cpp
+++ b/test/tstDetailsMutualReachabilityDistance.cpp
@@ -41,7 +41,9 @@ auto compute_core_distances(ExecutionSpace exec_space,
   constexpr auto inf =
       ArborX::Details::KokkosExt::ArithmeticTraits::infinity<float>::value;
   Kokkos::deep_copy(exec_space, distances, -inf);
-  bvh.query(exec_space, ArborX::Details::NearestK<decltype(points)>{points, k},
+  auto predicates = ArborX::Experimental::attach_indices(
+      ArborX::Experimental::nearest_k(points, k));
+  bvh.query(exec_space, predicates,
             ArborX::Details::MaxDistance<decltype(points), decltype(distances)>{
                 points, distances});
 

--- a/test/tstQueryTreeRay.cpp
+++ b/test/tstQueryTreeRay.cpp
@@ -23,52 +23,6 @@
 #include "ArborXTest_TreeTypeTraits.hpp"
 // clang-format on
 
-template <typename DeviceType>
-struct NearestBoxToRay
-{
-  Kokkos::View<ArborX::Experimental::Ray *, DeviceType> rays;
-  int k;
-};
-
-template <typename DeviceType>
-struct BoxesIntersectedByRay
-{
-  Kokkos::View<ArborX::Experimental::Ray *, DeviceType> rays;
-};
-
-template <typename DeviceType>
-struct ArborX::AccessTraits<NearestBoxToRay<DeviceType>, ArborX::PredicatesTag>
-{
-  using memory_space = typename DeviceType::memory_space;
-  static KOKKOS_FUNCTION int
-  size(NearestBoxToRay<DeviceType> const &nearest_boxes)
-  {
-    return nearest_boxes.rays.size();
-  }
-  static KOKKOS_FUNCTION auto
-  get(NearestBoxToRay<DeviceType> const &nearest_boxes, int i)
-  {
-    return nearest(nearest_boxes.rays(i), nearest_boxes.k);
-  }
-};
-
-template <typename DeviceType>
-struct ArborX::AccessTraits<BoxesIntersectedByRay<DeviceType>,
-                            ArborX::PredicatesTag>
-{
-  using memory_space = typename DeviceType::memory_space;
-  static KOKKOS_FUNCTION int
-  size(BoxesIntersectedByRay<DeviceType> const &nearest_boxes)
-  {
-    return nearest_boxes.rays.size();
-  }
-  static KOKKOS_FUNCTION auto
-  get(BoxesIntersectedByRay<DeviceType> const &nearest_boxes, int i)
-  {
-    return intersects(nearest_boxes.rays(i));
-  }
-};
-
 BOOST_AUTO_TEST_SUITE(RayTraversals)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_nearest, DeviceType,
@@ -96,9 +50,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_nearest, DeviceType,
   BOOST_TEST(intersects(
       ray, ArborX::Box{ArborX::Point{0, 0, 0}, ArborX::Point{1, 1, 1}}));
 
-  NearestBoxToRay<DeviceType> predicates{device_rays, 1};
-
-  ARBORX_TEST_QUERY_TREE(exec_space, tree, predicates,
+  ARBORX_TEST_QUERY_TREE(exec_space, tree,
+                         ArborX::Experimental::nearest_k(device_rays, 1),
                          make_reference_solution<int>({0}, {0, 1}));
 }
 
@@ -124,10 +77,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_intersection, DeviceType,
   Kokkos::View<ArborX::Experimental::Ray *, DeviceType> device_rays("rays", 1);
   Kokkos::deep_copy(exec_space, device_rays, ray);
 
-  BoxesIntersectedByRay<DeviceType> predicates{device_rays};
-
   ARBORX_TEST_QUERY_TREE(
-      exec_space, tree, predicates,
+      exec_space, tree, ArborX::Experimental::intersect_geometries(device_rays),
       make_reference_solution<int>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 10}));
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Introduce helper function to simplify several common predicate types given a set of primitives:
- intersects with geometries
- intersects with geometries and radius
- nearest K with geometries