### PR TITLE
Update Windows Github action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,9 @@ jobs:
         pkgs: boost-test boost-program-options boost-geometry benchmark
         triplet: x64-windows-release
         token: ${{ github.token }}
+        # FIXME: remove revision once microsoft/vcpkg makes a release after 2024.05.24
+        # Current hash corresponds to the merge of https://github.com/microsoft/vcpkg/pull/38979
+        revision: a8954b904ad2a6939ecd8fc213e87702fa1243ea
         github-binarycache: true
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,12 +14,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies via vcpkg
-      uses: johnwason/vcpkg-action@v5
+      uses: johnwason/vcpkg-action@v6
       id: vcpkg
       with:
         pkgs: boost-test boost-program-options boost-geometry benchmark
         triplet: x64-windows-release
         token: ${{ github.token }}
+        github-binarycache: true
     - uses: actions/checkout@v3
       with:
         repository: kokkos/kokkos


### PR DESCRIPTION
~Let's see if it fixes recent failures.~

Of course not. If only one looked at the logs:
```
error: Failed to download from mirror set
error: File does not have the expected hash:
url: https://github.com/boostorg/core/archive/boost-1.85.0.tar.gz
File: D:\a\ArborX\ArborX\vcpkg\downloads\boostorg-core-boost-1.85.0.tar.gz.3976.part
Expected hash: 3a7be75e52f5c20830fccb9e7391a1e4556ebb072e6324df95b1ba38bed46e24f4c9f27a62a1099eddc90f2ac1ede083f0c850e2dc27fd42375d028516f675b3
Actual hash: a1e774c98b537dd42018742af68f5889af1afd4e6c9809399987124e56a3b9ae2f20e8173170bc6fc0ad76fb95e2da7b9d385a4037e9ee12011fc02bf8f7e009
```
The problem is microsoft/vcpkg#38974. I switched to requiring a specific hash for `microsoft/vcpkg` temporarily until the next release.