### PR TITLE
change std::is_same to Kokkos::space_accessibility

### DIFF
--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -270,8 +270,11 @@ public:
                                   Kokkos::LayoutRight>));
 
     using MemorySpace = typename ExportView::memory_space;
-    static_assert(Kokkos::SpaceAccessibility<MemorySpace, typename ImportView::memory_space>::accessible);
-     static_assert(Kokkos::SpaceAccessibility<MemorySpace, typename decltype(_permute)::memory_space>::accessible);
+    static_assert(Kokkos::SpaceAccessibility<
+                  MemorySpace, typename ImportView::memory_space>::accessible);
+    static_assert(Kokkos::SpaceAccessibility<
+                  MemorySpace,
+                  typename decltype(_permute)::memory_space>::accessible);
 
     using ValueType = typename ImportView::value_type;
     static_assert(

--- a/src/details/ArborX_DetailsDistributor.hpp
+++ b/src/details/ArborX_DetailsDistributor.hpp
@@ -270,10 +270,8 @@ public:
                                   Kokkos::LayoutRight>));
 
     using MemorySpace = typename ExportView::memory_space;
-    static_assert(
-        std::is_same_v<MemorySpace, typename ImportView::memory_space>);
-    static_assert(
-        std::is_same_v<MemorySpace, typename decltype(_permute)::memory_space>);
+    static_assert(Kokkos::SpaceAccessibility<MemorySpace, typename ImportView::memory_space>::accessible);
+     static_assert(Kokkos::SpaceAccessibility<MemorySpace, typename decltype(_permute)::memory_space>::accessible);
 
     using ValueType = typename ImportView::value_type;
     static_assert(


### PR DESCRIPTION
Changes two static asserts from `std::is_same<MemorySpace1, MemorySpace2>` to use `Kokkos::SpaceAccessibility` instead.  This is more correct for UVM builds (such as STK).