### PR TITLE
Work around spurious "missing return statement" warnings for NVCC and Intel compilers

### DIFF
--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -52,7 +52,7 @@ public:
       expand(bounding_volume, Access::get(_primitives, i));
       return value_type{bounding_volume, (index_type)i};
     }
-#if (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)) || \
+#if (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)) ||        \
     (defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2021))
     // FIXME_NVCC, FIXME_INTEL: workaround for spurios "missing return
     // statement at end of non-void function" warning

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -46,12 +46,18 @@ public:
     {
       return value_type{Access::get(_primitives, i), (index_type)i};
     }
-    // some versions of the Intel and Nvidia compilers emit an
-    // incorrect warning about lack of return statement when doing
-    // if constexpr .. else
-    BoundingVolume bounding_volume{};
-    expand(bounding_volume, Access::get(_primitives, i));
-    return value_type{bounding_volume, (index_type)i};
+    else
+    {
+      BoundingVolume bounding_volume{};
+      expand(bounding_volume, Access::get(_primitives, i));
+      return value_type{bounding_volume, (index_type)i};
+    }
+#if (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)) || \
+    (defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2021))
+    // FIXME_NVCC, FIXME_INTEL: workaround for spurios "missing return
+    // statement at end of non-void function" warning
+    return value_type{};
+#endif
   }
 
   KOKKOS_FUNCTION

--- a/src/details/ArborX_DetailsLegacy.hpp
+++ b/src/details/ArborX_DetailsLegacy.hpp
@@ -46,12 +46,12 @@ public:
     {
       return value_type{Access::get(_primitives, i), (index_type)i};
     }
-    else
-    {
-      BoundingVolume bounding_volume{};
-      expand(bounding_volume, Access::get(_primitives, i));
-      return value_type{bounding_volume, (index_type)i};
-    }
+    // some versions of the Intel and Nvidia compilers emit an
+    // incorrect warning about lack of return statement when doing
+    // if constexpr .. else
+    BoundingVolume bounding_volume{};
+    expand(bounding_volume, Access::get(_primitives, i));
+    return value_type{bounding_volume, (index_type)i};
   }
 
   KOKKOS_FUNCTION


### PR DESCRIPTION
This is a small change to avoid a compiler warning on both Intel and Nvidia compilers.  The warning is incorrect, but it is muddying up compile output and the dashboard results for the Sierra Toolkit.

The warning is that (sometimes) the compiler thinks:

```c++
double foo()
{
  if constexpr (...)
  {
    return 42;
  } else
  {
    return 0;
  }
}  // warning here about lack of return statement in non-void function
```

is missing a return statement.