### PR TITLE
Fix a temporary objects issue with DefaultIndexableGetter

### DIFF
--- a/src/details/ArborX_IndexableGetter.hpp
+++ b/src/details/ArborX_IndexableGetter.hpp
@@ -31,6 +31,13 @@ struct DefaultIndexableGetter
     return geometry;
   }
 
+  template <typename Geometry, typename Enable = std::enable_if_t<
+                                   GeometryTraits::is_valid_geometry<Geometry>>>
+  KOKKOS_FUNCTION auto operator()(Geometry &&geometry) const
+  {
+    return geometry;
+  }
+
   template <typename Value, typename Index>
   KOKKOS_FUNCTION Value const &
   operator()(PairValueIndex<Value, Index> const &pair) const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -163,7 +163,12 @@ endif()
 target_include_directories(ArborX_Test_QueryTree.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME ArborX_Test_QueryTree COMMAND ArborX_Test_QueryTree.exe)
 
-add_executable(ArborX_Test_DetailsTreeConstruction.exe tstDetailsMortonCodes.cpp tstDetailsTreeConstruction.cpp utf_main.cpp)
+add_executable(ArborX_Test_DetailsTreeConstruction.exe
+  tstDetailsMortonCodes.cpp
+  tstDetailsTreeConstruction.cpp
+  tstIndexableGetter.cpp
+  utf_main.cpp
+)
 target_link_libraries(ArborX_Test_DetailsTreeConstruction.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_Test_DetailsTreeConstruction.exe PRIVATE BOOST_TEST_DYN_LINK)
 target_include_directories(ArborX_Test_DetailsTreeConstruction.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/tstIndexableGetter.cpp
+++ b/test/tstIndexableGetter.cpp
@@ -1,0 +1,135 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include <ArborX_AccessTraits.hpp>
+#include <ArborX_IndexableGetter.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace ArborX::Details;
+
+#include <ArborX_HyperPoint.hpp>
+
+template <typename MemorySpace>
+struct PointCloud
+{
+  ArborX::Point *data;
+  int n;
+};
+
+template <typename MemorySpace>
+struct ArborX::AccessTraits<PointCloud<MemorySpace>, ArborX::PrimitivesTag>
+{
+  using Points = PointCloud<MemorySpace>;
+
+  static KOKKOS_FUNCTION std::size_t size(Points const &points)
+  {
+    return points.n;
+  }
+  static KOKKOS_FUNCTION auto get(Points const &points, std::size_t i)
+  {
+    return points.data[i];
+  }
+  using memory_space = MemorySpace;
+};
+
+template <typename MemorySpace>
+struct PairPointIndexCloud
+{
+  ArborX::Point *data;
+  int n;
+};
+
+template <typename MemorySpace>
+struct ArborX::AccessTraits<PairPointIndexCloud<MemorySpace>,
+                            ArborX::PrimitivesTag>
+{
+  using Points = PairPointIndexCloud<MemorySpace>;
+
+  static KOKKOS_FUNCTION std::size_t size(Points const &points)
+  {
+    return points.n;
+  }
+  static KOKKOS_FUNCTION auto get(Points const &points, std::size_t i)
+  {
+    return ArborX::PairValueIndex<ArborX::Point, int>{points.data[i], (int)i};
+  }
+  using memory_space = MemorySpace;
+};
+
+template <typename ExecutionSpace, typename Indexables, typename Box>
+inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
+                                           Indexables const &indexables,
+                                           Box &scene_bounding_box)
+{
+  Kokkos::parallel_reduce(
+      "ArborX::TreeConstruction::calculate_bounding_box_of_the_scene",
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, indexables.size()),
+      KOKKOS_LAMBDA(int i, Box &update) { expand(update, indexables(i)); },
+      Kokkos::Sum<Box>{scene_bounding_box});
+}
+
+BOOST_AUTO_TEST_SUITE(MortonCodes)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(indexables, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  // Test that the two-level wrapping Data -> AccessValues -> Indexables by
+  // using DefaultIndexableGetter works correctly.
+
+  using ExecutionSpace = typename DeviceType::execution_space;
+  using MemorySpace = typename DeviceType::memory_space;
+
+  using ArborX::Details::equals;
+
+  Kokkos::View<ArborX::Point *, MemorySpace> points("Testing::points", 2);
+  auto points_host = Kokkos::create_mirror_view(points);
+  points_host(0) = {-1, -1, -1};
+  points_host(1) = {1, 1, 1};
+  Kokkos::deep_copy(points, points_host);
+
+  ArborX::Box scene_bounding_box = ArborX::Box{{-1, -1, -1}, {1, 1, 1}};
+
+  using IndexableGetter = ArborX::Details::DefaultIndexableGetter;
+  IndexableGetter indexable_getter;
+
+  {
+    PointCloud<MemorySpace> points_cloud{points.data(), (int)points.size()};
+
+    using Primitives = ArborX::Details::AccessValues<decltype(points_cloud),
+                                                     ArborX::PrimitivesTag>;
+    Primitives primitives(points_cloud);
+
+    ArborX::Details::Indexables<Primitives, IndexableGetter> indexables{
+        primitives, indexable_getter};
+
+    ArborX::Box box;
+    calculateBoundingBoxOfTheScene(ExecutionSpace{}, indexables, box);
+    BOOST_ASSERT(equals(box, scene_bounding_box));
+  }
+
+  {
+    PairPointIndexCloud<MemorySpace> points_cloud{points.data(),
+                                                  (int)points.size()};
+
+    using Primitives = ArborX::Details::AccessValues<decltype(points_cloud),
+                                                     ArborX::PrimitivesTag>;
+    Primitives primitives(points_cloud);
+
+    ArborX::Details::Indexables<Primitives, IndexableGetter> indexables{
+        primitives, indexable_getter};
+
+    ArborX::Box box;
+    calculateBoundingBoxOfTheScene(ExecutionSpace{}, indexables, box);
+    BOOST_ASSERT(equals(box, scene_bounding_box));
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In 0fdfa87 (part of #915), we addressed the temporaries issues when passing around
PairIndexObject. What we didn't realize at the time, that similar issues
could have been present in the geometries part too.

This was shown to break behavior of the FDBSCAN-DenseBox when called
with primitives assembled on the fly using AccessTraits. In that case,
the scene bounding box was completely wrong, resulting in random
asserts.

This only makes ArborX internally work. I'm not sure if we still have a potential issue when a user defines their own indexable getter. I'm not confident I understand the intricacies of what's going on.