### PR TITLE
Introduce AnyTag to allow users not specify tags in AccessTraits

### DIFF
--- a/examples/access_traits/example_cuda_access_traits.cpp
+++ b/examples/access_traits/example_cuda_access_traits.cpp
@@ -35,7 +35,7 @@ struct Spheres
 };
 
 template <>
-struct ArborX::AccessTraits<PointCloud, ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<PointCloud>
 {
   static KOKKOS_FUNCTION std::size_t size(PointCloud const &cloud)
   {
@@ -50,7 +50,7 @@ struct ArborX::AccessTraits<PointCloud, ArborX::PrimitivesTag>
 };
 
 template <>
-struct ArborX::AccessTraits<Spheres, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<Spheres>
 {
   static KOKKOS_FUNCTION std::size_t size(Spheres const &d) { return d.N; }
   static KOKKOS_FUNCTION auto get(Spheres const &d, std::size_t i)

--- a/examples/access_traits/example_host_access_traits.cpp
+++ b/examples/access_traits/example_host_access_traits.cpp
@@ -17,8 +17,8 @@
 #include <random>
 #include <vector>
 
-template <typename T, typename Tag>
-struct ArborX::AccessTraits<std::vector<T>, Tag>
+template <typename T>
+struct ArborX::AccessTraits<std::vector<T>>
 {
   static std::size_t size(std::vector<T> const &v) { return v.size(); }
   static T const &get(std::vector<T> const &v, std::size_t i) { return v[i]; }

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -29,7 +29,7 @@ struct NearestToOrigin
 };
 
 template <>
-struct ArborX::AccessTraits<FirstOctant, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<FirstOctant>
 {
   static KOKKOS_FUNCTION std::size_t size(FirstOctant) { return 1; }
   static KOKKOS_FUNCTION auto get(FirstOctant, std::size_t)
@@ -40,7 +40,7 @@ struct ArborX::AccessTraits<FirstOctant, ArborX::PredicatesTag>
 };
 
 template <>
-struct ArborX::AccessTraits<NearestToOrigin, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<NearestToOrigin>
 {
   static KOKKOS_FUNCTION std::size_t size(NearestToOrigin) { return 1; }
   static KOKKOS_FUNCTION auto get(NearestToOrigin d, std::size_t)

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -86,8 +86,7 @@ struct DepositEnergy
 } // namespace OrderedIntersectsBased
 
 template <typename MemorySpace>
-struct ArborX::AccessTraits<OrderedIntersectsBased::Rays<MemorySpace>,
-                            ArborX::PredicatesTag>
+struct ArborX::AccessTraits<OrderedIntersectsBased::Rays<MemorySpace>>
 {
   using memory_space = MemorySpace;
   using size_type = std::size_t;

--- a/src/ArborX_BruteForce.hpp
+++ b/src/ArborX_BruteForce.hpp
@@ -212,10 +212,7 @@ template <typename ExecutionSpace, typename UserValues>
 BruteForce<MemorySpace, Value, IndexableGetter, BoundingVolume>::BruteForce(
     ExecutionSpace const &space, UserValues const &user_values,
     IndexableGetter const &indexable_getter)
-    : _size(AccessTraits<UserValues, PrimitivesTag>::size(user_values))
-    , _values(Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
-                                 "ArborX::BruteForce::values"),
-              _size)
+    : _values("ArborX::BruteForce::values", 0)
     , _indexable_getter(indexable_getter)
 {
   static_assert(Details::KokkosExt::is_accessible_from<MemorySpace,
@@ -234,10 +231,13 @@ BruteForce<MemorySpace, Value, IndexableGetter, BoundingVolume>::BruteForce(
 
   Kokkos::Profiling::ScopedRegion guard("ArborX::BruteForce::BruteForce");
 
+  _size = values.size();
   if (empty())
   {
     return;
   }
+
+  Details::KokkosExt::reallocWithoutInitializing(space, _values, _size);
 
   Details::BruteForceImpl::initializeBoundingVolumesAndReduceBoundsOfTheScene(
       space, values, _indexable_getter, _values, _bounds);

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -98,8 +98,7 @@ struct MixedBoxPrimitives
 
 template <typename Primitives, typename PermuteFilter>
 struct AccessTraits<Details::PrimitivesWithRadiusReorderedAndFiltered<
-                        Primitives, PermuteFilter>,
-                    PredicatesTag>
+    Primitives, PermuteFilter>>
 {
   using memory_space = typename Primitives::memory_space;
   using Predicates =
@@ -129,8 +128,7 @@ struct AccessTraits<Details::PrimitivesWithRadiusReorderedAndFiltered<
 template <typename Points, typename MixedOffsets, typename CellIndices,
           typename Permutation>
 struct AccessTraits<
-    Details::MixedBoxPrimitives<Points, MixedOffsets, CellIndices, Permutation>,
-    ArborX::PrimitivesTag>
+    Details::MixedBoxPrimitives<Points, MixedOffsets, CellIndices, Permutation>>
 {
   using Primitives = Details::MixedBoxPrimitives<Points, MixedOffsets,
                                                  CellIndices, Permutation>;

--- a/src/details/ArborX_AttachIndices.hpp
+++ b/src/details/ArborX_AttachIndices.hpp
@@ -43,7 +43,8 @@ struct ArborX::AccessTraits<ArborX::Experimental::AttachIndices<Values, Index>,
 {
 private:
   using Self = ArborX::Experimental::AttachIndices<Values, Index>;
-  using Access = AccessTraits<Values, ArborX::PrimitivesTag>;
+  using Access =
+      AccessTraits<Values, Details::TrueTag<Values, ArborX::PrimitivesTag>>;
   using value_type = ArborX::PairValueIndex<
       std::decay_t<Kokkos::detected_t<
           ArborX::Details::AccessTraitsGetArchetypeExpression, Access, Values>>,
@@ -67,7 +68,8 @@ struct ArborX::AccessTraits<ArborX::Experimental::AttachIndices<Values, Index>,
 {
 private:
   using Self = ArborX::Experimental::AttachIndices<Values, Index>;
-  using Access = AccessTraits<Values, ArborX::PredicatesTag>;
+  using Access =
+      AccessTraits<Values, Details::TrueTag<Values, ArborX::PredicatesTag>>;
 
 public:
   using memory_space = typename Access::memory_space;

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -45,7 +45,7 @@ struct WithinDistanceFromPredicates
 
 template <class Predicates, class Distances>
 struct AccessTraits<
-    Details::WithinDistanceFromPredicates<Predicates, Distances>, PredicatesTag>
+    Details::WithinDistanceFromPredicates<Predicates, Distances>>
 {
   using Predicate = typename Predicates::value_type;
   using Geometry =

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -23,8 +23,9 @@ namespace ArborX::Details
 template <typename Primitives, typename BoundingVolume>
 class LegacyValues
 {
+  using Access = AccessTraits<Primitives, TrueTag<Primitives, PrimitivesTag>>;
+
   Primitives _primitives;
-  using Access = AccessTraits<Primitives, PrimitivesTag>;
 
 public:
   using memory_space = typename Access::memory_space;


### PR DESCRIPTION
Allow user to not specify the AccessTraits tags when there is clear disambiguation. If the same struct is used for both primitive and predicates, the tags are still required.

Mostly want to start the discussion and get the feedback. This works but I have not thought too deeply about whether it's a good implementation. 