### PR TITLE
Implement Box-Triangle intersection

### DIFF
--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -616,7 +616,9 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
                   (max_corner[1] - min_corner[1]) / 2,
                   (max_corner[2] - min_corner[2]) / 2};
 
-    // Test normal of the triangle
+    // test normal of the triangle
+    // check if the projection of the triangle its normal lies in the interval
+    // defined by the projecting of the box onto the same vector
     Point normal{{vector_ab[1] * vector_ac[2] - vector_ab[2] * vector_ac[1],
                   vector_ab[2] * vector_ac[0] - vector_ab[0] * vector_ac[2],
                   vector_ab[0] * vector_ac[1] - vector_ab[1] * vector_ac[0]}};
@@ -627,7 +629,7 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
     if (Kokkos::abs(a_projected) > radius)
       return false;
 
-    // Test crossproducts
+    // Test crossproducts in a similar way as the triangle's normal above
     Point vector_bc{c[0] - b[0], c[1] - b[1], c[2] - b[2]};
 
     // e_x x vector_ab = (0, -vector_ab[2],  vector_ab[1])

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -596,7 +596,6 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
     constexpr int DIM = GeometryTraits::dimension_v<Triangle>;
     static_assert(DIM == 3,
                   "Box-Triangle intersection only implemented in 3d!");
-    using Float = typename GeometryTraits::coordinate_type_t<Triangle>;
     auto min_corner = box.minCorner();
     auto max_corner = box.maxCorner();
     auto a = triangle.a;
@@ -604,7 +603,7 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
     auto c = triangle.c;
     for (int i = 0; i < DIM; ++i)
     {
-      Float const shift = -(max_corner[i] + min_corner[i]) / 2;
+      auto const shift = -(max_corner[i] + min_corner[i]) / 2;
       a[i] += shift;
       b[i] += shift;
       c[i] += shift;
@@ -621,10 +620,10 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
     Point normal{{vector_ab[1] * vector_ac[2] - vector_ab[2] * vector_ac[1],
                   vector_ab[2] * vector_ac[0] - vector_ab[0] * vector_ac[2],
                   vector_ab[0] * vector_ac[1] - vector_ab[1] * vector_ac[0]}};
-    Float radius = extents[0] * Kokkos::abs(normal[0]) +
-                   extents[1] * Kokkos::abs(normal[1]) +
-                   extents[2] * Kokkos::abs(normal[2]);
-    Float a_projected = a[0] * normal[0] + a[1] * normal[1] + a[2] * normal[2];
+    auto radius = extents[0] * Kokkos::abs(normal[0]) +
+                  extents[1] * Kokkos::abs(normal[1]) +
+                  extents[2] * Kokkos::abs(normal[2]);
+    auto a_projected = a[0] * normal[0] + a[1] * normal[1] + a[2] * normal[2];
     if (Kokkos::abs(a_projected) > radius)
       return false;
 
@@ -633,28 +632,28 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
 
     // e_x x vector_ab = (0, -vector_ab[2],  vector_ab[1])
     {
-      Float radius = extents[1] * Kokkos::abs(vector_ab[2]) +
-                     extents[2] * Kokkos::abs(vector_ab[1]);
-      Float xab_0 = -a[1] * vector_ab[2] + a[2] * vector_ab[1];
-      Float xab_1 = -c[1] * vector_ab[2] + c[2] * vector_ab[1];
+      auto radius = extents[1] * Kokkos::abs(vector_ab[2]) +
+                    extents[2] * Kokkos::abs(vector_ab[1]);
+      auto xab_0 = -a[1] * vector_ab[2] + a[2] * vector_ab[1];
+      auto xab_1 = -c[1] * vector_ab[2] + c[2] * vector_ab[1];
       if (Kokkos::fmin(xab_0, xab_1) > radius ||
           Kokkos::fmax(xab_0, xab_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[1] * Kokkos::abs(vector_ac[2]) +
-                     extents[2] * Kokkos::abs(vector_ac[1]);
-      Float xac_0 = -a[1] * vector_ac[2] + a[2] * vector_ac[1];
-      Float xac_1 = -b[1] * vector_ac[2] + b[2] * vector_ac[1];
+      auto radius = extents[1] * Kokkos::abs(vector_ac[2]) +
+                    extents[2] * Kokkos::abs(vector_ac[1]);
+      auto xac_0 = -a[1] * vector_ac[2] + a[2] * vector_ac[1];
+      auto xac_1 = -b[1] * vector_ac[2] + b[2] * vector_ac[1];
       if (Kokkos::fmin(xac_0, xac_1) > radius ||
           Kokkos::fmax(xac_0, xac_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[1] * Kokkos::abs(vector_bc[2]) +
-                     extents[2] * Kokkos::abs(vector_bc[1]);
-      Float xbc_0 = -a[1] * vector_bc[2] + a[2] * vector_bc[1];
-      Float xbc_1 = -b[1] * vector_bc[2] + b[2] * vector_bc[1];
+      auto radius = extents[1] * Kokkos::abs(vector_bc[2]) +
+                    extents[2] * Kokkos::abs(vector_bc[1]);
+      auto xbc_0 = -a[1] * vector_bc[2] + a[2] * vector_bc[1];
+      auto xbc_1 = -b[1] * vector_bc[2] + b[2] * vector_bc[1];
       if (Kokkos::fmin(xbc_0, xbc_1) > radius ||
           Kokkos::fmax(xbc_0, xbc_1) < -radius)
         return false;
@@ -662,28 +661,28 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
 
     // e_y x vector_ab = (vector_ab[2], 0, -vector_ab[0])
     {
-      Float radius = extents[0] * Kokkos::abs(vector_ab[2]) +
-                     extents[2] * Kokkos::abs(vector_ab[0]);
-      Float yab_0 = a[0] * vector_ab[2] - a[2] * vector_ab[0];
-      Float yab_1 = c[0] * vector_ab[2] - c[2] * vector_ab[0];
+      auto radius = extents[0] * Kokkos::abs(vector_ab[2]) +
+                    extents[2] * Kokkos::abs(vector_ab[0]);
+      auto yab_0 = a[0] * vector_ab[2] - a[2] * vector_ab[0];
+      auto yab_1 = c[0] * vector_ab[2] - c[2] * vector_ab[0];
       if (Kokkos::fmin(yab_0, yab_1) > radius ||
           Kokkos::fmax(yab_0, yab_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(vector_ac[2]) +
-                     extents[2] * Kokkos::abs(vector_ac[0]);
-      Float yac_0 = a[0] * vector_ac[2] - a[2] * vector_ac[0];
-      Float yac_1 = b[0] * vector_ac[2] - b[2] * vector_ac[0];
+      auto radius = extents[0] * Kokkos::abs(vector_ac[2]) +
+                    extents[2] * Kokkos::abs(vector_ac[0]);
+      auto yac_0 = a[0] * vector_ac[2] - a[2] * vector_ac[0];
+      auto yac_1 = b[0] * vector_ac[2] - b[2] * vector_ac[0];
       if (Kokkos::fmin(yac_0, yac_1) > radius ||
           Kokkos::fmax(yac_0, yac_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(vector_bc[2]) +
-                     extents[2] * Kokkos::abs(vector_bc[0]);
-      Float ybc_0 = a[1] * vector_bc[2] - a[2] * vector_bc[0];
-      Float ybc_1 = b[1] * vector_bc[2] - b[2] * vector_bc[0];
+      auto radius = extents[0] * Kokkos::abs(vector_bc[2]) +
+                    extents[2] * Kokkos::abs(vector_bc[0]);
+      auto ybc_0 = a[1] * vector_bc[2] - a[2] * vector_bc[0];
+      auto ybc_1 = b[1] * vector_bc[2] - b[2] * vector_bc[0];
       if (Kokkos::fmin(ybc_0, ybc_1) > radius ||
           Kokkos::fmax(ybc_0, ybc_1) < -radius)
         return false;
@@ -691,28 +690,28 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
 
     // e_z x vector_ab = (-vector_ab[1], vector_ab[0], 0)
     {
-      Float radius = extents[0] * Kokkos::abs(vector_ab[1]) +
-                     extents[1] * Kokkos::abs(vector_ab[0]);
-      Float zab_0 = -a[0] * vector_ab[1] + a[1] * vector_ab[0];
-      Float zab_1 = -c[0] * vector_ab[1] + c[1] * vector_ab[0];
+      auto radius = extents[0] * Kokkos::abs(vector_ab[1]) +
+                    extents[1] * Kokkos::abs(vector_ab[0]);
+      auto zab_0 = -a[0] * vector_ab[1] + a[1] * vector_ab[0];
+      auto zab_1 = -c[0] * vector_ab[1] + c[1] * vector_ab[0];
       if (Kokkos::fmin(zab_0, zab_1) > radius ||
           Kokkos::fmax(zab_0, zab_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(vector_ac[1]) +
-                     extents[1] * Kokkos::abs(vector_ac[0]);
-      Float xac_0 = -a[0] * vector_ac[1] + a[1] * vector_ac[0];
-      Float xac_1 = -b[0] * vector_ac[1] + b[1] * vector_ac[0];
+      auto radius = extents[0] * Kokkos::abs(vector_ac[1]) +
+                    extents[1] * Kokkos::abs(vector_ac[0]);
+      auto xac_0 = -a[0] * vector_ac[1] + a[1] * vector_ac[0];
+      auto xac_1 = -b[0] * vector_ac[1] + b[1] * vector_ac[0];
       if (Kokkos::fmin(xac_0, xac_1) > radius ||
           Kokkos::fmax(xac_0, xac_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(vector_bc[1]) +
-                     extents[1] * Kokkos::abs(vector_bc[0]);
-      Float zbc_0 = -a[0] * vector_bc[1] + a[1] * vector_bc[0];
-      Float zbc_1 = -b[0] * vector_bc[1] + b[1] * vector_bc[0];
+      auto radius = extents[0] * Kokkos::abs(vector_bc[1]) +
+                    extents[1] * Kokkos::abs(vector_bc[0]);
+      auto zbc_0 = -a[0] * vector_bc[1] + a[1] * vector_bc[0];
+      auto zbc_1 = -b[0] * vector_bc[1] + b[1] * vector_bc[0];
       if (Kokkos::fmin(zbc_0, zbc_1) > radius ||
           Kokkos::fmax(zbc_0, zbc_1) < -radius)
         return false;

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -610,9 +610,9 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
       b[i] += shift;
       c[i] += shift;
     }
-    ExperimentalHyperGeometry::Point<DIM, Float> edge_ab{
+    ExperimentalHyperGeometry::Point<DIM, Float> vector_ab{
         b[0] - a[0], b[1] - a[1], b[2] - a[2]};
-    ExperimentalHyperGeometry::Point<DIM, Float> edge_ac{
+    ExperimentalHyperGeometry::Point<DIM, Float> vector_ac{
         c[0] - a[0], c[1] - a[1], c[2] - a[2]};
     ExperimentalHyperGeometry::Point<DIM, Float> extents{
         max_corner[0] - min_corner[0], max_corner[1] - min_corner[1],
@@ -620,9 +620,9 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
 
     // Test normal of the triangle
     ExperimentalHyperGeometry::Point<DIM, Float> normal{
-        {edge_ab[1] * edge_ac[2] - edge_ab[2] * edge_ac[1],
-         edge_ab[2] * edge_ac[0] - edge_ab[0] * edge_ac[2],
-         edge_ab[0] * edge_ac[1] - edge_ab[1] * edge_ac[0]}};
+        {vector_ab[1] * vector_ac[2] - vector_ab[2] * vector_ac[1],
+         vector_ab[2] * vector_ac[0] - vector_ab[0] * vector_ac[2],
+         vector_ab[0] * vector_ac[1] - vector_ab[1] * vector_ac[0]}};
     Float radius = extents[0] * Kokkos::abs(normal[0]) +
                    extents[1] * Kokkos::abs(normal[1]) +
                    extents[2] * Kokkos::abs(normal[2]);
@@ -631,91 +631,91 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
       return false;
 
     // Test crossproducts
-    ExperimentalHyperGeometry::Point<DIM, Float> edge_bc{
+    ExperimentalHyperGeometry::Point<DIM, Float> vector_bc{
         c[0] - b[0], c[1] - b[1], c[2] - b[2]};
 
-    // e_x x edge_ab = (0, -edge_ab[2],  edge_ab[1])
+    // e_x x vector_ab = (0, -vector_ab[2],  vector_ab[1])
     {
-      Float radius = extents[1] * Kokkos::abs(edge_ab[2]) +
-                     extents[2] * Kokkos::abs(edge_ab[1]);
-      Float xab_0 = -a[1] * edge_ab[2] + a[2] * edge_ab[1];
-      Float xab_1 = -c[1] * edge_ab[2] + c[2] * edge_ab[1];
+      Float radius = extents[1] * Kokkos::abs(vector_ab[2]) +
+                     extents[2] * Kokkos::abs(vector_ab[1]);
+      Float xab_0 = -a[1] * vector_ab[2] + a[2] * vector_ab[1];
+      Float xab_1 = -c[1] * vector_ab[2] + c[2] * vector_ab[1];
       if (Kokkos::fmin(xab_0, xab_1) > radius ||
           Kokkos::fmax(xab_0, xab_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[1] * Kokkos::abs(edge_ac[2]) +
-                     extents[2] * Kokkos::abs(edge_ac[1]);
-      Float xac_0 = -a[1] * edge_ac[2] + a[2] * edge_ac[1];
-      Float xac_1 = -b[1] * edge_ac[2] + b[2] * edge_ac[1];
+      Float radius = extents[1] * Kokkos::abs(vector_ac[2]) +
+                     extents[2] * Kokkos::abs(vector_ac[1]);
+      Float xac_0 = -a[1] * vector_ac[2] + a[2] * vector_ac[1];
+      Float xac_1 = -b[1] * vector_ac[2] + b[2] * vector_ac[1];
       if (Kokkos::fmin(xac_0, xac_1) > radius ||
           Kokkos::fmax(xac_0, xac_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[1] * Kokkos::abs(edge_bc[2]) +
-                     extents[2] * Kokkos::abs(edge_bc[1]);
-      Float xbc_0 = -a[1] * edge_bc[2] + a[2] * edge_bc[1];
-      Float xbc_1 = -b[1] * edge_bc[2] + b[2] * edge_bc[1];
+      Float radius = extents[1] * Kokkos::abs(vector_bc[2]) +
+                     extents[2] * Kokkos::abs(vector_bc[1]);
+      Float xbc_0 = -a[1] * vector_bc[2] + a[2] * vector_bc[1];
+      Float xbc_1 = -b[1] * vector_bc[2] + b[2] * vector_bc[1];
       if (Kokkos::fmin(xbc_0, xbc_1) > radius ||
           Kokkos::fmax(xbc_0, xbc_1) < -radius)
         return false;
     }
 
-    // e_y x edge_ab = (edge_ab[2], 0, -edge_ab[0])
+    // e_y x vector_ab = (vector_ab[2], 0, -vector_ab[0])
     {
-      Float radius = extents[0] * Kokkos::abs(edge_ab[2]) +
-                     extents[2] * Kokkos::abs(edge_ab[0]);
-      Float yab_0 = a[0] * edge_ab[2] - a[2] * edge_ab[0];
-      Float yab_1 = c[0] * edge_ab[2] - c[2] * edge_ab[0];
+      Float radius = extents[0] * Kokkos::abs(vector_ab[2]) +
+                     extents[2] * Kokkos::abs(vector_ab[0]);
+      Float yab_0 = a[0] * vector_ab[2] - a[2] * vector_ab[0];
+      Float yab_1 = c[0] * vector_ab[2] - c[2] * vector_ab[0];
       if (Kokkos::fmin(yab_0, yab_1) > radius ||
           Kokkos::fmax(yab_0, yab_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(edge_ac[2]) +
-                     extents[2] * Kokkos::abs(edge_ac[0]);
-      Float yac_0 = a[0] * edge_ac[2] - a[2] * edge_ac[0];
-      Float yac_1 = b[0] * edge_ac[2] - b[2] * edge_ac[0];
+      Float radius = extents[0] * Kokkos::abs(vector_ac[2]) +
+                     extents[2] * Kokkos::abs(vector_ac[0]);
+      Float yac_0 = a[0] * vector_ac[2] - a[2] * vector_ac[0];
+      Float yac_1 = b[0] * vector_ac[2] - b[2] * vector_ac[0];
       if (Kokkos::fmin(yac_0, yac_1) > radius ||
           Kokkos::fmax(yac_0, yac_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(edge_bc[2]) +
-                     extents[2] * Kokkos::abs(edge_bc[0]);
-      Float ybc_0 = a[1] * edge_bc[2] - a[2] * edge_bc[0];
-      Float ybc_1 = b[1] * edge_bc[2] - b[2] * edge_bc[0];
+      Float radius = extents[0] * Kokkos::abs(vector_bc[2]) +
+                     extents[2] * Kokkos::abs(vector_bc[0]);
+      Float ybc_0 = a[1] * vector_bc[2] - a[2] * vector_bc[0];
+      Float ybc_1 = b[1] * vector_bc[2] - b[2] * vector_bc[0];
       if (Kokkos::fmin(ybc_0, ybc_1) > radius ||
           Kokkos::fmax(ybc_0, ybc_1) < -radius)
         return false;
     }
 
-    // e_z x edge_ab = (-edge_ab[1], edge_ab[0], 0)
+    // e_z x vector_ab = (-vector_ab[1], vector_ab[0], 0)
     {
-      Float radius = extents[0] * Kokkos::abs(edge_ab[1]) +
-                     extents[1] * Kokkos::abs(edge_ab[0]);
-      Float zab_0 = -a[0] * edge_ab[1] + a[1] * edge_ab[0];
-      Float zab_1 = -c[0] * edge_ab[1] + c[1] * edge_ab[0];
+      Float radius = extents[0] * Kokkos::abs(vector_ab[1]) +
+                     extents[1] * Kokkos::abs(vector_ab[0]);
+      Float zab_0 = -a[0] * vector_ab[1] + a[1] * vector_ab[0];
+      Float zab_1 = -c[0] * vector_ab[1] + c[1] * vector_ab[0];
       if (Kokkos::fmin(zab_0, zab_1) > radius ||
           Kokkos::fmax(zab_0, zab_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(edge_ac[1]) +
-                     extents[1] * Kokkos::abs(edge_ac[0]);
-      Float xac_0 = -a[0] * edge_ac[1] + a[1] * edge_ac[0];
-      Float xac_1 = -b[0] * edge_ac[1] + b[1] * edge_ac[0];
+      Float radius = extents[0] * Kokkos::abs(vector_ac[1]) +
+                     extents[1] * Kokkos::abs(vector_ac[0]);
+      Float xac_0 = -a[0] * vector_ac[1] + a[1] * vector_ac[0];
+      Float xac_1 = -b[0] * vector_ac[1] + b[1] * vector_ac[0];
       if (Kokkos::fmin(xac_0, xac_1) > radius ||
           Kokkos::fmax(xac_0, xac_1) < -radius)
         return false;
     }
     {
-      Float radius = extents[0] * Kokkos::abs(edge_bc[1]) +
-                     extents[1] * Kokkos::abs(edge_bc[0]);
-      Float zbc_0 = -a[0] * edge_bc[1] + a[1] * edge_bc[0];
-      Float zbc_1 = -b[0] * edge_bc[1] + b[1] * edge_bc[0];
+      Float radius = extents[0] * Kokkos::abs(vector_bc[1]) +
+                     extents[1] * Kokkos::abs(vector_bc[0]);
+      Float zbc_0 = -a[0] * vector_bc[1] + a[1] * vector_bc[0];
+      Float zbc_1 = -b[0] * vector_bc[1] + b[1] * vector_bc[0];
       if (Kokkos::fmin(zbc_0, zbc_1) > radius ||
           Kokkos::fmax(zbc_0, zbc_1) < -radius)
         return false;

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -613,8 +613,9 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
     using Point = decltype(a);
     Point vector_ab{b[0] - a[0], b[1] - a[1], b[2] - a[2]};
     Point vector_ac{c[0] - a[0], c[1] - a[1], c[2] - a[2]};
-    Point extents{max_corner[0] - min_corner[0], max_corner[1] - min_corner[1],
-                  max_corner[2] - min_corner[2]};
+    Point extents{(max_corner[0] - min_corner[0]) / 2,
+                  (max_corner[1] - min_corner[1]) / 2,
+                  (max_corner[2] - min_corner[2]) / 2};
 
     // Test normal of the triangle
     Point normal{{vector_ab[1] * vector_ac[2] - vector_ab[2] * vector_ac[1],

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -15,7 +15,6 @@
 #include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp> // min, max
 #include <ArborX_GeometryTraits.hpp>
-#include <ArborX_HyperPoint.hpp>
 
 #include <Kokkos_Assert.hpp> // KOKKOS_ASSERT
 #include <Kokkos_Macros.hpp>
@@ -610,19 +609,17 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
       b[i] += shift;
       c[i] += shift;
     }
-    ExperimentalHyperGeometry::Point<DIM, Float> vector_ab{
-        b[0] - a[0], b[1] - a[1], b[2] - a[2]};
-    ExperimentalHyperGeometry::Point<DIM, Float> vector_ac{
-        c[0] - a[0], c[1] - a[1], c[2] - a[2]};
-    ExperimentalHyperGeometry::Point<DIM, Float> extents{
-        max_corner[0] - min_corner[0], max_corner[1] - min_corner[1],
-        max_corner[2] - min_corner[2]};
+
+    using Point = decltype(a);
+    Point vector_ab{b[0] - a[0], b[1] - a[1], b[2] - a[2]};
+    Point vector_ac{c[0] - a[0], c[1] - a[1], c[2] - a[2]};
+    Point extents{max_corner[0] - min_corner[0], max_corner[1] - min_corner[1],
+                  max_corner[2] - min_corner[2]};
 
     // Test normal of the triangle
-    ExperimentalHyperGeometry::Point<DIM, Float> normal{
-        {vector_ab[1] * vector_ac[2] - vector_ab[2] * vector_ac[1],
-         vector_ab[2] * vector_ac[0] - vector_ab[0] * vector_ac[2],
-         vector_ab[0] * vector_ac[1] - vector_ab[1] * vector_ac[0]}};
+    Point normal{{vector_ab[1] * vector_ac[2] - vector_ab[2] * vector_ac[1],
+                  vector_ab[2] * vector_ac[0] - vector_ab[0] * vector_ac[2],
+                  vector_ab[0] * vector_ac[1] - vector_ab[1] * vector_ac[0]}};
     Float radius = extents[0] * Kokkos::abs(normal[0]) +
                    extents[1] * Kokkos::abs(normal[1]) +
                    extents[2] * Kokkos::abs(normal[2]);
@@ -631,8 +628,7 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
       return false;
 
     // Test crossproducts
-    ExperimentalHyperGeometry::Point<DIM, Float> vector_bc{
-        c[0] - b[0], c[1] - b[1], c[2] - b[2]};
+    Point vector_bc{c[0] - b[0], c[1] - b[1], c[2] - b[2]};
 
     // e_x x vector_ab = (0, -vector_ab[2],  vector_ab[1])
     {

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -603,21 +603,22 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
     auto triangle_a = triangle.a;
     auto triangle_b = triangle.b;
     auto triangle_c = triangle.c;
-    ExperimentalHyperGeometry::Point<DIM, Float> edge_ab;
-    ExperimentalHyperGeometry::Point<DIM, Float> edge_ac;
-    ExperimentalHyperGeometry::Point<DIM, Float> extents;
     for (int i = 0; i < DIM; ++i)
     {
       Float const shift = -(max_corner[i] + min_corner[i]) / 2;
-      min_corner[i] += shift;
-      max_corner[i] += shift;
       triangle_a[i] += shift;
       triangle_b[i] += shift;
       triangle_c[i] += shift;
-      edge_ab[i] = triangle_b[i] - triangle_a[i];
-      edge_ac[i] = triangle_c[i] - triangle_a[i];
-      extents[i] = (max_corner[i] - min_corner[i]) / 2;
     }
+    ExperimentalHyperGeometry::Point<DIM, Float> edge_ab{
+        triangle_b[0] - triangle_a[0], triangle_b[1] - triangle_a[1],
+        triangle_b[2] - triangle_a[2]};
+    ExperimentalHyperGeometry::Point<DIM, Float> edge_ac{
+        triangle_c[0] - triangle_a[0], triangle_c[1] - triangle_a[1],
+        triangle_c[2] - triangle_a[2]};
+    ExperimentalHyperGeometry::Point<DIM, Float> extents{
+        max_corner[0] - min_corner[0], max_corner[1] - min_corner[1],
+        max_corner[2] - min_corner[2]};
 
     // Test normal of the triangle
     ExperimentalHyperGeometry::Point<DIM, Float> normal{

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -578,14 +578,22 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
   {
     // Based on the Separating Axis Theorem
     // https://doi.org/10.1145/1198555.1198747
+    // we have to project the box and the triangle onto 13 axes and check for
+    // overlap. These axes are:
+    // - the 3 normals of the box
+    // - the normal of the triangle
+    // - the 9 crossproduct between the 3 edge (directions) of the box and the 3
+    // edges of the triangle
 
-    // Test bounding boxes, i.e., normals of the box
+    // Testing the normals of the box is the same as testing the overlap of
+    // bounding boxes.
     Box triangle_bounding_box;
     ArborX::Details::expand(triangle_bounding_box, triangle);
     if (!ArborX::Details::intersects(triangle_bounding_box, box))
       return false;
 
-    // shift to origin
+    // shift box and triangle so that the box's center is at the origin to
+    // simplify the following checks.
     constexpr int DIM = GeometryTraits::dimension_v<Triangle>;
     static_assert(DIM == 3,
                   "Box-Triangle intersection only implemented in 3d!");

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -577,6 +577,7 @@ struct intersects<BoxTag, TriangleTag, Box, Triangle>
                                               Triangle const &triangle)
   {
     // Based on the Separating Axis Theorem
+    // https://doi.org/10.1145/1198555.1198747
 
     // Test bounding boxes, i.e., normals of the box
     Box triangle_bounding_box;

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -255,6 +255,27 @@ BOOST_AUTO_TEST_CASE(intersects)
   BOOST_TEST(!intersects(Point2{{0.5, 1.1}}, triangle));
   BOOST_TEST(!intersects(Point2{{1.1, 0}}, triangle));
   BOOST_TEST(!intersects(Point2{{-0.1, 0}}, triangle));
+
+  // triangle box
+  constexpr ArborX::ExperimentalHyperGeometry::Triangle<3> triangle3{
+      {{1, 0, 0}}, {{0, 1, 0}}, {{0, 0, 1}}};
+  constexpr Box unit_box{{{0, 0, 0}}, {{1, 1, 1}}};
+  BOOST_TEST(intersects(triangle3, Box{{{0., 0., 0.}}, {{1., 1., 1.}}}));
+  BOOST_TEST(intersects(triangle3, Box{{{.2, .25, .25}}, {{.4, .3, .5}}}));
+  BOOST_TEST(!intersects(triangle3, Box{{{.1, .2, .3}}, {{.2, .3, .4}}}));
+  BOOST_TEST(intersects(triangle3, Box{{{0, 0, 0}}, {{.5, .25, .25}}}));
+  BOOST_TEST(intersects(
+      ArborX::ExperimentalHyperGeometry::Triangle<3>{
+          {{0, 0, 0}}, {{0, 1, 0}}, {{1, 0, 0}}},
+      unit_box));
+  BOOST_TEST(intersects(
+      ArborX::ExperimentalHyperGeometry::Triangle<3>{
+          {{0, 0, 0}}, {{0, 1, 0}}, {{-1, 0, 0}}},
+      unit_box));
+  BOOST_TEST(intersects(
+      ArborX::ExperimentalHyperGeometry::Triangle<3>{
+          {{.1, .1, .1}}, {{.1, .9, .1}}, {{.9, .1, .1}}},
+      unit_box));
 }
 
 BOOST_AUTO_TEST_CASE(equals)


### PR DESCRIPTION
Implements 3d box-triangle intersection based on the simplification in https://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/code/tribox_tam.pdf to the Separating Axis Theorem.