### PR TITLE
Update DefaultIndexableGetter to work with all valid geometries

### DIFF
--- a/src/details/ArborX_IndexableGetter.hpp
+++ b/src/details/ArborX_IndexableGetter.hpp
@@ -25,8 +25,7 @@ struct DefaultIndexableGetter
   DefaultIndexableGetter() = default;
 
   template <typename Geometry, typename Enable = std::enable_if_t<
-                                   GeometryTraits::is_point_v<Geometry> ||
-                                   GeometryTraits::is_box_v<Geometry>>>
+                                   GeometryTraits::is_valid_geometry<Geometry>>>
   KOKKOS_FUNCTION auto const &operator()(Geometry const &geometry) const
   {
     return geometry;


### PR DESCRIPTION
Right now, `DefaultIndexableGetter` only passes through points and boxes, unnecessarily restricting things. One, for example, cannot do
`ArborX::BVH<MemorySpace, Triangle> bvh(space, Kokkos::View<Triangle*>);`.

This patch extends passed through geometries to all that are considered valid in `GeometryTraits`.