### PR TITLE
Switch CI from MI100 to MI210

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -342,7 +342,7 @@ pipeline {
                             dir "docker"
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.6 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES} --env AMDGPU_TARGET=${AMDGPU_TARGET}'
-                            label 'rocm-docker && AMD_Radeon_Instinct_MI100'
+                            label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                         }
                     }
                     steps {

--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -92,7 +92,7 @@ pipeline {
                     agent {
                         docker {
                             image 'rocm/dev-ubuntu-22.04:5.4-complete'
-                            label 'AMD_Radeon_Instinct_MI100 && rocm-docker'
+                            label 'AMD_Radeon_Instinct_MI210 && rocm-docker'
                             args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES}'
                         }
                     }


### PR DESCRIPTION
The MI210 machines seem more stable than the MI100 ones. Let's just use them instead.