### PR TITLE
Switch to using expand for scene reductions

### DIFF
--- a/src/details/ArborX_DetailsBruteForceImpl.hpp
+++ b/src/details/ArborX_DetailsBruteForceImpl.hpp
@@ -37,10 +37,6 @@ struct BruteForceImpl
     IndexableGetter _indexable_getter;
     Nodes _nodes;
 
-    KOKKOS_FUNCTION void init(BoundingVolume &volume) const
-    {
-      volume = BoundingVolume{};
-    }
     KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
     {
       using Details::expand;

--- a/src/details/ArborX_DetailsBruteForceImpl.hpp
+++ b/src/details/ArborX_DetailsBruteForceImpl.hpp
@@ -28,6 +28,32 @@ namespace ArborX::Details
 {
 struct BruteForceImpl
 {
+
+  template <typename Values, typename IndexableGetter, typename Nodes,
+            typename BoundingVolume>
+  struct SceneReductionFunctor
+  {
+    Values _values;
+    IndexableGetter _indexable_getter;
+    Nodes _nodes;
+
+    KOKKOS_FUNCTION void init(BoundingVolume &volume) const
+    {
+      volume = BoundingVolume{};
+    }
+    KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
+    {
+      using Details::expand;
+      _nodes(i) = _values(i);
+      expand(update, _indexable_getter(_nodes(i)));
+    }
+    KOKKOS_FUNCTION void join(BoundingVolume &result,
+                              BoundingVolume const &update) const
+    {
+      expand(result, update);
+    }
+  };
+
   template <class ExecutionSpace, class Values, class IndexableGetter,
             class Nodes, class Bounds>
   static void initializeBoundingVolumesAndReduceBoundsOfTheScene(
@@ -39,15 +65,9 @@ struct BruteForceImpl
         "ArborX::BruteForce::BruteForce::"
         "initialize_values_and_reduce_bounds",
         Kokkos::RangePolicy<ExecutionSpace>(space, 0, values.size()),
-        KOKKOS_LAMBDA(int i, Bounds &update) {
-          nodes(i) = values(i);
-
-          using Details::expand;
-          Bounds bounding_volume{};
-          expand(bounding_volume, indexable_getter(nodes(i)));
-          update += bounding_volume;
-        },
-        Kokkos::Sum<Bounds>{bounds});
+        SceneReductionFunctor<Values, IndexableGetter, Nodes, Bounds>{
+            values, indexable_getter, nodes},
+        bounds);
   }
 
   template <class ExecutionSpace, class Predicates, class Values,

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -27,10 +27,6 @@ struct SceneReductionFunctor
 {
   Indexables _indexables;
 
-  KOKKOS_FUNCTION void init(BoundingVolume &volume) const
-  {
-    volume = BoundingVolume{};
-  }
   KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
   {
     using Details::expand;

--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -22,6 +22,27 @@
 namespace ArborX::Details::TreeConstruction
 {
 
+template <typename Indexables, typename BoundingVolume>
+struct SceneReductionFunctor
+{
+  Indexables _indexables;
+
+  KOKKOS_FUNCTION void init(BoundingVolume &volume) const
+  {
+    volume = BoundingVolume{};
+  }
+  KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
+  {
+    using Details::expand;
+    expand(update, _indexables(i));
+  }
+  KOKKOS_FUNCTION void join(BoundingVolume &result,
+                            BoundingVolume const &update) const
+  {
+    expand(result, update);
+  }
+};
+
 template <typename ExecutionSpace, typename Indexables, typename Box>
 inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
                                            Indexables const &indexables,
@@ -30,8 +51,7 @@ inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
   Kokkos::parallel_reduce(
       "ArborX::TreeConstruction::calculate_bounding_box_of_the_scene",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, indexables.size()),
-      KOKKOS_LAMBDA(int i, Box &update) { expand(update, indexables(i)); },
-      Kokkos::Sum<Box>{scene_bounding_box});
+      SceneReductionFunctor<Indexables, Box>{indexables}, scene_bounding_box);
 }
 
 template <typename ExecutionSpace, typename Indexables,

--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -59,7 +59,8 @@ struct Box
        Details::KokkosExt::ArithmeticTraits::finite_min<float>::value,
        Details::KokkosExt::ArithmeticTraits::finite_min<float>::value}};
 
-  KOKKOS_FUNCTION Box &operator+=(Box const &other)
+  [[deprecated("Use expand(Box, Box) instead.")]] KOKKOS_FUNCTION Box &
+  operator+=(Box const &other)
   {
     using Details::KokkosExt::max;
     using Details::KokkosExt::min;
@@ -72,7 +73,8 @@ struct Box
     return *this;
   }
 
-  KOKKOS_FUNCTION Box &operator+=(Point const &point)
+  [[deprecated("Use expand(Box, Point) instead.")]] KOKKOS_FUNCTION Box &
+  operator+=(Point const &point)
   {
     using Details::KokkosExt::max;
     using Details::KokkosExt::min;
@@ -88,7 +90,7 @@ struct Box
 // FIXME Temporary workaround until we clarify requirements on the Kokkos side.
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_SYCL)
 private:
-  friend KOKKOS_FUNCTION Box operator+(Box box, Box const &other)
+  [[deprecated]] friend KOKKOS_FUNCTION Box operator+(Box box, Box const &other)
   {
     return box += other;
   }
@@ -114,7 +116,7 @@ struct ArborX::GeometryTraits::coordinate_type<ArborX::Box>
 } // namespace ArborX
 
 template <>
-struct Kokkos::reduction_identity<ArborX::Box>
+struct [[deprecated]] Kokkos::reduction_identity<ArborX::Box>
 {
   KOKKOS_FUNCTION static ArborX::Box sum() { return {}; }
 };

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -391,7 +391,15 @@ struct expand<BoxTag, PointTag, Box, Point>
 {
   KOKKOS_FUNCTION static void apply(Box &box, Point const &point)
   {
-    box += point;
+    using Details::KokkosExt::max;
+    using Details::KokkosExt::min;
+
+    constexpr int DIM = GeometryTraits::dimension_v<Box>;
+    for (int d = 0; d < DIM; ++d)
+    {
+      box.minCorner()[d] = min(box.minCorner()[d], point[d]);
+      box.maxCorner()[d] = max(box.maxCorner()[d], point[d]);
+    }
   }
 };
 
@@ -414,7 +422,15 @@ struct expand<BoxTag, BoxTag, Box1, Box2>
 {
   KOKKOS_FUNCTION static void apply(Box1 &box, Box2 const &other)
   {
-    box += other;
+    using Details::KokkosExt::max;
+    using Details::KokkosExt::min;
+
+    constexpr int DIM = GeometryTraits::dimension_v<Box1>;
+    for (int d = 0; d < DIM; ++d)
+    {
+      box.minCorner()[d] = min(box.minCorner()[d], other.minCorner()[d]);
+      box.maxCorner()[d] = max(box.maxCorner()[d], other.maxCorner()[d]);
+    }
   }
 };
 

--- a/src/geometry/ArborX_HyperBox.hpp
+++ b/src/geometry/ArborX_HyperBox.hpp
@@ -63,36 +63,6 @@ struct Box
 
   Point<DIM, Coordinate> _min_corner;
   Point<DIM, Coordinate> _max_corner;
-
-  template <typename OtherBox,
-            std::enable_if_t<GeometryTraits::is_box<OtherBox>{}> * = nullptr>
-  KOKKOS_FUNCTION auto &operator+=(OtherBox const &other)
-  {
-    using Details::KokkosExt::max;
-    using Details::KokkosExt::min;
-
-    for (int d = 0; d < DIM; ++d)
-    {
-      minCorner()[d] = min(minCorner()[d], other.minCorner()[d]);
-      maxCorner()[d] = max(maxCorner()[d], other.maxCorner()[d]);
-    }
-    return *this;
-  }
-
-  template <typename Point,
-            std::enable_if_t<GeometryTraits::is_point_v<Point>> * = nullptr>
-  KOKKOS_FUNCTION auto &operator+=(Point const &point)
-  {
-    using Details::KokkosExt::max;
-    using Details::KokkosExt::min;
-
-    for (int d = 0; d < DIM; ++d)
-    {
-      minCorner()[d] = min(minCorner()[d], point[d]);
-      maxCorner()[d] = max(maxCorner()[d], point[d]);
-    }
-    return *this;
-  }
 };
 
 } // namespace ArborX::ExperimentalHyperGeometry
@@ -117,7 +87,7 @@ struct ArborX::GeometryTraits::coordinate_type<
 };
 
 template <int DIM, typename Coordinate>
-struct Kokkos::reduction_identity<
+struct [[deprecated]] Kokkos::reduction_identity<
     ArborX::ExperimentalHyperGeometry::Box<DIM, Coordinate>>
 {
   KOKKOS_FUNCTION static ArborX::ExperimentalHyperGeometry::Box<DIM, Coordinate>

--- a/test/tstIndexableGetter.cpp
+++ b/test/tstIndexableGetter.cpp
@@ -66,6 +66,26 @@ struct ArborX::AccessTraits<PairPointIndexCloud<MemorySpace>,
   using memory_space = MemorySpace;
 };
 
+template <typename Indexables, typename BoundingVolume>
+struct SceneReductionFunctor
+{
+  Indexables _indexables;
+
+  KOKKOS_FUNCTION void init(BoundingVolume &volume)
+  {
+    volume = BoundingVolume{};
+  }
+  KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
+  {
+    ArborX::Details::expand(update, _indexables(i));
+  }
+  KOKKOS_FUNCTION void join(BoundingVolume &result,
+                            BoundingVolume const &update)
+  {
+    expand(result, update);
+  }
+};
+
 template <typename ExecutionSpace, typename Indexables, typename Box>
 inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
                                            Indexables const &indexables,
@@ -74,11 +94,10 @@ inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
   Kokkos::parallel_reduce(
       "ArborX::TreeConstruction::calculate_bounding_box_of_the_scene",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, indexables.size()),
-      KOKKOS_LAMBDA(int i, Box &update) { expand(update, indexables(i)); },
-      Kokkos::Sum<Box>{scene_bounding_box});
+      SceneReductionFunctor<Indexables, Box>{indexables}, scene_bounding_box);
 }
 
-BOOST_AUTO_TEST_SUITE(MortonCodes)
+BOOST_AUTO_TEST_SUITE(IndexableGetterAccess)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(indexables, DeviceType, ARBORX_DEVICE_TYPES)
 {

--- a/test/tstIndexableGetter.cpp
+++ b/test/tstIndexableGetter.cpp
@@ -71,10 +71,6 @@ struct SceneReductionFunctor
 {
   Indexables _indexables;
 
-  KOKKOS_FUNCTION void init(BoundingVolume &volume)
-  {
-    volume = BoundingVolume{};
-  }
   KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
   {
     ArborX::Details::expand(update, _indexables(i));


### PR DESCRIPTION
Right now, we do a combination of `+=` and `expand` in our reduction. I would like to switch to only using `expand` in order to make the geometric algorithms a general as possible. `+=` relies on internal implementation, while `expand()` tells us exactly what operations a, say, `Box` geometry is required to provide.

The goal here is to move all stuff from inside the geometry classes (this includes KDOP and Ray, too) into generic algorithms.

- Deprecate `reduction_identity` in `ArborX::Box` and `ArborX::ExperimentalHyperGeometry::Box` (*not sure why we didn't have one in KDOP*)
- Deprecate `+=` in `ArborX::Box`
- Remove `+=` in `ArborX::ExperimentalHyperGeometry::Box`
- Switch scene calculation to using functors with `join` operation using `expand`
- Provide a generic implementation of `expand(Box, Point)` and `expand(Box, Box)`

Note that I didn't have to change `tstCompileOnlyTypeRequirement.cpp` test.

Next step would be redoing KDOP geometry in #982 to include dimension and coordinate, and reorganize it so that there are no internal class functions.