### PR TITLE
Move `OrderedSpatialPredicateTag` where it belongs that is namespace `Details::`

### DIFF
--- a/src/ArborX_LinearBVH.hpp
+++ b/src/ArborX_LinearBVH.hpp
@@ -401,8 +401,7 @@ void BoundingVolumeHierarchy<
   {
     profiling_prefix += "nearest";
   }
-  else if constexpr (std::is_same_v<Tag,
-                                    Experimental::OrderedSpatialPredicateTag>)
+  else if constexpr (std::is_same_v<Tag, Details::OrderedSpatialPredicateTag>)
   {
     profiling_prefix += "ordered_spatial";
   }

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -149,8 +149,7 @@ void check_valid_callback(Callback const &callback, Predicates const &)
 
   static_assert(
       !(std::is_same_v<PredicateTag, SpatialPredicateTag> ||
-        std::is_same_v<PredicateTag,
-                       Experimental::OrderedSpatialPredicateTag>) ||
+        std::is_same_v<PredicateTag, OrderedSpatialPredicateTag>) ||
           (std::is_same_v<
                CallbackTreeTraversalControl,
                std::invoke_result_t<Callback const &, Predicate, Value>> ||

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -354,8 +354,7 @@ queryDispatch(Tag, Tree const &tree, ExecutionSpace const &space,
   {
     profiling_prefix += "spatial";
   }
-  else if constexpr (std::is_same_v<Tag,
-                                    OrderedSpatialPredicateTag>)
+  else if constexpr (std::is_same_v<Tag, OrderedSpatialPredicateTag>)
   {
     profiling_prefix += "ordered_spatial";
   }

--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -288,7 +288,7 @@ struct Iota
 template <typename Tag, typename ExecutionSpace, typename Predicates,
           typename OffsetView, typename OutView>
 std::enable_if_t<std::is_same_v<Tag, SpatialPredicateTag> ||
-                 std::is_same_v<Tag, Experimental::OrderedSpatialPredicateTag>>
+                 std::is_same_v<Tag, OrderedSpatialPredicateTag>>
 allocateAndInitializeStorage(Tag, ExecutionSpace const &space,
                              Predicates const &predicates, OffsetView &offset,
                              OutView &out, int buffer_size)
@@ -355,7 +355,7 @@ queryDispatch(Tag, Tree const &tree, ExecutionSpace const &space,
     profiling_prefix += "spatial";
   }
   else if constexpr (std::is_same_v<Tag,
-                                    Experimental::OrderedSpatialPredicateTag>)
+                                    OrderedSpatialPredicateTag>)
   {
     profiling_prefix += "ordered_spatial";
   }

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -336,8 +336,7 @@ struct TreeTraversal<BVH, Predicates, Callback, NearestPredicateTag>
 };
 
 template <class BVH, class Predicates, class Callback>
-struct TreeTraversal<BVH, Predicates, Callback,
-                     Experimental::OrderedSpatialPredicateTag>
+struct TreeTraversal<BVH, Predicates, Callback, OrderedSpatialPredicateTag>
 {
   BVH _bvh;
   Predicates _predicates;

--- a/src/details/ArborX_Predicates.hpp
+++ b/src/details/ArborX_Predicates.hpp
@@ -21,15 +21,9 @@ struct NearestPredicateTag
 {};
 struct SpatialPredicateTag
 {};
-} // namespace Details
-namespace Experimental
-{
 struct OrderedSpatialPredicateTag
 {};
-} // namespace Experimental
 
-namespace Details
-{
 // nvcc has problems with using std::interal_constant here.
 template <typename PredicateTag>
 struct is_valid_predicate_tag
@@ -37,7 +31,7 @@ struct is_valid_predicate_tag
   static constexpr bool value =
       std::is_same<PredicateTag, SpatialPredicateTag>{} ||
       std::is_same<PredicateTag, NearestPredicateTag>{} ||
-      std::is_same<PredicateTag, Experimental::OrderedSpatialPredicateTag>{};
+      std::is_same<PredicateTag, OrderedSpatialPredicateTag>{};
 };
 } // namespace Details
 
@@ -92,7 +86,7 @@ namespace Experimental
 template <typename Geometry>
 struct OrderedSpatial
 {
-  using Tag = Experimental::OrderedSpatialPredicateTag;
+  using Tag = Details::OrderedSpatialPredicateTag;
 
   KOKKOS_DEFAULTED_FUNCTION
   OrderedSpatial() = default;


### PR DESCRIPTION
The predicate tags really are implementation details and do not belong to the `Experimental::` namespace.