### PR TITLE
Pass GeometryTraits template args through remove_cv

### DIFF
--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -26,7 +26,7 @@ struct dimension
   using not_specialized = void; // tag to detect existence of a specialization
 };
 template <typename Geometry>
-inline constexpr int dimension_v = dimension<Geometry>::value;
+inline constexpr int dimension_v = dimension<std::remove_cv_t<Geometry>>::value;
 
 struct not_specialized
 {};
@@ -37,7 +37,7 @@ struct tag
   using type = not_specialized;
 };
 template <typename Geometry>
-using tag_t = typename tag<Geometry>::type;
+using tag_t = typename tag<std::remove_cv_t<Geometry>>::type;
 
 template <typename Geometry>
 struct coordinate_type
@@ -45,7 +45,8 @@ struct coordinate_type
   using type = not_specialized;
 };
 template <typename Geometry>
-using coordinate_type_t = typename coordinate_type<Geometry>::type;
+using coordinate_type_t =
+    typename coordinate_type<std::remove_cv_t<Geometry>>::type;
 
 // clang-format off
 #define DEFINE_GEOMETRY(name, name_tag)                                        \

--- a/test/tstCompileOnlyGeometry.cpp
+++ b/test/tstCompileOnlyGeometry.cpp
@@ -218,6 +218,22 @@ void test_geometry_compile_only()
   // check_valid_geometry_traits(WrongCoordinateSpecialization{});
 }
 
+void test_point_cv_compile_only()
+{
+  using Point = ArborX::Point;
+  namespace GT = ArborX::GeometryTraits;
+
+  static_assert(GT::dimension_v<const Point> == 3);
+  static_assert(std::is_same_v<GT::coordinate_type_t<const Point>, float>);
+  static_assert(std::is_same_v<GT::tag_t<const Point>, GT::PointTag>);
+  static_assert(GT::is_point_v<const Point>);
+
+  static_assert(GT::dimension_v<volatile Point> == 3);
+  static_assert(std::is_same_v<GT::coordinate_type_t<volatile Point>, float>);
+  static_assert(std::is_same_v<GT::tag_t<volatile Point>, GT::PointTag>);
+  static_assert(GT::is_point_v<volatile Point>);
+}
+
 void test_point_ctad()
 {
   using ArborX::ExperimentalHyperGeometry::Point;

--- a/test/tstCompileOnlyGeometry.cpp
+++ b/test/tstCompileOnlyGeometry.cpp
@@ -227,11 +227,6 @@ void test_point_cv_compile_only()
   static_assert(std::is_same_v<GT::coordinate_type_t<const Point>, float>);
   static_assert(std::is_same_v<GT::tag_t<const Point>, GT::PointTag>);
   static_assert(GT::is_point_v<const Point>);
-
-  static_assert(GT::dimension_v<volatile Point> == 3);
-  static_assert(std::is_same_v<GT::coordinate_type_t<volatile Point>, float>);
-  static_assert(std::is_same_v<GT::tag_t<volatile Point>, GT::PointTag>);
-  static_assert(GT::is_point_v<volatile Point>);
 }
 
 void test_point_ctad()


### PR DESCRIPTION
Currently, code using things like `dimension_v<const Point>` does not work. This addresses the issue by passing provided template parameter `Geometry` through `std::remove_cv`.

Once we start requiring C++20, should probably switch to `std::remove_cvref`.