### PR TITLE
SYCL CI: avoid using setvars.sh

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -415,7 +415,6 @@ pipeline {
                         sh 'rm -rf build && mkdir -p build'
                         dir('build') {
                             sh '''
-                                . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
                                 cmake \
                                     -D CMAKE_INSTALL_PREFIX=$ARBORX_DIR \
                                     -D CMAKE_BUILD_TYPE=Release \
@@ -433,11 +432,9 @@ pipeline {
                                 ..
                             '''
                             sh '''
-                                . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
                                 make -j8 VERBOSE=1
                             '''
                             sh '''
-                                . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
                                 ctest $CTEST_OPTIONS
                             '''
                         }
@@ -453,7 +450,6 @@ pipeline {
                             dir('test_install') {
                                 sh 'cp -r ../examples .'
                                 sh '''
-                                    . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
                                     cmake \
                                         -D CMAKE_BUILD_TYPE=Release \
                                         -D CMAKE_CXX_COMPILER=${DPCPP} \
@@ -463,11 +459,9 @@ pipeline {
                                     examples \
                                 '''
                                 sh '''
-                                    . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
                                     make VERBOSE=1
                                 '''
                                 sh '''
-                                    . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
                                     make test
                                 '''
                             }

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -63,11 +63,21 @@ RUN wget https://cloud.cees.ornl.gov/download/oneapi-for-nvidia-gpus-${DPCPP_VER
     rm oneapi-for-nvidia-gpus-${DPCPP_VERSION}-linux.sh
 
 # Install oneDPL, see
-# https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=linux&distributions=online&version=2023.0.0 
+# https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=linux&distributions=online&version=2023.0.0
 RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/19133/l_oneDPL_p_2022.0.0.25335.sh &&\
     chmod +x ./l_oneDPL_p_2022.0.0.25335.sh && \
     ./l_oneDPL_p_2022.0.0.25335.sh -a -s --eula accept && \
     rm l_oneDPL_p_2022.0.0.25335.sh
+
+# Set up environment variables to avoid using setvars.sh in CI
+# clang++
+ENV PATH=/opt/intel/oneapi/compiler/latest/linux/bin-llvm/:$PATH
+# sycl-ls, icpx
+ENV PATH=/opt/intel/oneapi/compiler/latest/linux/bin/:$PATH
+# libsycl
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/latest/linux/lib:$LD_LIBRARY_PATH
+# libsvml
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:$LD_LIBRARY_PATH
 
 # Install Boost and patch it, see
 # intel.com/content/www/us/en/developer/articles/technical/building-boost-with-oneapi.html


### PR DESCRIPTION
This patch tries to avoid the SYCL CI issues we are seeing when running setvars.sh by setting the necessary environment variables in Dockerfile already.

Taken from kokkos/kokkos#6824.