### PR TITLE
Use custom QualifierOrder in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -39,4 +39,5 @@ IncludeCategories:
 # Finally the standard library
   - Regex: "<[a-z_]+>"
     Priority: 10
-QualifierAlignment: Right
+QualifierAlignment: Custom
+QualifierOrder: ['static', 'inline', 'constexpr', 'type', 'const', 'volatile']


### PR DESCRIPTION
The previous iteration would allow
```c++
int constexpr blah;
```
The new one would trigger on it.

I did not put 'friend' (should it be left-most?) and 'restrict' (we never use it).