### PR TITLE
Enable [ci skip] in Jenkins continuous pipeline

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -21,6 +21,13 @@ pipeline {
     }
     stages {
 
+        stage('Checkout') {
+            agent any
+            steps {
+                scmSkip(deleteBuild: true, skipPattern:'.*\\[ci skip\\].*')
+            }
+        }
+
         stage("Style") {
             agent {
                 dockerfile {


### PR DESCRIPTION
(Re)enable skipping builds if the latest commit message says "[ci skip]"
It used to be in place before our server went down in last November.  Being able to skip a build and save resources is worthwhile.

See [plugin doc](https://plugins.jenkins.io/scmskip/#plugin-content-enable-on-pipeline)