### PR TITLE
Generate point clouds on device

### DIFF
--- a/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
+++ b/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
@@ -159,7 +159,8 @@ int main(int argc, char *argv[])
                          "Benchmark::points"),
       n);
   ArborXBenchmark::generatePointCloud(
-      ArborXBenchmark::PointCloudType::filled_box, std::cbrt(n), random_points);
+      space, ArborXBenchmark::PointCloudType::filled_box, std::cbrt(n),
+      random_points);
   Kokkos::Profiling::popRegion();
 
   std::cout << "#triangles        : " << triangles.size() << '\n';

--- a/benchmarks/utils/ArborXBenchmark_PointClouds.hpp
+++ b/benchmarks/utils/ArborXBenchmark_PointClouds.hpp
@@ -138,13 +138,26 @@ private:
   KOKKOS_FUNCTION auto hollowSpherePoint(Random const &random) const
   {
     Point p;
-    Coordinate norm = 0;
-    for (int d = 0; d < DIM; ++d)
+    // We use "Alternative method 2" from
+    // https://corysimon.github.io/articles/uniformdistn-on-sphere/.
+    // Note that once the dimensions go high, more and more points are going to
+    // be rejected, and the algorithm based on normal distribution would be
+    // more efficient.
+    auto const radius_squared = 1;
+    Coordinate norm_squared;
+    do
     {
-      p[d] = random();
-      norm += p[d] * p[d];
-    }
-    norm = Kokkos::sqrt(norm);
+      norm_squared = 0;
+      for (int d = 0; d < DIM; ++d)
+      {
+        p[d] = random();
+        norm_squared += p[d] * p[d];
+      }
+
+      // Only accept points that are in the sphere
+    } while (norm_squared > radius_squared || norm_squared == 0);
+
+    auto norm = Kokkos::sqrt(norm_squared);
     for (int d = 0; d < DIM; ++d)
       p[d] /= norm;
 

--- a/benchmarks/utils/ArborXBenchmark_PointClouds.hpp
+++ b/benchmarks/utils/ArborXBenchmark_PointClouds.hpp
@@ -17,6 +17,7 @@
 #include <ArborX_GeometryTraits.hpp>
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
 
 #include <fstream>
 #include <random>
@@ -49,160 +50,217 @@ inline PointCloudType to_point_cloud_enum(std::string const &str)
 namespace Details
 {
 
-template <class Point, typename... ViewProperties>
-void filledBoxCloud(double const half_edge,
-                    Kokkos::View<Point *, ViewProperties...> random_points)
+template <typename ExecutionSpace, typename Points>
+void filledBoxCloud(ExecutionSpace const &exec, double const half_edge,
+                    Points &random_points)
 {
-  namespace KokkosExt = ArborX::Details::KokkosExt;
-  static_assert(
-      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
-      "The View should be accessible on the Host");
-  std::uniform_real_distribution<double> distribution(-half_edge, half_edge);
-  std::default_random_engine generator;
-  auto random = [&distribution, &generator]() {
-    return distribution(generator);
-  };
+  using Point = typename Points::value_type;
+  constexpr auto DIM = ArborX::GeometryTraits::dimension_v<Point>;
+  using Coordinate = ArborX::GeometryTraits::coordinate_type_t<Point>;
+
+  using GeneratorPool = Kokkos::Random_XorShift1024_Pool<ExecutionSpace>;
+  using GeneratorType = typename GeneratorPool::generator_type;
+  constexpr unsigned int batch_size = 8;
+
+  GeneratorPool random_pool(0);
   unsigned int const n = random_points.extent(0);
-  constexpr auto DIM = ArborX::GeometryTraits::dimension<Point>::value;
-  for (unsigned int i = 0; i < n; ++i)
-    for (int d = 0; d < DIM; ++d)
-      random_points(i)[d] = random();
+  Kokkos::parallel_for(
+      "ArborXBenchmark::filledBoxCloud::generate",
+      Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n / batch_size),
+      KOKKOS_LAMBDA(int i) {
+        auto generator = random_pool.get_state();
+        auto random = [&generator, half_edge]() {
+          return Kokkos::rand<GeneratorType, Coordinate>::draw(
+              generator, -half_edge, half_edge);
+        };
+
+        auto begin = i * batch_size;
+        auto end = Kokkos::min((i + 1) * batch_size, n);
+        for (unsigned int k = begin; k < end; ++k)
+          for (int d = 0; d < DIM; ++d)
+            random_points(k)[d] = random();
+
+        random_pool.free_state(generator);
+      });
 }
 
-template <class Point, typename... ViewProperties>
-void hollowBoxCloud(double const half_edge,
-                    Kokkos::View<Point *, ViewProperties...> random_points)
+template <typename ExecutionSpace, typename Points>
+void hollowBoxCloud(ExecutionSpace const &exec, double const half_edge,
+                    Points &random_points)
 {
-  namespace KokkosExt = ArborX::Details::KokkosExt;
-  static_assert(
-      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
-      "The View should be accessible on the Host");
-  std::uniform_real_distribution<double> distribution(-half_edge, half_edge);
-  std::default_random_engine generator;
-  auto random = [&distribution, &generator]() {
-    return distribution(generator);
-  };
+  using Point = typename Points::value_type;
+  constexpr auto DIM = ArborX::GeometryTraits::dimension_v<Point>;
+  using Coordinate = ArborX::GeometryTraits::coordinate_type_t<Point>;
+
+  using GeneratorPool = Kokkos::Random_XorShift1024_Pool<ExecutionSpace>;
+  using GeneratorType = typename GeneratorPool::generator_type;
+  constexpr unsigned int batch_size = 8;
+
+  GeneratorPool random_pool(0);
   unsigned int const n = random_points.extent(0);
-  constexpr auto DIM = ArborX::GeometryTraits::dimension<Point>::value;
   // Points are cyclically placed on the faces of a box
-  constexpr int num_faces = 2 * DIM;
-  for (int axis = 0; axis < DIM; ++axis)
-  {
-    for (unsigned int i = 2 * axis; i < n; i += num_faces)
-      for (int d = 0; d < DIM; ++d)
-        random_points(i)[d] = (d != axis ? random() : -half_edge);
+  Kokkos::parallel_for(
+      "ArborXBenchmark::hollowBoxCloud::generate",
+      Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n / batch_size),
+      KOKKOS_LAMBDA(int i) {
+        auto generator = random_pool.get_state();
+        auto random = [&generator, half_edge]() {
+          return Kokkos::rand<GeneratorType, Coordinate>::draw(
+              generator, -half_edge, half_edge);
+        };
 
-    for (unsigned int i = 2 * axis + 1; i < n; i += num_faces)
-      for (int d = 0; d < DIM; ++d)
-        random_points(i)[d] = (d != axis ? random() : +half_edge);
-  }
+        auto begin = i * batch_size;
+        auto end = Kokkos::min((i + 1) * batch_size, n);
+        for (unsigned int k = begin; k < end; ++k)
+        {
+          // For 3D, the order is
+          // Indices: 0  1  2  3  4  5  6  7  8  9
+          // Axes   : 0- 0+ 1- 1+ 2- 2+ 0- 0+ 1- 1+
+          int axis = (k / 2) % DIM;
+          for (int d = 0; d < DIM; ++d)
+          {
+            if (d != axis)
+              random_points(k)[d] = random();
+            else if (k % 2 == 0)
+              random_points(k)[d] = -half_edge;
+            else
+              random_points(k)[d] = half_edge;
+          }
+        }
+
+        random_pool.free_state(generator);
+      });
 }
 
-template <class Point, typename... ViewProperties>
-void filledSphereCloud(double const radius,
-                       Kokkos::View<Point *, ViewProperties...> random_points)
+template <typename ExecutionSpace, typename Points>
+void filledSphereCloud(ExecutionSpace const &exec, double const radius,
+                       Points &random_points)
 {
-  namespace KokkosExt = ArborX::Details::KokkosExt;
-  static_assert(
-      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
-      "The View should be accessible on the Host");
-  std::default_random_engine generator;
+  using Point = typename Points::value_type;
+  constexpr auto DIM = ArborX::GeometryTraits::dimension_v<Point>;
+  using Coordinate = ArborX::GeometryTraits::coordinate_type_t<Point>;
 
-  std::uniform_real_distribution<double> distribution(-radius, radius);
-  auto random = [&distribution, &generator]() {
-    return distribution(generator);
-  };
+  using GeneratorPool = Kokkos::Random_XorShift1024_Pool<ExecutionSpace>;
+  using GeneratorType = typename GeneratorPool::generator_type;
+  constexpr unsigned int batch_size = 8;
 
+  GeneratorPool random_pool(0);
   unsigned int const n = random_points.extent(0);
-  constexpr auto DIM = ArborX::GeometryTraits::dimension<Point>::value;
-  for (unsigned int i = 0; i < n; ++i)
-  {
-    bool point_accepted = false;
-    while (!point_accepted)
-    {
-      Point p;
-      double norm = 0.f;
-      for (int d = 0; d < DIM; ++d)
-      {
-        double v = random();
-        p[d] = v;
-        norm += v * v;
-      }
-      norm = std::sqrt(norm);
+  Kokkos::parallel_for(
+      "ArborXBenchmark::filledSphereCloud::generate",
+      Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n / batch_size),
+      KOKKOS_LAMBDA(int i) {
+        auto generator = random_pool.get_state();
+        auto random = [&generator, radius]() {
+          return Kokkos::rand<GeneratorType, Coordinate>::draw(generator,
+                                                               -radius, radius);
+        };
 
-      // Only accept points that are in the sphere
-      if (norm <= radius)
-      {
-        random_points(i) = p;
-        point_accepted = true;
-      }
-    }
-  }
+        auto begin = i * batch_size;
+        auto end = Kokkos::min((i + 1) * batch_size, n);
+        for (unsigned int k = begin; k < end; ++k)
+        {
+          do
+          {
+            Point p;
+            Coordinate norm = 0;
+            for (int d = 0; d < DIM; ++d)
+            {
+              p[d] = random();
+              norm += p[d] * p[d];
+            }
+            norm = Kokkos::sqrt(norm);
+
+            // Only accept points that are in the sphere
+            if (norm <= radius)
+            {
+              random_points(k) = p;
+              break;
+            }
+          } while (true);
+        }
+
+        random_pool.free_state(generator);
+      });
 }
 
-template <class Point, typename... ViewProperties>
-void hollowSphereCloud(double const radius,
-                       Kokkos::View<Point *, ViewProperties...> random_points)
+template <typename ExecutionSpace, typename Points>
+void hollowSphereCloud(ExecutionSpace const &exec, double const radius,
+                       Points &random_points)
 {
-  namespace KokkosExt = ArborX::Details::KokkosExt;
-  static_assert(
-      KokkosExt::is_accessible_from_host<decltype(random_points)>::value,
-      "The View should be accessible on the Host");
-  std::default_random_engine generator;
+  using Point = typename Points::value_type;
+  constexpr auto DIM = ArborX::GeometryTraits::dimension_v<Point>;
+  using Coordinate = ArborX::GeometryTraits::coordinate_type_t<Point>;
 
-  std::normal_distribution<float> distribution(0.f, 1.f);
-  auto random = [&distribution, &generator]() {
-    return distribution(generator);
-  };
+  using GeneratorPool = Kokkos::Random_XorShift1024_Pool<ExecutionSpace>;
+  using GeneratorType = typename GeneratorPool::generator_type;
+  constexpr unsigned int batch_size = 8;
 
+  GeneratorPool random_pool(0);
   unsigned int const n = random_points.extent(0);
-  constexpr auto DIM = ArborX::GeometryTraits::dimension<Point>::value;
-  for (unsigned int i = 0; i < n; ++i)
-  {
-    double v[DIM];
-    double norm = 0.;
-    for (int d = 0; d < DIM; ++d)
-    {
-      v[d] = random();
-      norm += v[d] * v[d];
-    }
-    norm = std::sqrt(norm);
+  Kokkos::parallel_for(
+      "ArborXBenchmark::hollowSphereCloud::generate",
+      Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n / batch_size),
+      KOKKOS_LAMBDA(int i) {
+        auto generator = random_pool.get_state();
+        auto random = [&generator, radius]() {
+          return Kokkos::rand<GeneratorType, Coordinate>::draw(generator,
+                                                               -radius, radius);
+        };
 
-    for (int d = 0; d < DIM; ++d)
-      random_points(i)[d] = radius * v[d] / norm;
-  }
+        auto begin = i * batch_size;
+        auto end = Kokkos::min((i + 1) * batch_size, n);
+        for (unsigned int k = begin; k < end; ++k)
+        {
+          Point p;
+          Coordinate norm = 0;
+          for (int d = 0; d < DIM; ++d)
+          {
+            p[d] = random();
+            norm += p[d] * p[d];
+          }
+          norm = Kokkos::sqrt(norm);
+
+          for (int d = 0; d < DIM; ++d)
+            random_points(k)[d] = radius * p[d] / norm;
+        }
+
+        random_pool.free_state(generator);
+      });
 }
 
 } // namespace Details
 
-template <class Point, typename DeviceType>
-void generatePointCloud(PointCloudType const point_cloud_type,
-                        double const length,
-                        Kokkos::View<Point *, DeviceType> random_points)
+template <typename ExecutionSpace, typename Points>
+void generatePointCloud(ExecutionSpace const &exec,
+                        PointCloudType const point_cloud_type,
+                        double const length, Points &random_points)
 {
+  static_assert(Kokkos::is_view_v<Points>);
+
+  using Point = typename Points::value_type;
+
   using namespace ArborX::GeometryTraits;
   check_valid_geometry_traits(Point{});
   static_assert(is_point_v<Point>, "ArborX: View must contain point values");
 
-  auto random_points_host = Kokkos::create_mirror_view(random_points);
   switch (point_cloud_type)
   {
   case PointCloudType::filled_box:
-    Details::filledBoxCloud(length, random_points_host);
+    Details::filledBoxCloud(exec, length, random_points);
     break;
   case PointCloudType::hollow_box:
-    Details::hollowBoxCloud(length, random_points_host);
+    Details::hollowBoxCloud(exec, length, random_points);
     break;
   case PointCloudType::filled_sphere:
-    Details::filledSphereCloud(length, random_points_host);
+    Details::filledSphereCloud(exec, length, random_points);
     break;
   case PointCloudType::hollow_sphere:
-    Details::hollowSphereCloud(length, random_points_host);
+    Details::hollowSphereCloud(exec, length, random_points);
     break;
   default:
     throw ArborX::SearchException("not implemented");
   }
-  Kokkos::deep_copy(random_points, random_points_host);
 }
 
 } // namespace ArborXBenchmark


### PR DESCRIPTION
Generating large point clouds (like 100M) on host takes about half a minute (on Frontier), which makes it challenging to run multiple benchmarks. This PR does generation on the device. In addition, this PR fixes point generation for sphere and hollow sphere to produce uniform distributions and work better for high dimensions.

The generation is done in batched mode. I compared generating a certain number of random floats on A100 using different batches using the following driver:
[kokkos_vs_std_random.cpp](https://github.com/user-attachments/files/15537921/kokkos_vs_std_random.txt).

There's not much difference once one goes beyond batch 4:
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
BM_std_random/100                     7.85 us         7.85 us        89068
BM_std_random/10000                   56.6 us         56.6 us        12132
BM_std_random/1000000                 4582 us         4582 us          152
BM_std_random/100000000             457032 us       456937 us            2

BM_kokkos_random/100/1                13.4 us         13.4 us        40553
BM_kokkos_random/10000/1              13.3 us         13.3 us        52073
BM_kokkos_random/1000000/1             146 us          146 us         4831
BM_kokkos_random/100000000/1         13616 us        13616 us           52

BM_kokkos_random/100/4                12.1 us         12.1 us        57673
BM_kokkos_random/10000/4              13.7 us         13.7 us        51221
BM_kokkos_random/1000000/4            68.3 us         68.3 us        10250
BM_kokkos_random/100000000/4          4465 us         4462 us          158

BM_kokkos_random/100/16               13.3 us         13.3 us        52455
BM_kokkos_random/10000/16             16.1 us         16.1 us        43482
BM_kokkos_random/1000000/16           40.4 us         40.4 us        17361
BM_kokkos_random/100000000/16         3964 us         3963 us          177

BM_kokkos_random/100/64               18.3 us         18.3 us        38187
BM_kokkos_random/10000/64             26.6 us         26.6 us        26283
BM_kokkos_random/1000000/64           51.8 us         51.8 us        13491
BM_kokkos_random/100000000/64         5250 us         5249 us          133

BM_kokkos_random/100/256              1.52 us         1.52 us       462197
BM_kokkos_random/10000/256            44.1 us         44.1 us        15880
BM_kokkos_random/1000000/256          69.5 us         69.5 us        10059
BM_kokkos_random/100000000/256        6434 us         6432 us          110

BM_kokkos_random/100/1024             1.51 us         1.51 us       463793
BM_kokkos_random/10000/1024            119 us          119 us         5907
BM_kokkos_random/1000000/1024          230 us          230 us         3052
BM_kokkos_random/100000000/1024       5408 us         5408 us          129

BM_kokkos_random/100/4096             1.51 us         1.51 us       463578
BM_kokkos_random/10000/4096            439 us          439 us         1596
BM_kokkos_random/1000000/4096          872 us          872 us          802
BM_kokkos_random/100000000/4096       4397 us         4396 us          157
```
I chose 8, on the lower end, given that we are going to generate multi-dimensional points, which means `n * DIM`.

I validated the produced clouds by dumping them into VTK and visualizing.
