### PR TITLE
Update Vector to add computation precision and normalize()

### DIFF
--- a/src/details/ArborX_DetailsVector.hpp
+++ b/src/details/ArborX_DetailsVector.hpp
@@ -36,19 +36,22 @@ struct Vector
   KOKKOS_FUNCTION
   constexpr auto const &operator[](unsigned int i) const { return _coords[i]; }
 
-  KOKKOS_FUNCTION
-  constexpr auto dot(Vector const &w) const
+  template <typename Precision = Coordinate>
+  KOKKOS_FUNCTION constexpr auto dot(Vector const &w) const
   {
     auto const &v = *this;
 
-    Coordinate r = 0;
+    Precision r = 0;
     for (int d = 0; d < DIM; ++d)
-      r += v[d] * w[d];
+      r += static_cast<Precision>(v[d]) * static_cast<Precision>(w[d]);
     return r;
   }
 
-  KOKKOS_FUNCTION
-  auto norm() const { return Kokkos::sqrt(dot(*this)); }
+  template <typename Precision = Coordinate>
+  KOKKOS_FUNCTION auto norm() const
+  {
+    return Kokkos::sqrt(dot<Precision>(*this));
+  }
 
   KOKKOS_FUNCTION
   constexpr auto cross(Vector const &w) const

--- a/src/details/ArborX_DetailsVector.hpp
+++ b/src/details/ArborX_DetailsVector.hpp
@@ -54,17 +54,6 @@ struct Vector
     return Kokkos::sqrt(dot<Precision>(*this));
   }
 
-  template <typename Precision = Coordinate>
-  KOKKOS_FUNCTION void normalize()
-  {
-    auto const magv = norm<Precision>();
-    KOKKOS_ASSERT(magv > 0);
-
-    auto &v = *this;
-    for (int d = 0; d < DIM; ++d)
-      v[d] /= magv;
-  }
-
   KOKKOS_FUNCTION
   constexpr auto cross(Vector const &w) const
   {
@@ -84,6 +73,24 @@ struct Vector
     return match;
   }
 };
+
+template <typename Precision, int DIM, typename Coordinate>
+KOKKOS_INLINE_FUNCTION auto normalize(Vector<DIM, Coordinate> const &v)
+{
+  auto const magv = v.template norm<Precision>();
+  KOKKOS_ASSERT(magv > 0);
+
+  Vector<DIM, Coordinate> w;
+  for (int d = 0; d < DIM; ++d)
+    w[d] = v[d] / magv;
+  return w;
+}
+
+template <int DIM, typename Coordinate>
+KOKKOS_INLINE_FUNCTION auto normalize(Vector<DIM, Coordinate> const &v)
+{
+  return normalize<Coordinate>(v);
+}
 
 template <typename T, typename... U>
 Vector(T, U...) -> Vector<1 + sizeof...(U), T>;

--- a/src/details/ArborX_DetailsVector.hpp
+++ b/src/details/ArborX_DetailsVector.hpp
@@ -14,6 +14,7 @@
 #include <ArborX_GeometryTraits.hpp>
 #include <ArborX_HyperPoint.hpp>
 
+#include <Kokkos_Assert.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 
 namespace ArborX::Details
@@ -51,6 +52,17 @@ struct Vector
   KOKKOS_FUNCTION auto norm() const
   {
     return Kokkos::sqrt(dot<Precision>(*this));
+  }
+
+  template <typename Precision = Coordinate>
+  KOKKOS_FUNCTION void normalize()
+  {
+    auto const magv = norm<Precision>();
+    KOKKOS_ASSERT(magv > 0);
+
+    auto &v = *this;
+    for (int d = 0; d < DIM; ++d)
+      v[d] /= magv;
   }
 
   KOKKOS_FUNCTION

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -47,7 +47,7 @@ struct Ray
     // Normalize direction using higher precision. Using `float` by default
     // creates a large error in the norm that affects ray tracing for
     // triangles.
-    _direction.normalize<double>();
+    _direction = Details::normalize<double>(_direction);
   }
 
   KOKKOS_FUNCTION

--- a/src/geometry/ArborX_Ray.hpp
+++ b/src/geometry/ArborX_Ray.hpp
@@ -44,7 +44,10 @@ struct Ray
       : _origin(origin)
       , _direction(direction)
   {
-    normalize(_direction);
+    // Normalize direction using higher precision. Using `float` by default
+    // creates a large error in the norm that affects ray tracing for
+    // triangles.
+    _direction.normalize<double>();
   }
 
   KOKKOS_FUNCTION
@@ -58,33 +61,6 @@ struct Ray
 
   KOKKOS_FUNCTION
   constexpr Vector const &direction() const { return _direction; }
-
-private:
-  // We would like to use Scalar defined as:
-  // using Scalar = std::decay_t<decltype(std::declval<Vector>()[0])>;
-  // However, this means using float to compute the norm. This creates a large
-  // error in the norm that affects ray tracing for triangles. Casting the
-  // norm from double to float once it has been computed is not enough to
-  // improve the value of the normalized vector. Thus, the norm has to return a
-  // double.
-  using Scalar = double;
-
-  KOKKOS_FUNCTION
-  static Scalar norm(Vector const &v)
-  {
-    Scalar sq{};
-    for (int d = 0; d < 3; ++d)
-      sq += static_cast<Scalar>(v[d]) * static_cast<Scalar>(v[d]);
-    return std::sqrt(sq);
-  }
-
-  KOKKOS_FUNCTION static void normalize(Vector &v)
-  {
-    auto const magv = norm(v);
-    KOKKOS_ASSERT(magv > 0);
-    for (int d = 0; d < 3; ++d)
-      v[d] /= magv;
-  }
 };
 
 KOKKOS_INLINE_FUNCTION

--- a/test/tstDetailsVector.cpp
+++ b/test/tstDetailsVector.cpp
@@ -45,14 +45,13 @@ BOOST_AUTO_TEST_CASE(vector_norm)
 BOOST_AUTO_TEST_CASE(vector_normalize)
 {
   using Vector = ArborX::Details::Vector<2, float>;
+  using ArborX::Details::normalize;
 
   Vector v{3, 0};
-  v.normalize();
-  BOOST_TEST((v == Vector{1, 0}));
+  BOOST_TEST((normalize(v) == Vector{1, 0}));
 
   Vector w{3, 4};
-  w.normalize<double>();
-  BOOST_TEST((w == Vector{0.6f, 0.8f}));
+  BOOST_TEST((normalize<double>(w) == Vector{0.6f, 0.8f}));
 }
 
 BOOST_AUTO_TEST_CASE(vector_cross_product)

--- a/test/tstDetailsVector.cpp
+++ b/test/tstDetailsVector.cpp
@@ -27,6 +27,9 @@ BOOST_AUTO_TEST_CASE(vector_dot_product)
   static_assert(Vector{1, 0, 0}.dot(Vector{0, 1, 0}) == 0);
   static_assert(Vector{1, 0, 0}.dot(Vector{0, 0, 1}) == 0);
   static_assert(Vector{1, 1, 1}.dot(Vector{1, 1, 1}) == 3);
+
+  static_assert(Vector{1, 1e-7, 0}.dot(Vector{1, 1e-7, 0}) == 1);
+  static_assert(Vector{1, 1e-7, 0}.dot<double>(Vector{1, 1e-7, 0}) > 1);
 }
 
 BOOST_AUTO_TEST_CASE(vector_norm)
@@ -34,6 +37,10 @@ BOOST_AUTO_TEST_CASE(vector_norm)
   using Vector = ArborX::Details::Vector<3, float>;
   BOOST_TEST((Vector{3, 4}.norm()) == 5);
   BOOST_TEST((Vector{6, 13, 18}.norm()) == 23);
+
+  BOOST_TEST((Vector{1, 1e-7, 0}.norm()) == 1);
+  BOOST_TEST((Vector{1, 1e-7, 0}.norm<double>()) > 1);
+}
 }
 
 BOOST_AUTO_TEST_CASE(vector_cross_product)

--- a/test/tstDetailsVector.cpp
+++ b/test/tstDetailsVector.cpp
@@ -41,6 +41,18 @@ BOOST_AUTO_TEST_CASE(vector_norm)
   BOOST_TEST((Vector{1, 1e-7, 0}.norm()) == 1);
   BOOST_TEST((Vector{1, 1e-7, 0}.norm<double>()) > 1);
 }
+
+BOOST_AUTO_TEST_CASE(vector_normalize)
+{
+  using Vector = ArborX::Details::Vector<2, float>;
+
+  Vector v{3, 0};
+  v.normalize();
+  BOOST_TEST((v == Vector{1, 0}));
+
+  Vector w{3, 4};
+  w.normalize<double>();
+  BOOST_TEST((w == Vector{0.6f, 0.8f}));
 }
 
 BOOST_AUTO_TEST_CASE(vector_cross_product)


### PR DESCRIPTION
- Allow `Vector::dot` to be in a precision different from its type
- Allow `Vector::norm` to be in a precision different from its type
- Add `Vector::normalize()`
- Switch `Ray` to using new precision Vector functions