### PR TITLE
Remove deprecated `InlineCallbackTag` and `ArborX::Traits`

### DIFF
--- a/src/details/ArborX_AccessTraits.hpp
+++ b/src/details/ArborX_AccessTraits.hpp
@@ -248,31 +248,6 @@ struct AccessTraits<Details::AccessValuesI<Values, Tag>, Tag>
   static decltype(auto) size(AccessValues const &w) { return w.size(); }
 };
 
-namespace Traits
-{
-using PredicatesTag [[deprecated("Use ArborX::PredicatesTag instead.")]] =
-    ::ArborX::PredicatesTag;
-using PrimitivesTag [[deprecated("Use ArborX::PrimitivesTag instead.")]] =
-    ::ArborX::PrimitivesTag;
-template <typename T, typename Tag, typename Enable = void>
-struct Access
-{
-  using not_specialized = void;
-};
-} // namespace Traits
-template <typename T, typename Tag>
-struct AccessTraits<
-    T, Tag,
-    std::enable_if_t<!Kokkos::is_detected<
-        AccessTraitsNotSpecializedArchetypeAlias, Traits::Access<T, Tag>>{}>>
-    : Traits::Access<T, Tag>
-{
-  template <class U>
-  static constexpr bool always_false = std::is_void_v<U>;
-  static_assert(
-      always_false<T>,
-      "ArborX::Traits::Access was removed. Use ArborX::AccessTraits instead");
-};
 } // namespace ArborX
 
 #endif

--- a/src/details/ArborX_Callbacks.hpp
+++ b/src/details/ArborX_Callbacks.hpp
@@ -31,9 +31,6 @@ enum class CallbackTreeTraversalControl
 namespace Details
 {
 
-struct [[deprecated]] InlineCallbackTag
-{};
-
 struct PostCallbackTag
 {};
 

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -48,17 +48,6 @@ struct ArborX::AccessTraits<SizeMemberFunctionNotStatic, Tag>
   int size(SizeMemberFunctionNotStatic) { return 255; }
 };
 
-// Ensure legacy access traits are still valid
-struct LegacyAccessTraits
-{};
-template <typename Tag>
-struct ArborX::Traits::Access<LegacyAccessTraits, Tag>
-{
-  using memory_space = Kokkos::HostSpace;
-  static int size(LegacyAccessTraits) { return 0; }
-  static Point get(LegacyAccessTraits, int) { return {}; }
-};
-
 template <class V, class Tag>
 using deduce_type_t =
     decltype(ArborX::AccessTraits<V, Tag>::get(std::declval<V>(), 0));
@@ -117,8 +106,6 @@ void test_access_traits_compile_only()
   // check_valid_access_traits(PrimitivesTag{}, InvalidMemorySpace{});
 
   // check_valid_access_traits(PrimitivesTag{}, SizeMemberFunctionNotStatic{});
-
-  // check_valid_access_traits(PrimitivesTag{}, LegacyAccessTraits{});
 }
 
 void test_deduce_point_type_from_view()


### PR DESCRIPTION
All things are 2+ years old.