### PR TITLE
Refactor distributed query internals

### DIFF
--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -60,12 +60,10 @@ struct DistributedTreeImpl
 
   // nearest neighbors helpers
   template <typename ExecutionSpace, typename DistributedTree,
-            typename Predicates, typename Distances, typename Indices,
-            typename Offset>
-  static void deviseStrategy(ExecutionSpace const &space,
-                             DistributedTree const &tree,
-                             Predicates const &queries, Distances const &,
-                             Indices &indices, Offset &offset);
+            typename Predicates, typename Indices, typename Offset>
+  static void
+  deviseStrategy(ExecutionSpace const &space, DistributedTree const &tree,
+                 Predicates const &queries, Indices &indices, Offset &offset);
 
   template <typename ExecutionSpace, typename DistributedTree,
             typename Predicates, typename Distances, typename Indices,

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -59,19 +59,18 @@ struct DistributedTreeImpl
                 IndicesAndRanks &values, Offset &offset);
 
   // nearest neighbors helpers
-  template <typename ExecutionSpace, typename DistributedTree,
-            typename Predicates, typename Indices, typename Offset>
-  static void
-  deviseStrategy(ExecutionSpace const &space, DistributedTree const &tree,
-                 Predicates const &queries, Indices &indices, Offset &offset);
+  template <typename ExecutionSpace, typename Tree, typename Predicates,
+            typename Distances>
+  static void phaseI(ExecutionSpace const &space, Tree const &tree,
+                     Predicates const &predicates,
+                     Distances &farthest_distances);
 
-  template <typename ExecutionSpace, typename DistributedTree,
-            typename Predicates, typename Distances, typename Indices,
-            typename Offset>
-  static void
-  reassessStrategy(ExecutionSpace const &space, DistributedTree const &tree,
-                   Predicates const &queries, Distances const &distances,
-                   Indices &indices, Offset &offset);
+  template <typename ExecutionSpace, typename Tree, typename Predicates,
+            typename Distances, typename Offset, typename Values,
+            typename Ranks>
+  static void phaseII(ExecutionSpace const &space, Tree const &tree,
+                      Predicates const &queries, Distances &distances,
+                      Offset &offset, Values &values, Ranks &ranks);
 };
 
 } // namespace ArborX::Details

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -353,7 +353,7 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
   deviseStrategy(space, tree, queries, nearest_ranks, offset);
   forwardQueriesAndCommunicateResults(comm, space, bottom_tree, queries,
                                       callback_with_distance, nearest_ranks,
-                                      offset, out, ranks);
+                                      offset, out, &ranks);
   // unzip
   auto n = out.extent(0);
   KokkosExt::reallocWithoutInitializing(space, values, n);
@@ -372,7 +372,7 @@ DistributedTreeImpl::queryDispatchImpl(NearestPredicateTag, Tree const &tree,
   reassessStrategy(space, tree, queries, distances, nearest_ranks, offset);
   forwardQueriesAndCommunicateResults(comm, space, bottom_tree, queries,
                                       callback_with_distance, nearest_ranks,
-                                      offset, out, ranks);
+                                      offset, out, &ranks);
 
   // Unzip
   n = out.extent(0);

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -220,8 +220,8 @@ void DistributedTreeImpl::phaseI(ExecutionSpace const &space, Tree const &tree,
 
   // Accumulate total leave count in the local trees until it reaches k which
   // is the number of neighbors queried for.  Stop if local trees get
-  // empty because it means that they are no more leaves and there is no point
-  // on forwarding predicates to leafless trees.
+  // empty because it means that there are no more leaves and there is no point
+  // in forwarding predicates to leafless trees.
   auto const n_predicates = predicates.size();
   auto const &bottom_tree_sizes = tree._bottom_tree_sizes;
   Kokkos::View<int *, MemorySpace> new_offset(

--- a/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
@@ -52,11 +52,9 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
   tree._top_tree.query(space, predicates, LegacyDefaultCallback{},
                        intersected_ranks, offset);
 
-  Kokkos::View<int *, MemorySpace> ranks(
-      "ArborX::DistributedTree::query::spatial::ranks", 0);
   DistributedTree::forwardQueriesAndCommunicateResults(
       tree.getComm(), space, tree._bottom_tree, predicates, callback,
-      intersected_ranks, offset, values, ranks);
+      intersected_ranks, offset, values);
 }
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,

--- a/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeSpatial.hpp
@@ -45,53 +45,18 @@ DistributedTreeImpl::queryDispatch(SpatialPredicateTag, Tree const &tree,
     return;
   }
 
-  using namespace DistributedTree;
   using MemorySpace = typename Tree::memory_space;
-
-  auto const &top_tree = tree._top_tree;
-  auto const &bottom_tree = tree._bottom_tree;
-  auto comm = tree.getComm();
 
   Kokkos::View<int *, MemorySpace> intersected_ranks(
       "ArborX::DistributedTree::query::spatial::intersected_ranks", 0);
-  top_tree.query(space, predicates, LegacyDefaultCallback{}, intersected_ranks,
-                 offset);
+  tree._top_tree.query(space, predicates, LegacyDefaultCallback{},
+                       intersected_ranks, offset);
 
   Kokkos::View<int *, MemorySpace> ranks(
       "ArborX::DistributedTree::query::spatial::ranks", 0);
-  {
-    // NOTE_COMM_SPATIAL: The communication pattern here for the spatial search
-    // is identical to that of the nearest search (see NOTE_COMM_NEAREST). The
-    // code differences are:
-    // - usage of callbacks
-    // - no explicit distances
-    // - no results filtering
-
-    // Forward predicates
-    using Query = typename Predicates::value_type;
-    Kokkos::View<int *, MemorySpace> ids(
-        "ArborX::DistributedTree::query::spatial::query_ids", 0);
-    Kokkos::View<Query *, MemorySpace> fwd_predicates(
-        "ArborX::DistributedTree::query::spatial::fwd_predicates", 0);
-    forwardQueries(comm, space, predicates, intersected_ranks, offset,
-                   fwd_predicates, ids, ranks);
-
-    // Perform predicates that have been received
-    bottom_tree.query(space, fwd_predicates, callback, values, offset);
-
-    // Communicate results back
-    communicateResultsBack(comm, space, values, offset, ranks, ids);
-
-    Kokkos::Profiling::pushRegion(
-        "ArborX::DistributedTree::spatial::postprocess_results");
-
-    // Merge results
-    int const n_predicates = predicates.size();
-    countResults(space, n_predicates, ids, offset);
-    sortResultsByKey(space, ids, values);
-
-    Kokkos::Profiling::popRegion();
-  }
+  DistributedTree::forwardQueriesAndCommunicateResults(
+      tree.getComm(), space, tree._bottom_tree, predicates, callback,
+      intersected_ranks, offset, values, ranks);
 }
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,

--- a/src/details/ArborX_DetailsDistributedTreeUtils.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeUtils.hpp
@@ -108,8 +108,9 @@ void sortResultsByKey(ExecutionSpace const &space, View keys,
   if (n == 0)
     return;
 
-  if constexpr (sizeof...(OtherViews) == 1 &&
-                std::tuple_element_t<0, std::tuple<OtherViews...>>::rank == 1)
+  using ViewType = std::tuple_element_t<0, std::tuple<OtherViews...>>;
+  if constexpr (sizeof...(OtherViews) == 1 && ViewType::rank == 1 &&
+                std::is_arithmetic_v<typename ViewType::value_type>)
   {
     // If there's only one 1D view to process, we can avoid computing the
     // permutation.
@@ -363,7 +364,7 @@ void forwardQueriesAndCommunicateResults(
   // Merge results
   int const n_predicates = predicates.size();
   countResults(space, n_predicates, ids, offset);
-  sortResultsByKey(space, ids, values);
+  sortResultsByKey(space, ids, values, ranks);
 
   Kokkos::Profiling::popRegion();
 }

--- a/src/details/ArborX_DetailsDistributedTreeUtils.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeUtils.hpp
@@ -113,7 +113,8 @@ void sortResultsByKey(ExecutionSpace const &space, View keys,
                 std::is_arithmetic_v<typename ViewType::value_type>)
   {
     // If there's only one 1D view to process, we can avoid computing the
-    // permutation.
+    // permutation. We also avoid 1D views with non-arithmetic types as we
+    // can't guarantee they provide comparison operator.
     KokkosExt::sortByKey(space, keys, other_views...);
   }
   else

--- a/src/details/ArborX_DetailsDistributedTreeUtils.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeUtils.hpp
@@ -330,6 +330,44 @@ void communicateResultsBack(MPI_Comm comm, ExecutionSpace const &space,
   }
 }
 
+template <typename ExecutionSpace, typename BottomTree, typename Predicates,
+          typename Callback, typename RanksTo, typename Offset, typename Values,
+          typename Ranks>
+void forwardQueriesAndCommunicateResults(
+    MPI_Comm comm, ExecutionSpace const &space, BottomTree const &bottom_tree,
+    Predicates const &predicates, Callback const &callback,
+    RanksTo const &ranks_to, Offset &offset, Values &values, Ranks &ranks)
+{
+  std::string prefix =
+      "ArborX::DistributedTree::query::forwardQueriesAndCommunicateResults";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+
+  using Query = typename Predicates::value_type;
+  using MemorySpace = typename BottomTree::memory_space;
+
+  // Forward predicates
+  Kokkos::View<int *, MemorySpace> ids(prefix + "::query_ids", 0);
+  Kokkos::View<Query *, MemorySpace> fwd_predicates(prefix + "::fwd_predicates",
+                                                    0);
+  forwardQueries(comm, space, predicates, ranks_to, offset, fwd_predicates, ids,
+                 ranks);
+
+  // Perform predicates that have been received
+  bottom_tree.query(space, fwd_predicates, callback, values, offset);
+
+  // Communicate results back
+  communicateResultsBack(comm, space, values, offset, ranks, ids);
+
+  Kokkos::Profiling::pushRegion(prefix + "postprocess_results");
+
+  // Merge results
+  int const n_predicates = predicates.size();
+  countResults(space, n_predicates, ids, offset);
+  sortResultsByKey(space, ids, values);
+
+  Kokkos::Profiling::popRegion();
+}
+
 template <typename ExecutionSpace, typename MemorySpace, typename Predicates,
           typename Values, typename Offset, typename Ranks>
 void filterResults(ExecutionSpace const &space, Predicates const &queries,


### PR DESCRIPTION
- Move common part from the spatial and nearest searches into `forwardQueriesAndCommunicateResults`
- Do not sort ranks for spatial searches and the first phase of the nearest search (it is unnecessary)
- Do not store and communicate values in the first phase of the nearest search; instead, only store the distances and communicate those
- Use nth_element algorithm instead of priority queue for determining the farthest distance in the nearest first phase; only use distances in the algorithm instead of pairs of values and distances
- Separated the code in the nearest `queryDispatchImpl` into `phaseI` and `phaseII` with interfaces making clear which data is passed where
- Some minor general improvements 

The overall goal of the PR is to prepare for reduce complexity. This should also help with the introduction of the nearest callbacks.