### PR TITLE
Simplify using APIv1 through APIv2 interface

### DIFF
--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
@@ -93,10 +93,10 @@ static void run_fp(int nprimitives, int nqueries, int nrepeats)
                                       ArborX::PairValueIndex<Point>>
           bvh{space, ArborX::Experimental::attach_indices(primitives)};
 
-      Kokkos::View<int *, ExecutionSpace> indices("Benchmark::indices_ref", 0);
+      Kokkos::View<unsigned *, ExecutionSpace> indices("Benchmark::indices_ref",
+                                                       0);
       Kokkos::View<int *, ExecutionSpace> offset("Benchmark::offset_ref", 0);
-      bvh.query(space, predicates, ArborX::Details::LegacyDefaultCallback{},
-                indices, offset);
+      bvh.query(space, predicates, indices, offset);
 
       space.fence();
       double time = timer.seconds();
@@ -112,10 +112,9 @@ static void run_fp(int nprimitives, int nqueries, int nrepeats)
       ArborX::BruteForce<MemorySpace, ArborX::PairValueIndex<Point>> brute{
           space, ArborX::Experimental::attach_indices(primitives)};
 
-      Kokkos::View<int *, ExecutionSpace> indices("Benchmark::indices", 0);
+      Kokkos::View<unsigned *, ExecutionSpace> indices("Benchmark::indices", 0);
       Kokkos::View<int *, ExecutionSpace> offset("Benchmark::offset", 0);
-      brute.query(space, predicates, ArborX::Details::LegacyDefaultCallback{},
-                  indices, offset);
+      brute.query(space, predicates, indices, offset);
 
       space.fence();
       double time = timer.seconds();

--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
@@ -93,8 +93,7 @@ static void run_fp(int nprimitives, int nqueries, int nrepeats)
                                       ArborX::PairValueIndex<Point>>
           bvh{space, ArborX::Experimental::attach_indices(primitives)};
 
-      Kokkos::View<unsigned *, ExecutionSpace> indices("Benchmark::indices_ref",
-                                                       0);
+      Kokkos::View<int *, ExecutionSpace> indices("Benchmark::indices_ref", 0);
       Kokkos::View<int *, ExecutionSpace> offset("Benchmark::offset_ref", 0);
       bvh.query(space, predicates, indices, offset);
 
@@ -112,7 +111,7 @@ static void run_fp(int nprimitives, int nqueries, int nrepeats)
       ArborX::BruteForce<MemorySpace, ArborX::PairValueIndex<Point>> brute{
           space, ArborX::Experimental::attach_indices(primitives)};
 
-      Kokkos::View<unsigned *, ExecutionSpace> indices("Benchmark::indices", 0);
+      Kokkos::View<int *, ExecutionSpace> indices("Benchmark::indices", 0);
       Kokkos::View<int *, ExecutionSpace> offset("Benchmark::offset", 0);
       brute.query(space, predicates, indices, offset);
 

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -317,10 +317,9 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   auto const predicates = ArborX::Experimental::attach_indices(
       ArborX::Experimental::make_intersects(points, eps));
 
-  Kokkos::View<int *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
+  Kokkos::View<unsigned *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
   Kokkos::View<int *, MemorySpace> offset("ArborX::DBSCAN::offset", 0);
-  ArborX::query(bvh, exec_space, predicates,
-                ArborX::Details::LegacyDefaultCallback{}, indices, offset);
+  ArborX::query(bvh, exec_space, predicates, indices, offset);
 
   auto passed = Details::verifyClusters(exec_space, indices, offset, labels,
                                         core_min_size);

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -317,7 +317,7 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
   auto const predicates = ArborX::Experimental::attach_indices(
       ArborX::Experimental::make_intersects(points, eps));
 
-  Kokkos::View<unsigned *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
+  Kokkos::View<int *, MemorySpace> indices("ArborX::DBSCAN::indices", 0);
   Kokkos::View<int *, MemorySpace> offset("ArborX::DBSCAN::offset", 0);
   ArborX::query(bvh, exec_space, predicates, indices, offset);
 

--- a/examples/simple_intersection/example_intersection.cpp
+++ b/examples/simple_intersection/example_intersection.cpp
@@ -22,12 +22,15 @@ int main(int argc, char *argv[])
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
   using MemorySpace = ExecutionSpace::memory_space;
 
-  Kokkos::View<ArborX::Box *, MemorySpace> boxes("Example::boxes", 4);
+  using Box = ArborX::ExperimentalHyperGeometry::Box<2>;
+  using Point = ArborX::ExperimentalHyperGeometry::Point<2>;
+
+  Kokkos::View<Box *, MemorySpace> boxes("Example::boxes", 4);
   auto boxes_host = Kokkos::create_mirror_view(boxes);
-  boxes_host[0] = {{0, 0, 0}, {1, 1, 1}};
-  boxes_host[1] = {{1, 0, 0}, {2, 1, 1}};
-  boxes_host[2] = {{0, 1, 0}, {1, 2, 1}};
-  boxes_host[3] = {{1, 1, 0}, {2, 2, 1}};
+  boxes_host[0] = {{0, 0}, {1, 1}};
+  boxes_host[1] = {{1, 0}, {2, 1}};
+  boxes_host[2] = {{0, 1}, {1, 2}};
+  boxes_host[3] = {{1, 1}, {2, 2}};
   Kokkos::deep_copy(boxes, boxes_host);
 
   // -----------
@@ -37,17 +40,18 @@ int main(int argc, char *argv[])
   // |    |    |
   // |    |    |
   // -----------
-  Kokkos::View<decltype(ArborX::intersects(ArborX::Point())) *, MemorySpace>
-      queries("Example::queries", 3);
+  Kokkos::View<decltype(ArborX::intersects(Point{})) *, MemorySpace> queries(
+      "Example::queries", 3);
   auto queries_host = Kokkos::create_mirror_view(queries);
-  queries_host[0] = ArborX::intersects(ArborX::Point{1.8, 1.5, 0.5});
-  queries_host[1] = ArborX::intersects(ArborX::Point{1.3, 1.7, 0.5});
-  queries_host[2] = ArborX::intersects(ArborX::Point{1, 1, 0.5});
+  queries_host[0] = ArborX::intersects(Point{1.8, 1.5});
+  queries_host[1] = ArborX::intersects(Point{1.3, 1.7});
+  queries_host[2] = ArborX::intersects(Point{1, 1});
   Kokkos::deep_copy(queries, queries_host);
 
   ExecutionSpace space;
 
-  ArborX::BVH<MemorySpace> const tree(space, boxes);
+  ArborX::BVH<MemorySpace, ArborX::PairValueIndex<Box, int>> const tree(
+      space, ArborX::Experimental::attach_indices<int>(boxes));
 
   // The query will resize indices and offsets accordingly
   Kokkos::View<int *, MemorySpace> indices("Example::indices", 0);

--- a/examples/simple_intersection/example_intersection.cpp
+++ b/examples/simple_intersection/example_intersection.cpp
@@ -50,8 +50,8 @@ int main(int argc, char *argv[])
 
   ExecutionSpace space;
 
-  ArborX::BVH<MemorySpace, ArborX::PairValueIndex<Box, int>> const tree(
-      space, ArborX::Experimental::attach_indices<int>(boxes));
+  ArborX::BVH<MemorySpace, ArborX::PairValueIndex<Box>> const tree(
+      space, ArborX::Experimental::attach_indices(boxes));
 
   // The query will resize indices and offsets accordingly
   Kokkos::View<int *, MemorySpace> indices("Example::indices", 0);

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -82,10 +82,39 @@ public:
     using Predicates = Details::AccessValues<UserPredicates, PredicatesTag>;
     using Tag = typename Predicates::value_type::Tag;
 
-    Details::CrsGraphWrapperImpl::queryDispatch(
-        Tag{}, *this, space, Predicates{user_predicates},
-        std::forward<CallbackOrView>(callback_or_view),
-        std::forward<View>(view), std::forward<Args>(args)...);
+    // Automatically add LegacyDefaultCallback if
+    //   1. A user does not provide a callback
+    //   2. The index is constructed on PairValueIndex
+    //   3. The output value_type matches the index_type in the PairValueIndex
+    constexpr bool use_convenient_shortcut = []() {
+      if constexpr (!Kokkos::is_view_v<std::decay_t<CallbackOrView>>)
+        return false;
+      else if constexpr (!Details::is_pair_value_index_v<value_type>)
+        return false;
+      else
+      {
+        return std::is_same_v<typename std::decay_t<CallbackOrView>::value_type,
+                              typename value_type::index_type>;
+      }
+    }();
+
+    if constexpr (use_convenient_shortcut)
+    {
+      // Simplified way to get APIv1 result using APIv2 interface
+      Details::CrsGraphWrapperImpl::queryDispatch(
+          Tag{}, *this, space, Predicates{user_predicates},
+          Details::LegacyDefaultCallback{},
+          std::forward<CallbackOrView>(callback_or_view),
+          std::forward<View>(view), std::forward<Args>(args)...);
+      return;
+    }
+    else
+    {
+      Details::CrsGraphWrapperImpl::queryDispatch(
+          Tag{}, *this, space, Predicates{user_predicates},
+          std::forward<CallbackOrView>(callback_or_view),
+          std::forward<View>(view), std::forward<Args>(args)...);
+    }
   }
 
   KOKKOS_FUNCTION auto const &indexable_get() const

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -85,7 +85,7 @@ public:
     // Automatically add LegacyDefaultCallback if
     //   1. A user does not provide a callback
     //   2. The index is constructed on PairValueIndex
-    //   3. The output value_type matches the index_type in the PairValueIndex
+    //   3. The output value_type is an integral type
     constexpr bool use_convenient_shortcut = []() {
       if constexpr (!Kokkos::is_view_v<std::decay_t<CallbackOrView>>)
         return false;
@@ -101,7 +101,7 @@ public:
       // Simplified way to get APIv1 result using APIv2 interface
       Details::CrsGraphWrapperImpl::queryDispatch(
           Tag{}, *this, space, Predicates{user_predicates},
-          Details::LegacyDefaultCallback{},
+          Details::LegacyDefaultCallback{}, // inject legacy callback arg
           std::forward<CallbackOrView>(callback_or_view),
           std::forward<View>(view), std::forward<Args>(args)...);
       return;

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -92,10 +92,8 @@ public:
       else if constexpr (!Details::is_pair_value_index_v<value_type>)
         return false;
       else
-      {
-        return std::is_same_v<typename std::decay_t<CallbackOrView>::value_type,
-                              typename value_type::index_type>;
-      }
+        return std::is_integral_v<
+            typename std::decay_t<CallbackOrView>::value_type>;
     }();
 
     if constexpr (use_convenient_shortcut)

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -109,7 +109,7 @@ public:
     // Automatically add LegacyDefaultCallback if
     //   1. A user does not provide a callback
     //   2. The index is constructed on PairValueIndex
-    //   3. The output value_type matches the index_type in the PairValueIndex
+    //   3. The output value_type is an integral type
     constexpr bool use_convenient_shortcut = []() {
       if constexpr (!Kokkos::is_view_v<std::decay_t<CallbackOrView>>)
         return false;
@@ -125,7 +125,7 @@ public:
       // Simplified way to get APIv1 result using APIv2 interface
       Details::CrsGraphWrapperImpl::queryDispatch(
           Tag{}, *this, space, Predicates{user_predicates},
-          Details::LegacyDefaultCallback{},
+          Details::LegacyDefaultCallback{}, // inject legacy callback arg
           std::forward<CallbackOrView>(callback_or_view),
           std::forward<View>(view), std::forward<Args>(args)...);
       return;

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -116,10 +116,8 @@ public:
       else if constexpr (!Details::is_pair_value_index_v<value_type>)
         return false;
       else
-      {
-        return std::is_same_v<typename std::decay_t<CallbackOrView>::value_type,
-                              typename value_type::index_type>;
-      }
+        return std::is_integral_v<
+            typename std::decay_t<CallbackOrView>::value_type>;
     }();
 
     if constexpr (use_convenient_shortcut)

--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -106,10 +106,39 @@ public:
     using Predicates = Details::AccessValues<UserPredicates, PredicatesTag>;
     using Tag = typename Predicates::value_type::Tag;
 
-    Details::CrsGraphWrapperImpl::queryDispatch(
-        Tag{}, *this, space, Predicates{user_predicates},
-        std::forward<CallbackOrView>(callback_or_view),
-        std::forward<View>(view), std::forward<Args>(args)...);
+    // Automatically add LegacyDefaultCallback if
+    //   1. A user does not provide a callback
+    //   2. The index is constructed on PairValueIndex
+    //   3. The output value_type matches the index_type in the PairValueIndex
+    constexpr bool use_convenient_shortcut = []() {
+      if constexpr (!Kokkos::is_view_v<std::decay_t<CallbackOrView>>)
+        return false;
+      else if constexpr (!Details::is_pair_value_index_v<value_type>)
+        return false;
+      else
+      {
+        return std::is_same_v<typename std::decay_t<CallbackOrView>::value_type,
+                              typename value_type::index_type>;
+      }
+    }();
+
+    if constexpr (use_convenient_shortcut)
+    {
+      // Simplified way to get APIv1 result using APIv2 interface
+      Details::CrsGraphWrapperImpl::queryDispatch(
+          Tag{}, *this, space, Predicates{user_predicates},
+          Details::LegacyDefaultCallback{},
+          std::forward<CallbackOrView>(callback_or_view),
+          std::forward<View>(view), std::forward<Args>(args)...);
+      return;
+    }
+    else
+    {
+      Details::CrsGraphWrapperImpl::queryDispatch(
+          Tag{}, *this, space, Predicates{user_predicates},
+          std::forward<CallbackOrView>(callback_or_view),
+          std::forward<View>(view), std::forward<Args>(args)...);
+    }
   }
 
   template <typename Predicate, typename Callback>

--- a/src/details/ArborX_PairValueIndex.hpp
+++ b/src/details/ArborX_PairValueIndex.hpp
@@ -31,6 +31,21 @@ struct PairValueIndex
   Index index;
 };
 
+namespace Details
+{
+template <typename T>
+struct is_pair_value_index : public std::false_type
+{};
+
+template <typename Value, typename Index>
+struct is_pair_value_index<PairValueIndex<Value, Index>> : public std::true_type
+{};
+
+template <typename T>
+inline constexpr bool is_pair_value_index_v = is_pair_value_index<T>::value;
+
+} // namespace Details
+
 } // namespace ArborX
 
 #endif


### PR DESCRIPTION
Right now, it is inconvenient to get the old behavior. One has to write
```c++
ArborX::BVH<MemorySpace, ArborX::PairValueIndex<Box>>
  tree(space, ArborX::Experimental::attach_indices(boxes));
tree.query(space, queries, ArborX::LegacyDefaultCallback{}, indices, offsets);
```
The presence of the `LegacyDefaultCallback` is really annoying.

This patch changes this. It automatically adds LegacyDefaultCallback
if the following 3 conditions are satisfied:
1. A user does not provide a callback
2. The index is constructed on PairValueIndex
2. The output value_type matches the index_type in the PairValueIndex.