### PR TITLE
[ci skip] Add .git-blame-ignore-revs to skip clang-format changes for blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# clang-format 14.0
+18e8e71c8fbbb9e46bbc4e0fcad9986778fe9793
+# clang-format 7.0
+c301dd34ea30800b051f72b78cd93d2d33eae4b2
+# clang-format 6.0
+08d6ebb08782ff40559230ef34a4008f15453f71
+# clang-format 5.0
+85705177e98282db10b10026e8ae3cd0bc1fedad


### PR DESCRIPTION
GitHub provides a [newish](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/) (March 2022) [option](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) to ignore revisions in the blame view. I added 4 commits to the specified files to ignore 4 formatting patches we had:
- 18e8e71c8fbbb9e46bbc4e0fcad9986778fe9793 [clang-format 14.0]
- c301dd34ea30800b051f72b78cd93d2d33eae4b2 [clang-format 7.0]
- 08d6ebb08782ff40559230ef34a4008f15453f71 [clang-format 6.0]
- 85705177e98282db10b10026e8ae3cd0bc1fedad [clang-format 5.0]