### PR TITLE
Implement nearest query for BruteForce

### DIFF
--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -237,18 +237,12 @@ void BruteForce<MemorySpace, Value, IndexableGetter, BoundingVolume>::query(
   Predicates predicates{user_predicates}; // NOLINT
 
   using Tag = typename Predicates::value_type::Tag;
-  static_assert(std::is_same<Tag, Details::SpatialPredicateTag>{},
-                "nearest query not implemented yet");
-
-  Kokkos::Profiling::pushRegion("ArborX::BruteForce::query::spatial");
 
   Details::BruteForceImpl::query(
-      space, predicates, _values,
+      Tag{}, space, predicates, _values,
       Details::Indexables<decltype(_values), IndexableGetter>{
           _values, _indexable_getter},
       callback);
-
-  Kokkos::Profiling::popRegion();
 }
 
 } // namespace ArborX

--- a/src/details/ArborX_DetailsBruteForceImpl.hpp
+++ b/src/details/ArborX_DetailsBruteForceImpl.hpp
@@ -206,11 +206,11 @@ struct BruteForceImpl
               radius = heap.top().second;
             }
           }
-          while (!heap.empty())
-          {
-            callback(predicate, values(heap.top().first));
-            heap.pop();
-          }
+
+          // Match the logic in TreeTraversal and do the sorting
+          sortHeap(heap.data(), heap.data() + heap.size(), heap.valueComp());
+          for (decltype(heap.size()) i = 0; i < heap.size(); ++i)
+            callback(predicate, values((heap.data() + i)->first));
         });
   }
 };

--- a/src/details/ArborX_DetailsBruteForceImpl.hpp
+++ b/src/details/ArborX_DetailsBruteForceImpl.hpp
@@ -192,18 +192,19 @@ struct BruteForceImpl
           // neighbors have been found.
           auto radius = KokkosExt::ArithmeticTraits::infinity<float>::value;
 
-          for (int j = 0; j < n_indexables; ++j)
+          int j = 0;
+          for (; j < n_indexables && j < k; ++j)
+          {
+            auto const distance = predicate.distance(indexables(j));
+            heap.push(Kokkos::make_pair(j, distance));
+          }
+          for (; j < n_indexables; ++j)
           {
             auto const distance = predicate.distance(indexables(j));
             if (distance < radius)
             {
-              auto pair = Kokkos::make_pair(j, distance);
-              if ((int)heap.size() < k)
-                heap.push(pair);
-              else
-                heap.popPush(pair);
-              if ((int)heap.size() == k)
-                radius = heap.top().second;
+              heap.popPush(Kokkos::make_pair(j, distance));
+              radius = heap.top().second;
             }
           }
           while (!heap.empty())

--- a/src/details/ArborX_DetailsBruteForceImpl.hpp
+++ b/src/details/ArborX_DetailsBruteForceImpl.hpp
@@ -19,6 +19,7 @@
 #include <ArborX_DetailsNearestBufferProvider.hpp>
 #include <ArborX_DetailsPriorityQueue.hpp>
 #include <ArborX_Exception.hpp>
+#include <ArborX_Predicates.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>

--- a/src/details/ArborX_DetailsBruteForceImpl.hpp
+++ b/src/details/ArborX_DetailsBruteForceImpl.hpp
@@ -110,8 +110,7 @@ struct BruteForceImpl
                                                   predicates_per_team);
           ScratchIndexableType scratch_indexables(teamMember.team_scratch(0),
                                                   indexables_per_team);
-          // fill the scratch space with the predicates / indexables in the
-          // tile
+          // fill the scratch space with the predicates / indexables in the tile
           Kokkos::parallel_for(
               Kokkos::TeamVectorRange(teamMember, predicates_in_this_team),
               [&](const int q) {

--- a/src/details/ArborX_DetailsNearestBufferProvider.hpp
+++ b/src/details/ArborX_DetailsNearestBufferProvider.hpp
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * Copyright (c) 2017-2023 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef ARBORX_DETAILS_NEAREST_BUFFER_PROVIDER_HPP
+#define ARBORX_DETAILS_NEAREST_BUFFER_PROVIDER_HPP
+
+#include <ArborX_DetailsKokkosExtViewHelpers.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace ArborX::Details
+{
+
+template <typename MemorySpace>
+struct NearestBufferProvider
+{
+  static_assert(Kokkos::is_memory_space_v<MemorySpace>);
+
+  using PairIndexDistance = Kokkos::pair<int, float>;
+
+  Kokkos::View<PairIndexDistance *, MemorySpace> _buffer;
+  Kokkos::View<int *, MemorySpace> _offset;
+
+  NearestBufferProvider() = default;
+
+  template <typename ExecutionSpace, typename Predicates>
+  NearestBufferProvider(ExecutionSpace const &space,
+                        Predicates const &predicates)
+      : _buffer("ArborX::NearestBufferProvider::buffer", 0)
+      , _offset("ArborX::NearestBufferProvider::offset", 0)
+  {
+    allocateBuffer(space, predicates);
+  }
+
+  KOKKOS_FUNCTION auto operator()(int i) const
+  {
+    auto const *offset_ptr = &_offset(i);
+    return Kokkos::subview(_buffer,
+                           Kokkos::make_pair(*offset_ptr, *(offset_ptr + 1)));
+  }
+
+  template <typename ExecutionSpace, typename Predicates>
+  void allocateBuffer(ExecutionSpace const &space, Predicates const &predicates)
+  {
+    auto const n_queries = predicates.size();
+
+    KokkosExt::reallocWithoutInitializing(space, _offset, n_queries + 1);
+
+    Kokkos::parallel_for(
+        "ArborX::NearestBufferProvider::scan_queries_for_numbers_of_neighbors",
+        Kokkos::RangePolicy<ExecutionSpace>(space, 0, n_queries),
+        KOKKOS_CLASS_LAMBDA(int i) { _offset(i) = getK(predicates(i)); });
+    KokkosExt::exclusive_scan(space, _offset, _offset, 0);
+    int const buffer_size = KokkosExt::lastElement(space, _offset);
+    // Allocate buffer over which to perform heap operations in the nearest
+    // query to store nearest nodes found so far.
+    // It is not possible to anticipate how much memory to allocate since the
+    // number of nearest neighbors k is only known at runtime.
+
+    KokkosExt::reallocWithoutInitializing(space, _buffer, buffer_size);
+  }
+};
+
+} // namespace ArborX::Details
+
+#endif

--- a/src/details/ArborX_DetailsNearestBufferProvider.hpp
+++ b/src/details/ArborX_DetailsNearestBufferProvider.hpp
@@ -41,9 +41,8 @@ struct NearestBufferProvider
 
   KOKKOS_FUNCTION auto operator()(int i) const
   {
-    auto const *offset_ptr = &_offset(i);
     return Kokkos::subview(_buffer,
-                           Kokkos::make_pair(*offset_ptr, *(offset_ptr + 1)));
+                           Kokkos::make_pair(_offset(i), _offset(i + 1)));
   }
 
   // Enclosing function for an extended __host__ __device__ lambda cannot have

--- a/src/details/ArborX_DetailsNearestBufferProvider.hpp
+++ b/src/details/ArborX_DetailsNearestBufferProvider.hpp
@@ -11,6 +11,7 @@
 #ifndef ARBORX_DETAILS_NEAREST_BUFFER_PROVIDER_HPP
 #define ARBORX_DETAILS_NEAREST_BUFFER_PROVIDER_HPP
 
+#include <ArborX_DetailsKokkosExtStdAlgorithms.hpp>
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/src/details/ArborX_DetailsNearestBufferProvider.hpp
+++ b/src/details/ArborX_DetailsNearestBufferProvider.hpp
@@ -46,6 +46,11 @@ struct NearestBufferProvider
                            Kokkos::make_pair(*offset_ptr, *(offset_ptr + 1)));
   }
 
+  // Enclosing function for an extended __host__ __device__ lambda cannot have
+  // private or protected access within its class
+#ifndef KOKKOS_COMPILER_NVCC
+private:
+#endif
   template <typename ExecutionSpace, typename Predicates>
   void allocateBuffer(ExecutionSpace const &space, Predicates const &predicates)
   {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,7 +106,6 @@ foreach(_test Callbacks Degenerate ManufacturedSolution ComparisonWithBoost)
     "        ArborX::Details::DefaultIndexableGetter, ArborX::Box>>;\n"
     "#define ARBORX_TEST_TREE_TYPES Tuple<ArborX_BruteForce_Box, ArborX_Legacy_BruteForce_Box>\n"
     "#define ARBORX_TEST_DEVICE_TYPES std::tuple<${ARBORX_DEVICE_TYPES}>\n"
-    "#define ARBORX_TEST_DISABLE_NEAREST_QUERY\n"
     "#define ARBORX_TEST_DISABLE_CALLBACK_EARLY_EXIT\n"
     "#include <tstQueryTree${_test}.cpp>\n"
   )

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -41,7 +41,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
          void const * /*ptr*/, uint64_t /*size*/) {
         std::regex re("^(Testing::"
                       "|ArborX::BVH::"
-                      "|ArborX::NearestBufferProvider::"
                       "|ArborX::Sorting::"
                       "|Kokkos::SortImpl::BinSortFunctor::"
                       "|Kokkos::Serial::" // unsure what's going on

--- a/test/tstKokkosToolsAnnotations.cpp
+++ b/test/tstKokkosToolsAnnotations.cpp
@@ -41,6 +41,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_bvh_allocations_prefixed, DeviceType,
          void const * /*ptr*/, uint64_t /*size*/) {
         std::regex re("^(Testing::"
                       "|ArborX::BVH::"
+                      "|ArborX::NearestBufferProvider::"
                       "|ArborX::Sorting::"
                       "|Kokkos::SortImpl::BinSortFunctor::"
                       "|Kokkos::Serial::" // unsure what's going on
@@ -89,6 +90,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(bvh_query_allocations_prefixed, DeviceType,
          void const * /*ptr*/, uint64_t /*size*/) {
         std::regex re("^(Testing::"
                       "|ArborX::BVH::query::"
+                      "|ArborX::NearestBufferProvider::"
                       "|ArborX::TreeTraversal::spatial::"
                       "|ArborX::TreeTraversal::nearest::"
                       "|ArborX::CrsGraphWrapper::"

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -38,7 +38,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         std::regex re("^(Testing::"
                       "|ArborX::DistributedTree::"
                       "|ArborX::BVH::"
-                      "|ArborX::NearestBufferProvider::"
                       "|ArborX::Sorting::"
                       ").*");
         BOOST_TEST(std::regex_match(label, re),

--- a/test/tstKokkosToolsDistributedAnnotations.cpp
+++ b/test/tstKokkosToolsDistributedAnnotations.cpp
@@ -38,6 +38,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         std::regex re("^(Testing::"
                       "|ArborX::DistributedTree::"
                       "|ArborX::BVH::"
+                      "|ArborX::NearestBufferProvider::"
                       "|ArborX::Sorting::"
                       ").*");
         BOOST_TEST(std::regex_match(label, re),
@@ -73,6 +74,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
                       "|ArborX::DistributedTree::query::"
                       "|ArborX::Distributor::"
                       "|ArborX::BVH::query::"
+                      "|ArborX::NearestBufferProvider::"
                       "|ArborX::TreeTraversal::spatial::"
                       "|ArborX::TreeTraversal::nearest::"
                       "|ArborX::CrsGraphWrapper::"


### PR DESCRIPTION
This is a straightforward not-optimized version of the nearest query for BruteForce. I think, k=1 case should be separated out in the future, as it can be performed in a tiling manner similar to the spatial search. The same, however, can't be said about k > 1 case.

Right now, a single thread is allocated per predicate, that goes through all indexables. This limitation is due to the fact that we don't have a multi-thread PriorityQueue.

I reenabled the nearest queries tests in the tests.

My overall motivation for implementing this is to try using BruteForce as the top tree in the DistributedTree.