### PR TITLE
Do WithoutInitializing when resizing output view in CrsGraph

### DIFF
--- a/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
+++ b/src/details/ArborX_DetailsCrsGraphWrapperImpl.hpp
@@ -217,7 +217,8 @@ void queryImpl(ExecutionSpace const &space, Tree const &tree,
     // Exit early if either no results were found for any of the queries, or
     // nothing was inserted inside a callback for found results. This check
     // guarantees that the second pass will not be executed.
-    Kokkos::resize(out, 0);
+    Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing), out,
+                   0);
     // FIXME: do we need to reset offset if it was preallocated here?
     Kokkos::Profiling::popRegion();
     return;


### PR DESCRIPTION
This is important for types that are not default constructible.

Could theoretically do `KokkosExt::reallocWithoutInitializing(space, out, 0);`. Not sure what the difference is.