### PR TITLE
SYCL CI: Manually build oneDPL

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -426,7 +426,7 @@ pipeline {
                                     -D CMAKE_CXX_COMPILER=${DPCPP} \
                                     -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-fp-model=precise -fsycl-device-code-split=per_kernel -Wpedantic -Wall -Wextra -Wno-sycl-target -Wno-unknown-cuda-version -Wno-deprecated-declarations" \
-                                    -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
+                                    -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR;$ONE_DPL_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
                                     -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
                                     -D MPIEXEC_MAX_NUMPROCS=4 \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -62,12 +62,20 @@ RUN wget https://cloud.cees.ornl.gov/download/oneapi-for-nvidia-gpus-${DPCPP_VER
     ./oneapi-for-nvidia-gpus-${DPCPP_VERSION}-linux.sh -y && \
     rm oneapi-for-nvidia-gpus-${DPCPP_VERSION}-linux.sh
 
-# Install oneDPL, see
-# https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=linux&distributions=online&version=2023.0.0
-RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/19133/l_oneDPL_p_2022.0.0.25335.sh &&\
-    chmod +x ./l_oneDPL_p_2022.0.0.25335.sh && \
-    ./l_oneDPL_p_2022.0.0.25335.sh -a -s --eula accept && \
-    rm l_oneDPL_p_2022.0.0.25335.sh
+# Install oneDPL
+ENV ONE_DPL_DIR=/opt/onedpl
+RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
+    ONE_DPL_VERSION=oneDPL-2022.2.0 && \
+    ONE_DPL_URL=https://github.com/oneapi-src/oneDPL/archive && \
+    ONE_DPL_ARCHIVE=${ONE_DPL_VERSION}-rc1.tar.gz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${ONE_DPL_URL}/${ONE_DPL_ARCHIVE} && \
+    mkdir onedpl && \
+    tar -xf ${ONE_DPL_ARCHIVE} -C onedpl --strip-components=1 && cd onedpl && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX=${ONE_DPL_DIR} -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=TRUE -DONEDPL_BACKEND="dpcpp_only" .. && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}
 
 # Set up environment variables to avoid using setvars.sh in CI
 # clang++


### PR DESCRIPTION
Alternative to #1118. Uses the same approach as in https://github.com/kokkos/kokkos/pull/7112 to avoid errors such as
```
--2024-06-28 16:01:41--  (try: 2)  https://registrationcenter-download.intel.com/akdlm/irc_nas/19133/l_oneDPL_p_2022.0.0.25335.sh

Connecting to registrationcenter-download.intel.com (registrationcenter-download.intel.com)|23.211.176.50|:443... 
connected.

HTTP request sent, awaiting response... 
No data received.
```
when building the SYCL image used in the CI.