### PR TITLE
Revert MI100->MI210 for nightly testing

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -92,7 +92,7 @@ pipeline {
                     agent {
                         docker {
                             image 'rocm/dev-ubuntu-22.04:5.4-complete'
-                            label 'AMD_Radeon_Instinct_MI210 && rocm-docker'
+                            label 'AMD_Radeon_Instinct_MI100 && rocm-docker'
                             args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES}'
                         }
                     }


### PR DESCRIPTION
Nightlies' HIP has been failing since #1048. 

The change in continuous has been fine. But it broke the nightlies.

The alternative would be to upgrade nightly to ROCm 5.6. I have no strong opinion. 

cc @Rombur 