### PR TITLE
Use floats to construct Point in tests and benchmarks

### DIFF
--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -55,7 +55,7 @@ int main_(std::vector<std::string> const &args, MPI_Comm const comm)
         ( "values", bpo::value<int>(&n_values)->default_value(20000), "Number of indexable values (source) per MPI rank." )
         ( "queries", bpo::value<int>(&n_queries)->default_value(5000), "Number of queries (target) per MPI rank." )
         ( "neighbors", bpo::value<int>(&n_neighbors)->default_value(10), "Desired number of results per query." )
-        ( "shift", bpo::value<float>(&shift)->default_value(1.), "Shift of the point clouds. '0' means the clouds are built "
+        ( "shift", bpo::value<float>(&shift)->default_value(1.f), "Shift of the point clouds. '0' means the clouds are built "
 	                                                          "at the same place, while '1' places the clouds next to each"
 								  "other. Negative values and values larger than one "
                                                                   "mean that the clouds are separated." )

--- a/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
+++ b/benchmarks/distributed_tree_driver/distributed_tree_driver.cpp
@@ -42,7 +42,7 @@ int main_(std::vector<std::string> const &args, MPI_Comm const comm)
   int n_values;
   int n_queries;
   int n_neighbors;
-  double shift;
+  float shift;
   int partition_dim;
   bool perform_knn_search = true;
   bool perform_radius_search = true;
@@ -55,7 +55,7 @@ int main_(std::vector<std::string> const &args, MPI_Comm const comm)
         ( "values", bpo::value<int>(&n_values)->default_value(20000), "Number of indexable values (source) per MPI rank." )
         ( "queries", bpo::value<int>(&n_queries)->default_value(5000), "Number of queries (target) per MPI rank." )
         ( "neighbors", bpo::value<int>(&n_neighbors)->default_value(10), "Desired number of results per query." )
-        ( "shift", bpo::value<double>(&shift)->default_value(1.), "Shift of the point clouds. '0' means the clouds are built "
+        ( "shift", bpo::value<float>(&shift)->default_value(1.), "Shift of the point clouds. '0' means the clouds are built "
 	                                                          "at the same place, while '1' places the clouds next to each"
 								  "other. Negative values and values larger than one "
                                                                   "mean that the clouds are separated." )
@@ -113,10 +113,10 @@ int main_(std::vector<std::string> const &args, MPI_Comm const comm)
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "Benchmark::queries"),
       n_queries);
   {
-    double a = 0.;
-    double offset_x = 0.;
-    double offset_y = 0.;
-    double offset_z = 0.;
+    float a = 0.;
+    float offset_x = 0.;
+    float offset_y = 0.;
+    float offset_z = 0.;
     int i_max = 0;
     // Change the geometry of the problem. In 1D, all the point clouds are
     // aligned on a line. In 2D, the point clouds create a board and in 3D,
@@ -163,7 +163,7 @@ int main_(std::vector<std::string> const &args, MPI_Comm const comm)
     }
 
     // Generate random points uniformly distributed within a box.
-    std::uniform_real_distribution<double> distribution(-1., 1.);
+    std::uniform_real_distribution<float> distribution(-1, 1);
     std::default_random_engine generator;
     auto random = [&distribution, &generator]() {
       return distribution(generator);

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(!bg::is_valid(other_invalid_box, message));
   BOOST_TEST(message == "Box has corners in wrong order");
 
-  auto const infty = std::numeric_limits<double>::infinity();
+  auto const infty = std::numeric_limits<float>::infinity();
   other_invalid_box = {{{1., 5., 3.}}, {{infty, 3., 6.}}};
   BOOST_TEST(!details::isValid(other_invalid_box));
   BOOST_TEST(!bg::is_valid(other_invalid_box, message));

--- a/test/tstBoostGeometryAdapters.cpp
+++ b/test/tstBoostGeometryAdapters.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(is_valid)
   BOOST_TEST(!bg::is_valid(other_invalid_box, message));
   BOOST_TEST(message == "Box has corners in wrong order");
 
-  auto const infty = std::numeric_limits<float>::infinity();
+  auto const infty = std::numeric_limits<double>::infinity();
   other_invalid_box = {{{1., 5., 3.}}, {{infty, 3., 6.}}};
   BOOST_TEST(!details::isValid(other_invalid_box));
   BOOST_TEST(!bg::is_valid(other_invalid_box, message));

--- a/test/tstDistributedTree.cpp
+++ b/test/tstDistributedTree.cpp
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
   //                                                 0   1   2   3
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i / n + comm_rank, 0., 0.}};
+        points(i) = {{(float)i / n + comm_rank, 0., 0.}};
       });
 
   Tree tree(comm, ExecutionSpace{}, points);
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
       queries("Testing::queries", 1);
   auto queries_host = Kokkos::create_mirror_view(queries);
   queries_host(0) = ArborX::intersects(
-      ArborX::Sphere{{{0.5 + comm_size - 1 - comm_rank, 0., 0.}}, 0.5});
+      ArborX::Sphere{{{0.5f + comm_size - 1 - comm_rank, 0., 0.}}, 0.5});
   deep_copy(queries, queries_host);
 
   // 0---0---0---0---1---1---1---1---2---2---2---2---3---3---3---3---
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hello_world, DeviceType, ARBORX_DEVICE_TYPES)
       "Testing::nearest_queries", 1);
   auto nearest_queries_host = Kokkos::create_mirror_view(nearest_queries);
   nearest_queries_host(0) = ArborX::nearest<ArborX::Point>(
-      {{0.0 + comm_size - 1 - comm_rank, 0., 0.}},
+      {{0.f + comm_size - 1 - comm_rank, 0., 0.}},
       comm_rank < comm_size - 1 ? 3 : 2);
   deep_copy(nearest_queries, nearest_queries_host);
 
@@ -319,8 +319,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(unique_leaf_on_rank_0, DeviceType,
   ARBORX_TEST_QUERY_TREE(
       ExecutionSpace{}, tree,
       makeNearestQueries<DeviceType>({
-          {{{(double)comm_rank, (double)comm_rank, (double)comm_rank}},
-           comm_size},
+          {{{(float)comm_rank, (float)comm_rank, (float)comm_rank}}, comm_size},
       }),
       make_reference_solution<PairIndexRank>({{0, 0}}, {0, 1}));
 }
@@ -340,22 +339,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(one_leaf_per_rank, DeviceType,
   auto const tree = makeDistributedTree<DeviceType>(
       comm,
       {
-          {{{(double)comm_rank, 0., 0.}}, {{(double)comm_rank + 1., 1., 1.}}},
+          {{{(float)comm_rank, 0., 0.}}, {{(float)comm_rank + 1, 1., 1.}}},
       });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST((int)tree.size() == comm_size);
 
   BOOST_TEST(ArborX::Details::equals(
-      tree.bounds(), {{{0., 0., 0.}}, {{(double)comm_size, 1., 1.}}}));
+      tree.bounds(), {{{0., 0., 0.}}, {{(float)comm_size, 1., 1.}}}));
 
   ARBORX_TEST_QUERY_TREE(
       ExecutionSpace{}, tree,
       makeIntersectsBoxQueries<DeviceType>({
-          {{{(double)comm_size - (double)comm_rank - .5, .5, .5}},
-           {{(double)comm_size - (double)comm_rank - .5, .5, .5}}},
-          {{{(double)comm_rank + .5, .5, .5}},
-           {{(double)comm_rank + .5, .5, .5}}},
+          {{{(float)comm_size - (float)comm_rank - .5f, .5, .5}},
+           {{(float)comm_size - (float)comm_rank - .5f, .5, .5}}},
+          {{{(float)comm_rank + .5f, .5, .5}},
+           {{(float)comm_rank + .5f, .5, .5}}},
       }),
       make_reference_solution<PairIndexRank>(
           {{0, comm_size - 1 - comm_rank}, {0, comm_rank}}, {0, 1, 2}));
@@ -448,11 +447,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_nearest_neighbors, DeviceType,
   //                        [  rank 2  ]
   //                                   [  rank 3  ]
   auto const tree = makeDistributedTree<DeviceType>(
-      comm, {
-                {{{(double)comm_rank, 0., 0.}}, {{(double)comm_rank, 0., 0.}}},
-                {{{(double)comm_rank + 1., 1., 1.}},
-                 {{(double)comm_rank + 1., 1., 1.}}},
-            });
+      comm,
+      {
+          {{{(float)comm_rank, 0., 0.}}, {{(float)comm_rank, 0., 0.}}},
+          {{{(float)comm_rank + 1, 1., 1.}}, {{(float)comm_rank + 1, 1., 1.}}},
+      });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST((int)tree.size() == 2 * comm_size);
@@ -470,7 +469,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_nearest_neighbors, DeviceType,
     ARBORX_TEST_QUERY_TREE(
         ExecutionSpace{}, tree,
         makeNearestQueries<DeviceType>({
-            {{{(double)(comm_size - 1 - comm_rank) + .75, 0., 0.}}, 1},
+            {{{(float)(comm_size - 1 - comm_rank) + .75f, 0., 0.}}, 1},
         }),
         make_reference_solution<PairIndexRank>({{0, comm_size - comm_rank}},
                                                {0, 1}));
@@ -480,7 +479,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_nearest_neighbors, DeviceType,
     ARBORX_TEST_QUERY_TREE(
         ExecutionSpace{}, tree,
         makeNearestQueries<DeviceType>({
-            {{{(double)(comm_size - 1 - comm_rank) + .75, 0., 0.}}, 1},
+            {{{(float)(comm_size - 1 - comm_rank) + .75f, 0., 0.}}, 1},
         }),
         make_reference_solution<PairIndexRank>({{0, comm_size - 1}}, {0, 1}));
   }
@@ -508,11 +507,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_box_nearest_neighbors, DeviceType,
   //                        [  rank 2  ]
   //                                   [  rank 3  ]
   auto const tree = makeDistributedTree<DeviceType>(
-      comm, {
-                {{{(double)comm_rank, 0., 0.}}, {{(double)comm_rank, 0., 0.}}},
-                {{{(double)comm_rank + 1., 1., 1.}},
-                 {{(double)comm_rank + 1., 1., 1.}}},
-            });
+      comm,
+      {
+          {{{(float)comm_rank, 0., 0.}}, {{(float)comm_rank, 0., 0.}}},
+          {{{(float)comm_rank + 1, 1., 1.}}, {{(float)comm_rank + 1, 1., 1.}}},
+      });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST((int)tree.size() == 2 * comm_size);
@@ -530,8 +529,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_box_nearest_neighbors, DeviceType,
     ARBORX_TEST_QUERY_TREE(
         ExecutionSpace{}, tree,
         makeBoxNearestQueries<DeviceType>({
-            {{{(double)(comm_size - 1 - comm_rank) + .65, 0., 0.}},
-             {{(double)(comm_size - 1 - comm_rank) + .85, 0., 0.}},
+            {{{(float)(comm_size - 1 - comm_rank) + .65f, 0., 0.}},
+             {{(float)(comm_size - 1 - comm_rank) + .85f, 0., 0.}},
              1},
         }),
         make_reference_solution<PairIndexRank>({{0, comm_size - comm_rank}},
@@ -542,8 +541,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_box_nearest_neighbors, DeviceType,
     ARBORX_TEST_QUERY_TREE(
         ExecutionSpace{}, tree,
         makeBoxNearestQueries<DeviceType>({
-            {{{(double)(comm_size - 1 - comm_rank) + .65, 0., 0.}},
-             {{(double)(comm_size - 1 - comm_rank) + .85, 0., 0.}},
+            {{{(float)(comm_size - 1 - comm_rank) + .65f, 0., 0.}},
+             {{(float)(comm_size - 1 - comm_rank) + .85f, 0., 0.}},
              1},
         }),
         make_reference_solution<PairIndexRank>({{0, comm_size - 1}}, {0, 1}));
@@ -572,11 +571,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_sphere_nearest_neighbors,
   //                        [  rank 2  ]
   //                                   [  rank 3  ]
   auto const tree = makeDistributedTree<DeviceType>(
-      comm, {
-                {{{(double)comm_rank, 0., 0.}}, {{(double)comm_rank, 0., 0.}}},
-                {{{(double)comm_rank + 1., 1., 1.}},
-                 {{(double)comm_rank + 1., 1., 1.}}},
-            });
+      comm,
+      {
+          {{{(float)comm_rank, 0., 0.}}, {{(float)comm_rank, 0., 0.}}},
+          {{{(float)comm_rank + 1, 1., 1.}}, {{(float)comm_rank + 1, 1., 1.}}},
+      });
 
   BOOST_TEST(!tree.empty());
   BOOST_TEST((int)tree.size() == 2 * comm_size);
@@ -594,7 +593,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_sphere_nearest_neighbors,
     ARBORX_TEST_QUERY_TREE(
         ExecutionSpace{}, tree,
         makeSphereNearestQueries<DeviceType>({
-            {{{(double)(comm_size - 1 - comm_rank) + .75, 0., 0.}}, 0.1, 1},
+            {{{(float)(comm_size - 1 - comm_rank) + .75f, 0., 0.}}, 0.1, 1},
         }),
         make_reference_solution<PairIndexRank>({{0, comm_size - comm_rank}},
                                                {0, 1}));
@@ -604,7 +603,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(non_approximate_sphere_nearest_neighbors,
     ARBORX_TEST_QUERY_TREE(
         ExecutionSpace{}, tree,
         makeSphereNearestQueries<DeviceType>({
-            {{{(double)(comm_size - 1 - comm_rank) + .75, 0., 0.}}, 0.1, 1},
+            {{{(float)(comm_size - 1 - comm_rank) + .75f, 0., 0.}}, 0.1, 1},
         }),
         make_reference_solution<PairIndexRank>({{0, comm_size - 1}}, {0, 1}));
   }
@@ -674,8 +673,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment, DeviceType,
   //                        [  rank 2  ]
   //                                   [  rank 3  ]
   auto const tree = makeDistributedTree<DeviceType>(
-      comm,
-      {{{{(double)comm_rank, 0., 0.}}, {{(double)comm_rank + 1, 1., 1.}}}});
+      comm, {{{{(float)comm_rank, 0., 0.}}, {{(float)comm_rank + 1, 1., 1.}}}});
 
   //  +--------0---------1----------2---------3
   //  |        |         |          |         |
@@ -904,7 +902,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(distributed_ray, DeviceType, ARBORX_DEVICE_TYPES)
   auto const tree = makeDistributedTree<DeviceType>(
       comm,
       {
-          {{{(double)comm_rank, 0., 0.}}, {{(double)comm_rank + 1., 1., 1.}}},
+          {{{(float)comm_rank, 0., 0.}}, {{(float)comm_rank + 1, 1., 1.}}},
       });
 
   std::vector<ArborX::Experimental::Ray> rays = {

--- a/test/tstKDOP.cpp
+++ b/test/tstKDOP.cpp
@@ -140,17 +140,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(intersects_point_kdop, KDOP_t, KDOP_3D_types)
   {
     KDOP_t x; // unit cube with (1,1,0)--(1,1,1) edge chopped away
     // bottom face
-    expand(x, Point(0, 0, 0));
-    expand(x, Point(1, 0, 0));
-    expand(x, Point(1, 0.75, 0));
-    expand(x, Point(0.75, 1, 0));
-    expand(x, Point(0, 1, 0));
+    expand(x, Point{0, 0, 0});
+    expand(x, Point{1, 0, 0});
+    expand(x, Point{1, 0.75, 0});
+    expand(x, Point{0.75, 1, 0});
+    expand(x, Point{0, 1, 0});
     // top
-    expand(x, Point(0, 0, 1));
-    expand(x, Point(1, 0, 1));
-    expand(x, Point(1, 0.75, 1));
-    expand(x, Point(0.75, 1, 1));
-    expand(x, Point(0, 1, 1));
+    expand(x, Point{0, 0, 1});
+    expand(x, Point{1, 0, 1});
+    expand(x, Point{1, 0.75, 1});
+    expand(x, Point{0.75, 1, 1});
+    expand(x, Point{0, 1, 1});
     // test intersection with point on the missing edge
     BOOST_TEST(intersects(Point{1, 1, 0.5}, x) ==
                (std::is_same<KDOP_t, KDOP<3, 6>>::value ||
@@ -178,16 +178,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(intersects_point_kdop, KDOP_t, KDOP_3D_types)
   {
     KDOP_t x; // unit cube with (1,1,1) corner cut off
     // bottom face
-    expand(x, Point(0, 0, 0));
-    expand(x, Point(1, 0, 0));
-    expand(x, Point(1, 1, 0));
-    expand(x, Point(0, 1, 0));
+    expand(x, Point{0, 0, 0});
+    expand(x, Point{1, 0, 0});
+    expand(x, Point{1, 1, 0});
+    expand(x, Point{0, 1, 0});
     // top
-    expand(x, Point(0, 0, 1));
-    expand(x, Point(1, 0, 1));
-    expand(x, Point(1, 0.75, 1));
-    expand(x, Point(0.75, 1, 1));
-    expand(x, Point(0, 1, 1));
+    expand(x, Point{0, 0, 1});
+    expand(x, Point{1, 0, 1});
+    expand(x, Point{1, 0.75, 1});
+    expand(x, Point{0.75, 1, 1});
+    expand(x, Point{0, 1, 1});
     // test intersection with center of the missing corner
     BOOST_TEST(intersects(Point{1, 1, 1}, x) ==
                (std::is_same<KDOP_t, KDOP<3, 6>>::value ||

--- a/test/tstMinimumSpanningTreeGoldenTest.cpp
+++ b/test/tstMinimumSpanningTreeGoldenTest.cpp
@@ -52,7 +52,7 @@ auto parsePointsFromCSVFile(std::string const &filename)
     Tokenizer tok(line);
     auto first = tok.begin();
     auto const last = tok.end();
-    points.push_back(
+    points.push_back( // NOLINT(modernize-use-emplace)
         {std::stof(*first++), std::stof(*first++), std::stof(*first++)});
     assert(first == last);
   }

--- a/test/tstMinimumSpanningTreeGoldenTest.cpp
+++ b/test/tstMinimumSpanningTreeGoldenTest.cpp
@@ -52,8 +52,8 @@ auto parsePointsFromCSVFile(std::string const &filename)
     Tokenizer tok(line);
     auto first = tok.begin();
     auto const last = tok.end();
-    points.emplace_back(std::stof(*first++), std::stof(*first++),
-                        std::stof(*first++));
+    points.push_back(
+        {std::stof(*first++), std::stof(*first++), std::stof(*first++)});
     assert(first == last);
   }
   return points;

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_spatial_predicate, TreeTypeTraits,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
 
   auto values = initialize_values(points, /*delta*/ 0.f);
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_nearest_predicate, TreeTypeTraits,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
   ArborX::Point const origin = {{0., 0., 0.}};
 
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_spatial_predicate,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
   float const delta = 5.f;
 
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_nearest_predicate,
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "points"), n);
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
-        points(i) = {{(double)i, (double)i, (double)i}};
+        points(i) = {{(float)i, (float)i, (float)i}};
       });
   float const delta = 5.f;
   ArborX::Point const origin = {{0., 0., 0.}};

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_SUITE(ComparisonWithBoost)
 namespace tt = boost::test_tools;
 
 inline Kokkos::View<ArborX::Point *, Kokkos::HostSpace>
-make_stuctured_cloud(double Lx, double Ly, double Lz, int nx, int ny, int nz)
+make_stuctured_cloud(float Lx, float Ly, float Lz, int nx, int ny, int nz)
 {
   std::function<int(int, int, int)> ind = [nx, ny](int i, int j, int k) {
     return i + j * nx + k * (nx * ny);
@@ -51,9 +51,9 @@ template <typename Tree, typename ExecutionSpace, typename DeviceType,
 void boost_rtree_nearest_predicate()
 {
   // construct a cloud of points (nodes of a structured grid)
-  double Lx = 10.0;
-  double Ly = 10.0;
-  double Lz = 10.0;
+  float Lx = 10.0;
+  float Ly = 10.0;
+  float Lz = 10.0;
   int nx = 11;
   int ny = 11;
   int nz = 11;
@@ -117,9 +117,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
 #endif
 
   // construct a cloud of points (nodes of a structured grid)
-  double Lx = 10.0;
-  double Ly = 10.0;
-  double Lz = 10.0;
+  float Lx = 10.0;
+  float Ly = 10.0;
+  float Lz = 10.0;
   int nx = 11;
   int ny = 11;
   int nz = 11;
@@ -132,11 +132,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
   auto points = ArborXTest::make_random_cloud<ArborX::Point>(
       ExecutionSpace{}, n_points, Lx, Ly, Lz);
 
-  Kokkos::View<double *, ExecutionSpace> radii("radii", n_points);
+  Kokkos::View<float *, ExecutionSpace> radii("radii", n_points);
   auto radii_host = Kokkos::create_mirror_view(radii);
   // use random radius for the search
   std::default_random_engine generator;
-  std::uniform_real_distribution<double> distribution_radius(
+  std::uniform_real_distribution<float> distribution_radius(
       0.0, std::sqrt(Lx * Lx + Ly * Ly + Lz * Lz));
   for (unsigned int i = 0; i < n_points; ++i)
   {

--- a/test/tstQueryTreeDegenerate.cpp
+++ b/test/tstQueryTreeDegenerate.cpp
@@ -350,8 +350,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_spatial_predicate,
   boxes.reserve(n);
   for (int i = 0; i < n; ++i)
   {
-    double const a = i;
-    double const b = i + 1;
+    float const a = i;
+    float const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
   ExecutionSpace space;
@@ -383,8 +383,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(not_exceeding_stack_capacity_nearest_predicate,
   boxes.reserve(n);
   for (int i = 0; i < n; ++i)
   {
-    double const a = i;
-    double const b = i + 1;
+    float const a = i;
+    float const b = i + 1;
     boxes.push_back({{{a, a, a}}, {{b, b, b}}});
   }
   ExecutionSpace space;

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
   std::uniform_int_distribution<> dist_x(0, nx - 1);
   std::uniform_int_distribution<> dist_y(0, ny - 1);
   std::uniform_int_distribution<> dist_z(0, nz - 1);
-  std::uniform_real_distribution<double> dist_shift(-0.45, 0.45);
+  std::uniform_real_distribution<float> dist_shift(-0.45f, 0.45f);
 
   // The generation is a bit convoluted to avoid a situation where a centroid
   // of a box falls on any of the lattice planes, resulting in multiple
@@ -236,8 +236,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
     auto const x = (i + dist_shift(generator)) * hx;
     auto const y = (j + dist_shift(generator)) * hy;
     auto const z = (k + dist_shift(generator)) * hz;
-    bounding_boxes_host(l) = {{{x - 0.5 * hx, y - 0.5 * hy, z - 0.5 * hz}},
-                              {{x + 0.5 * hx, y + 0.5 * hy, z + 0.5 * hz}}};
+    bounding_boxes_host(l) = {{{x - hx / 2, y - hy / 2, z - hz / 2}},
+                              {{x + hx / 2, y + hy / 2, z + hz / 2}}};
 
     // Save the indices for the check
     indices_ref[l] = ind(i, j, k);

--- a/test/tstQueryTreeRay.cpp
+++ b/test/tstQueryTreeRay.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_nearest, DeviceType,
 
   std::vector<ArborX::Box> boxes;
   for (unsigned int i = 0; i < 10; ++i)
-    boxes.emplace_back(ArborX::Point(i, i, i),
-                       ArborX::Point(i + 1, i + 1, i + 1));
+    boxes.emplace_back(ArborX::Point{(float)i, (float)i, (float)i},
+                       ArborX::Point{(float)i + 1, (float)i + 1, (float)i + 1});
   Kokkos::View<ArborX::Box *, DeviceType> device_boxes("boxes", 10);
   Kokkos::deep_copy(exec_space, device_boxes,
                     Kokkos::View<ArborX::Box *, Kokkos::HostSpace>(
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_intersection, DeviceType,
 
   std::vector<ArborX::Box> boxes;
   for (unsigned int i = 0; i < 10; ++i)
-    boxes.emplace_back(ArborX::Point(i, i, i),
-                       ArborX::Point(i + 1, i + 1, i + 1));
+    boxes.emplace_back(ArborX::Point{(float)i, (float)i, (float)i},
+                       ArborX::Point{(float)i + 1, (float)i + 1, (float)i + 1});
   Kokkos::View<ArborX::Box *, DeviceType> device_boxes("boxes", 10);
   Kokkos::deep_copy(exec_space, device_boxes,
                     Kokkos::View<ArborX::Box *, Kokkos::HostSpace>(
@@ -140,8 +140,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_ray_box_intersection_new, DeviceType,
   std::vector<ArborX::Box> boxes;
   int const n = 10;
   for (unsigned int i = 0; i < n; ++i)
-    boxes.emplace_back(ArborX::Point(i, i, i),
-                       ArborX::Point(i + 1, i + 1, i + 1));
+    boxes.emplace_back(ArborX::Point{(float)i, (float)i, (float)i},
+                       ArborX::Point{(float)i + 1, (float)i + 1, (float)i + 1});
   auto device_boxes = ArborXTest::toView<DeviceType>(boxes, "boxes");
 
   ArborX::BVH<memory_space> const tree(exec_space, device_boxes);


### PR DESCRIPTION
In preparation for switching Point to hyper Point.

I aliased `using Point = ExperimentalHyperGeometry::Point<3, float>;` and fixed all the resulting errors. This PR, however, does not make the switch itself.

~If we used C++20, some of them could have been avoided. For example, `(a, b, c)` -> `{a, b, c}` switch and `emplace_back` would work as C++20 allows parenthesis aggregate initialization.~ *Update:* C++20 (p0960)[https://wg21.link/p0960] does **not** allow initialization of inner array with parenthesized list of values.