### PR TITLE
Fix some nvcc warnings

### DIFF
--- a/src/interpolation/detail/ArborX_InterpDetailsPolynomialBasis.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsPolynomialBasis.hpp
@@ -95,8 +95,13 @@ KOKKOS_FUNCTION constexpr std::size_t polynomialBasisSize()
   static_assert(DIM > 0, "Polynomial basis with no dimension is invalid");
 
   std::size_t result = 1;
-  for (std::size_t k = 0; k < Kokkos::min(DIM, Degree); ++k)
-    result = result * (DIM + Degree - k) / (k + 1);
+
+  constexpr auto D = Kokkos::min(DIM, Degree);
+  if constexpr (D > 0)
+  {
+    for (std::size_t k = 0; k < D; ++k)
+      result = result * (DIM + Degree - k) / (k + 1);
+  }
   return result;
 }
 

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -120,6 +120,8 @@ void test_access_traits_compile_only()
   struct CustomIndex
   {
     char index;
+
+    KOKKOS_FUNCTION
     CustomIndex(int i) { index = i; }
   };
   auto q_with_custom_indices =

--- a/test/tstDendrogram.cpp
+++ b/test/tstDendrogram.cpp
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dendrogram_boruvka, DeviceType,
 
     auto permute = sortObjects(space, weights);
 
-    Kokkos::View<unsigned *, MemorySpace> inv_permute(
+    Kokkos::View<int *, MemorySpace> inv_permute(
         Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                            "Testing::inv_permute"),
         n - 1);

--- a/test/tstKokkosToolsExecutionSpaceInstances.cpp
+++ b/test/tstKokkosToolsExecutionSpaceInstances.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
 #include <string>
 
 #include "Search_UnitTestHelpers.hpp"
@@ -28,8 +29,9 @@ namespace
 // Lambdas can only be converted to function pointers if they do not capture.
 // Using a global non-static variable in an unnamed namespace to "capture" the
 // device id.
-uint32_t arborx_test_device_id = -1;
-uint32_t arborx_test_root_device_id = -1;
+uint32_t INVALID_DEVICE_ID = std::numeric_limits<uint32_t>::max();
+uint32_t arborx_test_device_id = INVALID_DEVICE_ID;
+uint32_t arborx_test_root_device_id = INVALID_DEVICE_ID;
 
 void arborx_test_parallel_x_callback(char const *label, uint32_t device_id,
                                      uint64_t * /*kernel_id*/)
@@ -66,8 +68,8 @@ void arborx_test_unset_tools_callbacks()
   Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
   Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(nullptr);
   Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
-  arborx_test_device_id = -1;
-  arborx_test_root_device_id = -1;
+  arborx_test_device_id = INVALID_DEVICE_ID;
+  arborx_test_root_device_id = INVALID_DEVICE_ID;
 }
 
 } // namespace

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -142,6 +142,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_nearest_predicate, TreeTypeTraits,
       Kokkos::RangePolicy<ExecutionSpace>(0, n), KOKKOS_LAMBDA(int i) {
         points(i) = {{(float)i, (float)i, (float)i}};
       });
+#ifdef KOKKOS_COMPILER_NVCC
+  [[maybe_unused]]
+#endif
   Point const origin = {{0., 0., 0.}};
 
   auto values = initialize_values(points, /*delta*/ 0.f);
@@ -328,6 +331,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_nearest_predicate,
         points(i) = {{(float)i, (float)i, (float)i}};
       });
   float const delta = 5.f;
+#ifdef KOKKOS_COMPILER_NVCC
+  [[maybe_unused]]
+#endif
   Point const origin = {{0., 0., 0.}};
 
   auto values = initialize_values(points, delta);


### PR DESCRIPTION
Partially address #272 only for nvcc 11.5+. Addressing pre-11.3 requires a lot more work, and not sure it's worth it unless people complain. The plan it to switch to nvcc 11.5 or later once SummitPlus goes away.