### PR TITLE
Distributed nearest callback

### DIFF
--- a/src/ArborX_DistributedTree.hpp
+++ b/src/ArborX_DistributedTree.hpp
@@ -195,7 +195,7 @@ public:
       MPI_Comm_rank(base_type::getComm(), &comm_rank);
 
     base_type::query(space, predicates,
-                     Details::LegacyDefaultCallbackWithRank{comm_rank},
+                     Details::DefaultCallbackWithRank{comm_rank},
                      std::forward<IndicesAndRanks>(indices_and_ranks),
                      std::forward<OffsetView>(offset));
   }

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -11,6 +11,8 @@
 #ifndef ARBORX_CALLBACKS_HPP
 #define ARBORX_CALLBACKS_HPP
 
+#include <ArborX_Config.hpp>
+
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_Predicates.hpp> // is_valid_predicate_tag
 
@@ -43,6 +45,25 @@ struct DefaultCallback
     out(value);
   }
 };
+
+#ifdef ARBORX_ENABLE_MPI
+struct ConstrainedNearestCallbackTag
+{};
+
+struct DefaultCallbackWithRank
+{
+  using tag = ConstrainedNearestCallbackTag;
+
+  int _rank;
+
+  template <typename Predicate, typename Value, typename OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Predicate const &, Value const &value,
+                                  OutputFunctor const &out) const
+  {
+    out({value, _rank});
+  }
+};
+#endif
 
 // archetypal alias for a 'tag' type member in user callbacks
 template <typename Callback>

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -11,8 +11,6 @@
 #ifndef ARBORX_CALLBACKS_HPP
 #define ARBORX_CALLBACKS_HPP
 
-#include <ArborX_Config.hpp>
-
 #include <ArborX_AccessTraits.hpp>
 #include <ArborX_Predicates.hpp> // is_valid_predicate_tag
 
@@ -45,25 +43,6 @@ struct DefaultCallback
     out(value);
   }
 };
-
-#ifdef ARBORX_ENABLE_MPI
-struct ConstrainedNearestCallbackTag
-{};
-
-struct DefaultCallbackWithRank
-{
-  using tag = ConstrainedNearestCallbackTag;
-
-  int _rank;
-
-  template <typename Predicate, typename Value, typename OutputFunctor>
-  KOKKOS_FUNCTION void operator()(Predicate const &, Value const &value,
-                                  OutputFunctor const &out) const
-  {
-    out({value, _rank});
-  }
-};
-#endif
 
 // archetypal alias for a 'tag' type member in user callbacks
 template <typename Callback>

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -42,13 +42,13 @@ struct DistributedTreeImpl
 
   // nearest neighbors queries
   template <typename DistributedTree, typename ExecutionSpace,
-            typename Predicates, typename Indices, typename Offset,
-            typename Ranks>
+            typename Predicates, typename Callback, typename Indices,
+            typename Offset>
   static std::enable_if_t<Kokkos::is_view_v<Indices> &&
-                          Kokkos::is_view_v<Offset> && Kokkos::is_view_v<Ranks>>
+                          Kokkos::is_view_v<Offset>>
   queryDispatchImpl(NearestPredicateTag, DistributedTree const &tree,
                     ExecutionSpace const &space, Predicates const &queries,
-                    Indices &indices, Offset &offset, Ranks &ranks);
+                    Callback const &callback, Indices &indices, Offset &offset);
 
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename IndicesAndRanks, typename Offset>
@@ -57,6 +57,13 @@ struct DistributedTreeImpl
   queryDispatch(NearestPredicateTag tag, DistributedTree const &tree,
                 ExecutionSpace const &space, Predicates const &queries,
                 IndicesAndRanks &values, Offset &offset);
+  template <typename Tree, typename ExecutionSpace, typename Predicates,
+            typename Callback, typename Values, typename Offset>
+  static std::enable_if_t<Kokkos::is_view_v<Values> &&
+                          Kokkos::is_view_v<Offset>>
+  queryDispatch(NearestPredicateTag tag, Tree const &tree,
+                ExecutionSpace const &space, Predicates const &predicates,
+                Callback const &callback, Values &values, Offset &offset);
 
   // nearest neighbors helpers
   template <typename ExecutionSpace, typename Tree, typename Predicates,
@@ -66,11 +73,11 @@ struct DistributedTreeImpl
                      Distances &farthest_distances);
 
   template <typename ExecutionSpace, typename Tree, typename Predicates,
-            typename Distances, typename Offset, typename Values,
-            typename Ranks>
+            typename Callback, typename Distances, typename Offset,
+            typename Values>
   static void phaseII(ExecutionSpace const &space, Tree const &tree,
-                      Predicates const &queries, Distances &distances,
-                      Offset &offset, Values &values, Ranks &ranks);
+                      Predicates const &predicates, Callback const &callback,
+                      Distances &distances, Offset &offset, Values &values);
 };
 
 } // namespace ArborX::Details

--- a/src/details/ArborX_DetailsDistributedTreeImpl.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeImpl.hpp
@@ -24,12 +24,12 @@ struct DistributedTreeImpl
 {
   // spatial queries
   template <typename DistributedTree, typename ExecutionSpace,
-            typename Predicates, typename IndicesAndRanks, typename Offset>
-  static std::enable_if_t<Kokkos::is_view_v<IndicesAndRanks> &&
+            typename Predicates, typename Values, typename Offset>
+  static std::enable_if_t<Kokkos::is_view_v<Values> &&
                           Kokkos::is_view_v<Offset>>
   queryDispatch(SpatialPredicateTag, DistributedTree const &tree,
                 ExecutionSpace const &space, Predicates const &queries,
-                IndicesAndRanks &values, Offset &offset);
+                Values &values, Offset &offset);
 
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename OutputView, typename OffsetView,
@@ -44,24 +44,24 @@ struct DistributedTreeImpl
   template <typename DistributedTree, typename ExecutionSpace,
             typename Predicates, typename Callback, typename Indices,
             typename Offset>
-  static std::enable_if_t<Kokkos::is_view_v<Indices> &&
-                          Kokkos::is_view_v<Offset>>
-  queryDispatchImpl(NearestPredicateTag, DistributedTree const &tree,
-                    ExecutionSpace const &space, Predicates const &queries,
-                    Callback const &callback, Indices &indices, Offset &offset);
+  static void
+  queryDispatch2RoundImpl(NearestPredicateTag, DistributedTree const &tree,
+                          ExecutionSpace const &space,
+                          Predicates const &queries, Callback const &callback,
+                          Indices &indices, Offset &offset);
 
   template <typename DistributedTree, typename ExecutionSpace,
-            typename Predicates, typename IndicesAndRanks, typename Offset>
-  static std::enable_if_t<Kokkos::is_view_v<IndicesAndRanks> &&
+            typename Predicates, typename Values, typename Offset>
+  static std::enable_if_t<Kokkos::is_view_v<Values> &&
                           Kokkos::is_view_v<Offset>>
   queryDispatch(NearestPredicateTag tag, DistributedTree const &tree,
                 ExecutionSpace const &space, Predicates const &queries,
-                IndicesAndRanks &values, Offset &offset);
+                Values &values, Offset &offset);
   template <typename Tree, typename ExecutionSpace, typename Predicates,
             typename Callback, typename Values, typename Offset>
   static std::enable_if_t<Kokkos::is_view_v<Values> &&
                           Kokkos::is_view_v<Offset>>
-  queryDispatch(NearestPredicateTag tag, Tree const &tree,
+  queryDispatch(NearestPredicateTag, Tree const &tree,
                 ExecutionSpace const &space, Predicates const &predicates,
                 Callback const &callback, Values &values, Offset &offset);
 

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -183,6 +183,8 @@ void DistributedTreeImpl::queryDispatch2RoundImpl(
 
   Kokkos::Profiling::ScopedRegion guard(prefix);
 
+  static_assert(is_constrained_callback_v<Callback>);
+
   if (tree.empty())
   {
     KokkosExt::reallocWithoutInitializing(space, values, 0);
@@ -233,11 +235,15 @@ DistributedTreeImpl::queryDispatch(NearestPredicateTag, Tree const &tree,
                                    Callback const &callback, Values &values,
                                    Offset &offset)
 {
-  static_assert(Kokkos::is_detected_v<CallbackTagArchetypeAlias, Callback>);
-  static_assert(
-      std::is_same_v<typename Callback::tag, ConstrainedNearestCallbackTag>);
-  queryDispatch2RoundImpl(NearestPredicateTag{}, tree, space, predicates,
-                          callback, values, offset);
+  if constexpr (is_constrained_callback_v<Callback>)
+  {
+    queryDispatch2RoundImpl(NearestPredicateTag{}, tree, space, predicates,
+                            callback, values, offset);
+  }
+  else
+  {
+    Kokkos::abort("3-arg callback not implemented yet.");
+  }
 }
 
 } // namespace ArborX::Details

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -359,8 +359,7 @@ void DistributedTreeImpl::phaseII(ExecutionSpace const &space, Tree const &tree,
         distances(i) = out(i).distance;
       });
 
-  DistributedTree::filterResults(space, predicates, distances, values, offset,
-                                 ranks);
+  DistributedTree::filterResults(space, predicates, distances, values, offset);
 }
 
 template <typename Tree, typename ExecutionSpace, typename Predicates,

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -11,20 +11,14 @@
 #ifndef ARBORX_DETAILS_DISTRIBUTED_TREE_NEAREST_HPP
 #define ARBORX_DETAILS_DISTRIBUTED_TREE_NEAREST_HPP
 
-#include <ArborX_AccessTraits.hpp>
-#include <ArborX_Box.hpp>
 #include <ArborX_DetailsDistributedTreeImpl.hpp>
+#include <ArborX_DetailsDistributedTreeNearestHelpers.hpp>
 #include <ArborX_DetailsDistributedTreeUtils.hpp>
-#include <ArborX_DetailsHappyTreeFriends.hpp>
 #include <ArborX_DetailsKokkosExtKernelStdAlgorithms.hpp>
 #include <ArborX_DetailsKokkosExtMinMaxOperations.hpp>
 #include <ArborX_DetailsKokkosExtStdAlgorithms.hpp>
 #include <ArborX_DetailsKokkosExtViewHelpers.hpp>
-#include <ArborX_LinearBVH.hpp>
-#include <ArborX_Point.hpp>
 #include <ArborX_Predicates.hpp>
-#include <ArborX_Ray.hpp>
-#include <ArborX_Sphere.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
@@ -32,80 +26,7 @@
 // Don't really need it, but our self containment tests rely on its presence
 #include <mpi.h>
 
-namespace ArborX
-{
-namespace Details
-{
-template <class Predicates, class Distances>
-struct WithinDistanceFromPredicates
-{
-  Predicates predicates;
-  Distances distances;
-};
-} // namespace Details
-
-template <class Predicates, class Distances>
-struct AccessTraits<
-    Details::WithinDistanceFromPredicates<Predicates, Distances>, PredicatesTag>
-{
-  using Predicate = typename Predicates::value_type;
-  using Geometry =
-      std::decay_t<decltype(getGeometry(std::declval<Predicate const &>()))>;
-  using Self = Details::WithinDistanceFromPredicates<Predicates, Distances>;
-
-  using memory_space = typename Predicates::memory_space;
-  using size_type = decltype(std::declval<Predicates const &>().size());
-
-  static KOKKOS_FUNCTION size_type size(Self const &x)
-  {
-    return x.predicates.size();
-  }
-  template <class Dummy = Geometry,
-            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
-                             std::is_same_v<Dummy, Point>> * = nullptr>
-  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
-  {
-    auto const point = getGeometry(x.predicates(i));
-    auto const distance = x.distances(i);
-    return intersects(Sphere{point, distance});
-  }
-  template <class Dummy = Geometry,
-            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
-                             std::is_same_v<Dummy, Box>> * = nullptr>
-  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
-  {
-    auto box = getGeometry(x.predicates(i));
-    auto &min_corner = box.minCorner();
-    auto &max_corner = box.maxCorner();
-    auto const distance = x.distances(i);
-    for (int d = 0; d < 3; ++d)
-    {
-      min_corner[d] -= distance;
-      max_corner[d] += distance;
-    }
-    return intersects(box);
-  }
-  template <class Dummy = Geometry,
-            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
-                             std::is_same_v<Dummy, Sphere>> * = nullptr>
-  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
-  {
-    auto const sphere = getGeometry(x.predicates(i));
-    auto const distance = x.distances(i);
-    return intersects(Sphere{sphere.centroid(), distance + sphere.radius()});
-  }
-  template <
-      class Dummy = Geometry,
-      std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
-                       std::is_same_v<Dummy, Experimental::Ray>> * = nullptr>
-  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
-  {
-    auto const ray = getGeometry(x.predicates(i));
-    return intersects(ray);
-  }
-};
-
-namespace Details
+namespace ArborX::Details
 {
 
 template <typename Value>
@@ -113,116 +34,6 @@ struct PairValueDistance
 {
   Value value;
   float distance;
-};
-
-template <typename Tree, typename Callback, typename OutValue, bool UseValues>
-struct CallbackWithDistance
-{
-  Tree _tree;
-  Callback _callback;
-
-  template <typename ExecutionSpace>
-  CallbackWithDistance(ExecutionSpace const &, Tree const &tree,
-                       Callback const &callback)
-      : _tree(tree)
-      , _callback(callback)
-  {}
-
-  template <typename Query, typename Value, typename Output>
-  KOKKOS_FUNCTION void operator()(Query const &query, Value const &value,
-                                  Output const &out) const
-  {
-    if constexpr (UseValues)
-    {
-      OutValue out_value;
-      int count = 0;
-      _callback(query, value, [&](OutValue const &ov) {
-        out_value = ov;
-        ++count;
-      });
-      KOKKOS_ASSERT(count == 1);
-      out({out_value,
-           distance(getGeometry(query), _tree.indexable_get()(value))});
-    }
-    else
-      out(distance(getGeometry(query), _tree.indexable_get()(value)));
-  }
-};
-
-template <typename MemorySpace, typename Callback, typename OutValue,
-          bool UseValues>
-struct CallbackWithDistance<
-    BoundingVolumeHierarchy<MemorySpace, Details::LegacyDefaultTemplateValue,
-                            Details::DefaultIndexableGetter,
-                            ExperimentalHyperGeometry::Box<3, float>>,
-    Callback, OutValue, UseValues>
-{
-  using Tree =
-      BoundingVolumeHierarchy<MemorySpace, Details::LegacyDefaultTemplateValue,
-                              Details::DefaultIndexableGetter,
-                              ExperimentalHyperGeometry::Box<3, float>>;
-
-  Tree _tree;
-  Callback _callback;
-  Kokkos::View<unsigned int *, typename Tree::memory_space> _rev_permute;
-
-  template <typename ExecutionSpace>
-  CallbackWithDistance(ExecutionSpace const &exec_space, Tree const &tree,
-                       Callback const &callback)
-      : _tree(tree)
-      , _callback(callback)
-  {
-    // NOTE cannot have extended __host__ __device__  lambda in constructor with
-    // NVCC
-    computeReversePermutation(exec_space);
-  }
-
-  template <typename ExecutionSpace>
-  void computeReversePermutation(ExecutionSpace const &exec_space)
-  {
-    auto const n = _tree.size();
-
-    _rev_permute = Kokkos::View<unsigned int *, typename Tree::memory_space>(
-        Kokkos::view_alloc(
-            Kokkos::WithoutInitializing,
-            "ArborX::DistributedTree::query::nearest::reverse_permutation"),
-        n);
-    if (!_tree.empty())
-    {
-      Kokkos::parallel_for(
-          "ArborX::DistributedTree::query::nearest::"
-          "compute_reverse_permutation",
-          Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
-          KOKKOS_CLASS_LAMBDA(int const i) {
-            _rev_permute(HappyTreeFriends::getValue(_tree, i).index) = i;
-          });
-    }
-  }
-
-  template <typename Query, typename OutputFunctor>
-  KOKKOS_FUNCTION void operator()(Query const &query, int index,
-                                  OutputFunctor const &out) const
-  {
-    // TODO: This breaks the abstraction of the distributed Tree not knowing
-    // the details of the local tree. Right now, this is the only way. Will
-    // need to be fixed with a proper callback abstraction.
-    int const leaf_node_index = _rev_permute(index);
-    auto const &leaf_node_bounding_volume =
-        HappyTreeFriends::getIndexable(_tree, leaf_node_index);
-    if constexpr (UseValues)
-    {
-      OutValue out_value;
-      int count = 0;
-      _callback(query, index, [&](OutValue const &ov) {
-        out_value = ov;
-        ++count;
-      });
-      KOKKOS_ASSERT(count == 1);
-      out({out_value, distance(getGeometry(query), leaf_node_bounding_volume)});
-    }
-    else
-      out(distance(getGeometry(query), leaf_node_bounding_volume));
-  }
 };
 
 template <typename ExecutionSpace, typename Tree, typename Predicates,
@@ -428,7 +239,6 @@ DistributedTreeImpl::queryDispatch(NearestPredicateTag tag, Tree const &tree,
   queryDispatchImpl(tag, tree, space, predicates, callback, values, offset);
 }
 
-} // namespace Details
-} // namespace ArborX
+} // namespace ArborX::Details
 
 #endif

--- a/src/details/ArborX_DetailsDistributedTreeNearest.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearest.hpp
@@ -152,12 +152,11 @@ void DistributedTreeImpl::phaseII(ExecutionSpace const &space, Tree const &tree,
   // rather than nearest predicates.
   Kokkos::View<PairValueDistance<typename Values::value_type> *, MemorySpace>
       out(prefix + "::pairs_value_distance", 0);
-  Kokkos::View<int *, MemorySpace> ranks(prefix + "::ranks", 0);
   DistributedTree::forwardQueriesAndCommunicateResults(
       tree.getComm(), space, bottom_tree, predicates,
       CallbackWithDistance<BottomTree, Callback, typename Values::value_type,
                            true>(space, bottom_tree, callback),
-      nearest_ranks, offset, out, &ranks);
+      nearest_ranks, offset, out);
 
   // Unzip
   auto n = out.extent(0);

--- a/src/details/ArborX_DetailsDistributedTreeNearestHelpers.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearestHelpers.hpp
@@ -1,0 +1,212 @@
+/****************************************************************************
+ * Copyright (c) 2017-2024 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef ARBORX_DETAILS_DISTRIBUTED_TREE_NEAREST_HELPERS_HPP
+#define ARBORX_DETAILS_DISTRIBUTED_TREE_NEAREST_HELPERS_HPP
+
+#include <ArborX_AccessTraits.hpp>
+#include <ArborX_Box.hpp>
+#include <ArborX_DetailsHappyTreeFriends.hpp>
+#include <ArborX_LinearBVH.hpp>
+#include <ArborX_Point.hpp>
+#include <ArborX_Ray.hpp>
+#include <ArborX_Sphere.hpp>
+
+namespace ArborX
+{
+namespace Details
+{
+
+template <class Predicates, class Distances>
+struct WithinDistanceFromPredicates
+{
+  Predicates predicates;
+  Distances distances;
+};
+} // namespace Details
+
+template <class Predicates, class Distances>
+struct AccessTraits<
+    Details::WithinDistanceFromPredicates<Predicates, Distances>, PredicatesTag>
+{
+  using Predicate = typename Predicates::value_type;
+  using Geometry =
+      std::decay_t<decltype(getGeometry(std::declval<Predicate const &>()))>;
+  using Self = Details::WithinDistanceFromPredicates<Predicates, Distances>;
+
+  using memory_space = typename Predicates::memory_space;
+  using size_type = decltype(std::declval<Predicates const &>().size());
+
+  static KOKKOS_FUNCTION size_type size(Self const &x)
+  {
+    return x.predicates.size();
+  }
+  template <class Dummy = Geometry,
+            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                             std::is_same_v<Dummy, Point>> * = nullptr>
+  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
+  {
+    auto const point = getGeometry(x.predicates(i));
+    auto const distance = x.distances(i);
+    return intersects(Sphere{point, distance});
+  }
+  template <class Dummy = Geometry,
+            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                             std::is_same_v<Dummy, Box>> * = nullptr>
+  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
+  {
+    auto box = getGeometry(x.predicates(i));
+    auto &min_corner = box.minCorner();
+    auto &max_corner = box.maxCorner();
+    auto const distance = x.distances(i);
+    for (int d = 0; d < 3; ++d)
+    {
+      min_corner[d] -= distance;
+      max_corner[d] += distance;
+    }
+    return intersects(box);
+  }
+  template <class Dummy = Geometry,
+            std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                             std::is_same_v<Dummy, Sphere>> * = nullptr>
+  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
+  {
+    auto const sphere = getGeometry(x.predicates(i));
+    auto const distance = x.distances(i);
+    return intersects(Sphere{sphere.centroid(), distance + sphere.radius()});
+  }
+  template <
+      class Dummy = Geometry,
+      std::enable_if_t<std::is_same_v<Dummy, Geometry> &&
+                       std::is_same_v<Dummy, Experimental::Ray>> * = nullptr>
+  static KOKKOS_FUNCTION auto get(Self const &x, size_type i)
+  {
+    auto const ray = getGeometry(x.predicates(i));
+    return intersects(ray);
+  }
+};
+
+namespace Details
+{
+
+template <typename Tree, typename Callback, typename OutValue, bool UseValues>
+struct CallbackWithDistance
+{
+  Tree _tree;
+  Callback _callback;
+
+  template <typename ExecutionSpace>
+  CallbackWithDistance(ExecutionSpace const &, Tree const &tree,
+                       Callback const &callback)
+      : _tree(tree)
+      , _callback(callback)
+  {}
+
+  template <typename Query, typename Value, typename Output>
+  KOKKOS_FUNCTION void operator()(Query const &query, Value const &value,
+                                  Output const &out) const
+  {
+    if constexpr (UseValues)
+    {
+      OutValue out_value;
+      int count = 0;
+      _callback(query, value, [&](OutValue const &ov) {
+        out_value = ov;
+        ++count;
+      });
+      KOKKOS_ASSERT(count == 1);
+      out({out_value,
+           distance(getGeometry(query), _tree.indexable_get()(value))});
+    }
+    else
+      out(distance(getGeometry(query), _tree.indexable_get()(value)));
+  }
+};
+
+template <typename MemorySpace, typename Callback, typename OutValue,
+          bool UseValues>
+struct CallbackWithDistance<
+    BoundingVolumeHierarchy<MemorySpace, Details::LegacyDefaultTemplateValue,
+                            Details::DefaultIndexableGetter,
+                            ExperimentalHyperGeometry::Box<3, float>>,
+    Callback, OutValue, UseValues>
+{
+  using Tree =
+      BoundingVolumeHierarchy<MemorySpace, Details::LegacyDefaultTemplateValue,
+                              Details::DefaultIndexableGetter,
+                              ExperimentalHyperGeometry::Box<3, float>>;
+
+  Tree _tree;
+  Callback _callback;
+  Kokkos::View<unsigned int *, typename Tree::memory_space> _rev_permute;
+
+  template <typename ExecutionSpace>
+  CallbackWithDistance(ExecutionSpace const &exec_space, Tree const &tree,
+                       Callback const &callback)
+      : _tree(tree)
+      , _callback(callback)
+  {
+    // NOTE cannot have extended __host__ __device__  lambda in constructor with
+    // NVCC
+    computeReversePermutation(exec_space);
+  }
+
+  template <typename ExecutionSpace>
+  void computeReversePermutation(ExecutionSpace const &exec_space)
+  {
+    auto const n = _tree.size();
+
+    _rev_permute = Kokkos::View<unsigned int *, typename Tree::memory_space>(
+        Kokkos::view_alloc(
+            Kokkos::WithoutInitializing,
+            "ArborX::DistributedTree::query::nearest::reverse_permutation"),
+        n);
+    if (!_tree.empty())
+    {
+      Kokkos::parallel_for(
+          "ArborX::DistributedTree::query::nearest::"
+          "compute_reverse_permutation",
+          Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, n),
+          KOKKOS_CLASS_LAMBDA(int const i) {
+            _rev_permute(HappyTreeFriends::getValue(_tree, i).index) = i;
+          });
+    }
+  }
+
+  template <typename Query, typename OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Query const &query, int index,
+                                  OutputFunctor const &out) const
+  {
+    // TODO: This breaks the abstraction of the distributed Tree not knowing
+    // the details of the local tree. Right now, this is the only way. Will
+    // need to be fixed with a proper callback abstraction.
+    int const leaf_node_index = _rev_permute(index);
+    auto const &leaf_node_bounding_volume =
+        HappyTreeFriends::getIndexable(_tree, leaf_node_index);
+    if constexpr (UseValues)
+    {
+      OutValue out_value;
+      int count = 0;
+      _callback(query, index, [&](OutValue const &ov) {
+        out_value = ov;
+        ++count;
+      });
+      KOKKOS_ASSERT(count == 1);
+      out({out_value, distance(getGeometry(query), leaf_node_bounding_volume)});
+    }
+    else
+      out(distance(getGeometry(query), leaf_node_bounding_volume));
+  }
+};
+
+} // namespace Details
+} // namespace ArborX
+
+#endif

--- a/src/details/ArborX_DetailsDistributedTreeNearestHelpers.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearestHelpers.hpp
@@ -26,7 +26,7 @@ namespace Experimental
 {
 
 // Constrained callback is a callback that a user promises to:
-// - be not pure
+// - be not pure (i.e., allow output argument in the signature)
 // - be allowed to be called on non-final results
 // - produce exactly one result for each match
 template <class Callback>
@@ -182,6 +182,11 @@ struct CallbackWithDistance
       [[maybe_unused]] int count = 0;
       _callback(query, value, [&](OutValue const &ov) {
         out_value = ov;
+        // NOTE: this will break if we are running multiple threads per query.
+        // It could happen that the callback is called by different threads,
+        // resulting in multiple outputs while having count = 1 in each thread.
+        // As we don't envision this happening in the near future, it is ok for
+        // now.
         ++count;
       });
       // If the user callback produces no output, we have nothing to attach the

--- a/src/details/ArborX_DetailsDistributedTreeUtils.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeUtils.hpp
@@ -243,12 +243,10 @@ void forwardQueries(MPI_Comm comm, ExecutionSpace const &space,
 }
 
 template <typename ExecutionSpace, typename OutputView, typename Offset,
-          typename Ranks, typename Ids,
-          typename Distances =
-              Kokkos::View<float *, typename OutputView::memory_space>>
+          typename Ranks, typename Ids>
 void communicateResultsBack(MPI_Comm comm, ExecutionSpace const &space,
                             OutputView &out, Offset const &offset, Ranks &ranks,
-                            Ids &ids, Distances *distances_ptr = nullptr)
+                            Ids &ids)
 {
   Kokkos::Profiling::ScopedRegion guard(
       "ArborX::DistributedTree::communicateResultsBack");
@@ -317,18 +315,6 @@ void communicateResultsBack(MPI_Comm comm, ExecutionSpace const &space,
 
     sendAcrossNetwork(space, distributor, export_out, import_out);
     out = import_out;
-  }
-
-  if (distances_ptr)
-  {
-    auto &distances = *distances_ptr;
-    Kokkos::View<float *, MemorySpace> export_distances = distances;
-    Kokkos::View<float *, MemorySpace> import_distances(
-        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
-                           distances.label()),
-        n_imports);
-    sendAcrossNetwork(space, distributor, export_distances, import_distances);
-    distances = import_distances;
   }
 }
 

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -84,7 +84,7 @@ struct LegacyCallbackWrapper
                                   PairValueIndex<Value, Index> const &value,
                                   Output const &out) const
   {
-    _callback(predicate, value.index, out);
+    _callback(predicate, (int)value.index, out);
   }
 };
 
@@ -96,23 +96,9 @@ struct LegacyDefaultCallback
                                   PairValueIndex<Value, Index> const &value,
                                   OutputFunctor const &output) const
   {
-    output(value.index);
+    output((int)value.index);
   }
 };
-
-#ifdef ARBORX_ENABLE_MPI
-struct LegacyDefaultCallbackWithRank
-{
-  int _rank;
-
-  template <typename Predicate, typename OutputFunctor>
-  KOKKOS_FUNCTION void operator()(Predicate const &, int primitive_index,
-                                  OutputFunctor const &out) const
-  {
-    out({primitive_index, _rank});
-  }
-};
-#endif
 
 struct LegacyDefaultTemplateValue
 {};

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -84,6 +84,9 @@ struct LegacyCallbackWrapper
                                   PairValueIndex<Value, Index> const &value,
                                   Output const &out) const
   {
+    // APIv1 callback has the signature operator()(Query, int)
+    // As we store PairValueIndex with potentially non int index (like
+    // unsigned), we explicitly cast it here.
     _callback(predicate, (int)value.index, out);
   }
 };
@@ -96,6 +99,9 @@ struct LegacyDefaultCallback
                                   PairValueIndex<Value, Index> const &value,
                                   OutputFunctor const &output) const
   {
+    // APIv1 callback has the signature operator()(Query, int)
+    // As we store PairValueIndex with potentially non int index (like
+    // unsigned), we explicitly cast it here.
     output((int)value.index);
   }
 };

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -31,6 +31,39 @@ namespace tt = boost::test_tools;
 
 using ArborX::PairIndexRank;
 
+struct PairRankIndex
+{
+  int rank;
+  int index;
+
+  friend bool operator==(PairRankIndex lhs, PairRankIndex rhs)
+  {
+    return lhs.index == rhs.index && lhs.rank == rhs.rank;
+  }
+  friend bool operator<(PairRankIndex lhs, PairRankIndex rhs)
+  {
+    return lhs.rank < rhs.rank ||
+           (lhs.rank == rhs.rank && lhs.index < rhs.index);
+  }
+  friend std::ostream &operator<<(std::ostream &stream,
+                                  PairRankIndex const &pair)
+  {
+    return stream << '[' << pair.rank << ',' << pair.index << ']';
+  }
+};
+
+struct DistributedNearestCallback
+{
+  int rank;
+
+  template <typename Predicate, typename Value, typename OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Predicate const &, Value const &value,
+                                  OutputFunctor const &out) const
+  {
+    out({rank, value});
+  }
+};
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using Tree = ArborX::DistributedTree<typename DeviceType::memory_space>;
@@ -126,6 +159,27 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
         ExecutionSpace{}, tree, nearest_queries,
         make_reference_solution<PairIndexRank>(
             {{0, comm_size - 1 - comm_rank}, {1, comm_size - 1 - comm_rank}},
+            {0, 2}));
+  }
+
+  // Now do the same with callbacks
+  if (comm_rank < comm_size - 1)
+  {
+    ARBORX_TEST_QUERY_TREE_CALLBACK(ExecutionSpace{}, tree, nearest_queries,
+                                    DistributedNearestCallback{comm_rank},
+                                    make_reference_solution<PairRankIndex>(
+                                        {{comm_size - 1 - comm_rank, 0},
+                                         {comm_size - 2 - comm_rank, n - 1},
+                                         {comm_size - 1 - comm_rank, 1}},
+                                        {0, 3}));
+  }
+  else
+  {
+    ARBORX_TEST_QUERY_TREE_CALLBACK(
+        ExecutionSpace{}, tree, nearest_queries,
+        DistributedNearestCallback{comm_rank},
+        make_reference_solution<PairRankIndex>(
+            {{comm_size - 1 - comm_rank, 0}, {comm_size - 1 - comm_rank, 1}},
             {0, 2}));
   }
 }

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -54,8 +54,6 @@ struct PairRankIndex
 
 struct DistributedNearestCallback
 {
-  using tag = ArborX::Details::ConstrainedNearestCallbackTag;
-
   int rank;
 
   template <typename Predicate, typename Value, typename OutputFunctor>
@@ -167,19 +165,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   // Now do the same with callbacks
   if (comm_rank < comm_size - 1)
   {
-    ARBORX_TEST_QUERY_TREE_CALLBACK(ExecutionSpace{}, tree, nearest_queries,
-                                    DistributedNearestCallback{comm_rank},
-                                    make_reference_solution<PairRankIndex>(
-                                        {{comm_size - 1 - comm_rank, 0},
-                                         {comm_size - 2 - comm_rank, n - 1},
-                                         {comm_size - 1 - comm_rank, 1}},
-                                        {0, 3}));
+    ARBORX_TEST_QUERY_TREE_CALLBACK(
+        ExecutionSpace{}, tree, nearest_queries,
+        ArborX::Experimental::declare_callback_constrained(
+            DistributedNearestCallback{comm_rank}),
+        make_reference_solution<PairRankIndex>(
+            {{comm_size - 1 - comm_rank, 0},
+             {comm_size - 2 - comm_rank, n - 1},
+             {comm_size - 1 - comm_rank, 1}},
+            {0, 3}));
   }
   else
   {
     ARBORX_TEST_QUERY_TREE_CALLBACK(
         ExecutionSpace{}, tree, nearest_queries,
-        DistributedNearestCallback{comm_rank},
+        ArborX::Experimental::declare_callback_constrained(
+            DistributedNearestCallback{comm_rank}),
         make_reference_solution<PairRankIndex>(
             {{comm_size - 1 - comm_rank, 0}, {comm_size - 1 - comm_rank, 1}},
             {0, 2}));

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -54,6 +54,8 @@ struct PairRankIndex
 
 struct DistributedNearestCallback
 {
+  using tag = ArborX::Details::ConstrainedNearestCallbackTag;
+
   int rank;
 
   template <typename Predicate, typename Value, typename OutputFunctor>

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -60,6 +60,8 @@ struct DistributedNearestCallback
   KOKKOS_FUNCTION void operator()(Predicate const &, Value const &value,
                                   OutputFunctor const &out) const
   {
+    // This is almost like the DefaultCallbackWithRank, except the order is
+    // swapped, with rank going first. This is strictly for testing.
     out({rank, value});
   }
 };


### PR DESCRIPTION
[The 3-round rework of #737 will be pushed in that branch once this PR has been merged].

Works for both APIv1 and APIv2 (that was quite tricky).

Introduces two ways to do a nearest callback in the distributed setting:
- 2-round communication for a constrained callback

Constrained meaning that
- It is allowed to be called on not final matches
- For each match, it outputs exactly one result

Constrained callback is indicated with a new tag.

Current limitations:
- I have not thought yet about post-callbacks and whether they should be allowed
  To be fair, even with the spatial callbacks I'm not sure what that means