### PR TITLE
Add missing header for CUDA clang workaround

### DIFF
--- a/test/tstIndexableGetter.cpp
+++ b/test/tstIndexableGetter.cpp
@@ -12,6 +12,7 @@
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_IndexableGetter.hpp>
 
+#include "BoostTest_CUDA_clang_workarounds.hpp"
 #include <boost/test/unit_test.hpp>
 
 using namespace ArborX::Details;


### PR DESCRIPTION
Missed CUDA-Clang failure in #1045.