### PR TITLE
Avoid double deep_copy in create_layout_right_mirror_view_and_copy for compatible layouts

### DIFF
--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -119,6 +119,10 @@ create_layout_right_mirror_view_and_copy(ExecutionSpace const &execution_space,
   {
     return src;
   }
+  else if constexpr (has_compatible_layout)
+  {
+    return Kokkos::create_mirror_view_and_copy(memory_space, src);
+  }
   else
   {
     constexpr int pointer_depth =

--- a/src/details/ArborX_DetailsUtils.hpp
+++ b/src/details/ArborX_DetailsUtils.hpp
@@ -112,14 +112,8 @@ create_layout_right_mirror_view_and_copy(ExecutionSpace const &execution_space,
        (View::rank == 1 &&
         (std::is_same_v<typename View::array_layout, Kokkos::LayoutLeft> ||
          std::is_same_v<typename View::array_layout, Kokkos::LayoutRight>)));
-  constexpr bool has_compatible_memory_space =
-      std::is_same_v<typename View::memory_space, MemorySpace>;
 
-  if constexpr (has_compatible_layout && has_compatible_memory_space)
-  {
-    return src;
-  }
-  else if constexpr (has_compatible_layout)
+  if constexpr (has_compatible_layout)
   {
     return Kokkos::create_mirror_view_and_copy(memory_space, src);
   }


### PR DESCRIPTION
This drops the number of host-device copies in the distributed nearest neighbors to 2. In a benchmark I'm running, 98% of the time is taken by copies. So, this speeds things up by 30%. Just the first patch of several to improve the performance.