### PR TITLE
Add oriented bounding box (OBB)

### DIFF
--- a/src/ArborX.hpp
+++ b/src/ArborX.hpp
@@ -22,6 +22,7 @@
 #include <ArborX_CrsGraphWrapper.hpp>
 #include <ArborX_Exception.hpp>
 #include <ArborX_LinearBVH.hpp>
+#include <ArborX_OBB.hpp>
 #include <ArborX_Point.hpp>
 #include <ArborX_PredicateHelpers.hpp>
 #include <ArborX_Predicates.hpp>

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -30,6 +30,7 @@ namespace Dispatch
 {
 using GeometryTraits::BoxTag;
 using GeometryTraits::KDOPTag;
+using GeometryTraits::OBBTag;
 using GeometryTraits::PointTag;
 using GeometryTraits::RayTag;
 using GeometryTraits::SphereTag;

--- a/src/geometry/ArborX_GeometryTraits.hpp
+++ b/src/geometry/ArborX_GeometryTraits.hpp
@@ -62,6 +62,7 @@ DEFINE_GEOMETRY(box, BoxTag);
 DEFINE_GEOMETRY(sphere, SphereTag);
 DEFINE_GEOMETRY(triangle, TriangleTag);
 DEFINE_GEOMETRY(kdop, KDOPTag);
+DEFINE_GEOMETRY(obb, OBBTag);
 DEFINE_GEOMETRY(tetrahedron, TetrahedronTag);
 DEFINE_GEOMETRY(ray, RayTag);
 #undef DEFINE_GEOMETRY
@@ -70,7 +71,7 @@ template <typename Geometry>
 inline constexpr bool
     is_valid_geometry = (is_point_v<Geometry> || is_box_v<Geometry> ||
                          is_sphere_v<Geometry> || is_kdop_v<Geometry> ||
-                         is_triangle_v<Geometry> ||
+                         is_obb_v<Geometry> || is_triangle_v<Geometry> ||
                          is_tetrahedron_v<Geometry> || is_ray_v<Geometry>);
 
 template <typename Geometry>

--- a/src/geometry/ArborX_OBB.hpp
+++ b/src/geometry/ArborX_OBB.hpp
@@ -1,0 +1,415 @@
+/****************************************************************************
+ * Copyright (c) 2024 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef ARBORX_OBB_HPP
+#define ARBORX_OBB_HPP
+
+#include <ArborX_Box.hpp>
+#include <ArborX_DetailsAlgorithms.hpp>
+#include <ArborX_DetailsContainers.hpp> // StaticVector
+#include <ArborX_DetailsKokkosExtArithmeticTraits.hpp>
+#include <ArborX_DetailsSymmetricSVD.hpp>
+#include <ArborX_DetailsUtils.hpp>
+#include <ArborX_DetailsVector.hpp>
+#include <ArborX_GeometryTraits.hpp>
+#include <ArborX_HyperBox.hpp>
+#include <ArborX_HyperPoint.hpp>
+
+#include <Kokkos_Array.hpp>
+#include <Kokkos_Macros.hpp>
+
+namespace ArborX::Experimental
+{
+
+namespace
+{
+template <typename T>
+using UnmanagedViewWrapper =
+    Kokkos::View<T, Kokkos::AnonymousSpace,
+                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+}
+
+template <int DIM, typename Coordinate = float>
+struct OBB
+{
+  // Ortho-normal transformation matrix
+  // Normalized eigenvectors are stores in columns.
+  // The inverse is the transpose.
+  Coordinate _matrix[DIM * DIM];
+
+  // Box in the new coordinate system
+  ExperimentalHyperGeometry::Box<DIM, Coordinate> _box;
+
+  KOKKOS_DEFAULTED_FUNCTION OBB() = default;
+
+  template <typename View, typename = std::enable_if_t<Kokkos::is_view_v<View>>>
+  KOKKOS_FUNCTION OBB(View const &points)
+  {
+    static_assert(View::rank == 1);
+
+    using Point = typename View::value_type;
+    static_assert(GeometryTraits::is_point_v<Point>);
+    static_assert(GeometryTraits::dimension_v<Point> == DIM);
+    static_assert(
+        std::is_same_v<GeometryTraits::coordinate_type_t<Point>, Coordinate>);
+
+    int const n = points.size();
+    KOKKOS_ASSERT(n > 0);
+
+    auto mat = matrix();
+
+    if (n == 1)
+    {
+      // Set matrix to identity
+      for (int i = 0; i < DIM; ++i)
+        for (int j = 0; j < DIM; ++j)
+          mat(i, j) = (i == j ? 1 : 0);
+
+      Details::expand(_box, points[0]);
+      return;
+    }
+
+    // Compute covariance matrix
+    Coordinate cov_data[DIM * DIM];
+    UnmanagedViewWrapper<Coordinate[DIM][DIM]> cov(cov_data);
+    {
+      // There's a way to optimize computing covariance in a single loop,
+      // however, it is likely less precise
+      Coordinate mean[DIM];
+      for (int i = 0; i < DIM; ++i)
+      {
+        mean[i] = 0;
+        for (int k = 0; k < n; ++k)
+          mean[i] += points(k)[i];
+        mean[i] /= n;
+      }
+      for (int i = 0; i < DIM; ++i)
+        for (int j = i; j < DIM; ++j)
+        {
+          cov(i, j) = 0;
+          for (int k = 0; k < n; ++k)
+            cov(i, j) += (points(k)[i] - mean[i]) * (points(k)[j] - mean[j]);
+          cov(i, j) /= n;
+        }
+
+      // FIXME: not sure we need to do this (depends on SymSVD implementation)
+      for (int i = 0; i < DIM; ++i)
+        for (int j = 0; j < i; ++j)
+          cov(i, j) = cov(j, i);
+    }
+
+    // Find the orthonormalized eigenvectors and store them
+    Coordinate d_data[DIM];
+    UnmanagedViewWrapper<Coordinate[DIM]> D(d_data);
+
+    Interpolation::Details::symmetricSVDKernel(cov, D, mat);
+
+    // Find extents by projecting points
+    for (int i = 0; i < n; ++i)
+      Details::expand(_box, transform(points(i)));
+  }
+
+  template <int N>
+  KOKKOS_FUNCTION
+  OBB(ExperimentalHyperGeometry::Point<DIM, Coordinate> const (&points)[N])
+      : OBB(UnmanagedViewWrapper<
+            const ExperimentalHyperGeometry::Point<DIM, Coordinate>[N]>(points))
+  {}
+
+  KOKKOS_FUNCTION auto matrix()
+  {
+    return UnmanagedViewWrapper<Coordinate[DIM][DIM]>(_matrix);
+  }
+
+  KOKKOS_FUNCTION auto matrix() const
+  {
+    return UnmanagedViewWrapper<const Coordinate[DIM][DIM]>(_matrix);
+  }
+
+  template <typename Point>
+  KOKKOS_FUNCTION auto transform(Point const &point) const
+  {
+    static_assert(GeometryTraits::is_point_v<Point>);
+    static_assert(GeometryTraits::dimension_v<Point> == DIM);
+
+    auto const &mat = matrix();
+
+    // Use matrix transpose
+    Point p;
+    for (int row = 0; row < DIM; ++row)
+    {
+      p[row] = 0;
+      for (int col = 0; col < DIM; ++col)
+        p[row] += mat(col, row) * point[col];
+    }
+    return p;
+  }
+
+  template <typename Point>
+  KOKKOS_FUNCTION auto transform_back(Point const &point) const
+  {
+    static_assert(GeometryTraits::is_point_v<Point>);
+    static_assert(GeometryTraits::dimension_v<Point> == DIM);
+
+    auto const &mat = matrix();
+
+    Point p;
+    for (int row = 0; row < DIM; ++row)
+    {
+      p[row] = 0;
+      for (int col = 0; col < DIM; ++col)
+        p[row] += mat(row, col) * point[col];
+    }
+    return p;
+  }
+
+  KOKKOS_FUNCTION auto corners() const
+  {
+    static_assert(DIM == 2 || DIM == 3);
+
+    KOKKOS_ASSERT(Details::isValid(*this));
+
+    using Point = ExperimentalHyperGeometry::Point<DIM, Coordinate>;
+
+    Coordinate const xs[2] = {_box.minCorner()[0], _box.maxCorner()[0]};
+    Coordinate const ys[2] = {_box.minCorner()[1], _box.maxCorner()[1]};
+    int const num_unique_xs = (xs[0] != xs[1]) + 1;
+    int const num_unique_ys = (ys[0] != ys[1]) + 1;
+    if constexpr (DIM == 2)
+    {
+      Details::StaticVector<Point, 4> points;
+      for (int i = 0; i < num_unique_xs; ++i)
+        for (int j = 0; j < num_unique_ys; ++j)
+          points.emplaceBack(transform_back(Point{xs[i], ys[j]}));
+      return points;
+    }
+    else
+    {
+      Coordinate const zs[2] = {_box.minCorner()[2], _box.maxCorner()[2]};
+      int const num_unique_zs = (zs[0] != zs[1]) + 1;
+      Details::StaticVector<Point, 8> points;
+      for (int i = 0; i < num_unique_xs; ++i)
+        for (int j = 0; j < num_unique_ys; ++j)
+          for (int k = 0; k < num_unique_zs; ++k)
+            points.emplaceBack(transform_back(Point{xs[i], ys[j], zs[k]}));
+      return points;
+    }
+  }
+
+  // FIXME: only necessary to not modify the tests
+  KOKKOS_FUNCTION explicit operator Box() const
+  {
+    Box box;
+    Details::expand(box, *this);
+    return box;
+  }
+};
+
+} // namespace ArborX::Experimental
+
+template <int DIM, typename Coordinate>
+struct ArborX::GeometryTraits::dimension<
+    ArborX::Experimental::OBB<DIM, Coordinate>>
+{
+  static constexpr int value = DIM;
+};
+template <int DIM, typename Coordinate>
+struct ArborX::GeometryTraits::tag<ArborX::Experimental::OBB<DIM, Coordinate>>
+{
+  using type = OBBTag;
+};
+template <int DIM, typename Coordinate>
+struct ArborX::GeometryTraits::coordinate_type<
+    ArborX::Experimental::OBB<DIM, Coordinate>>
+{
+  using type = Coordinate;
+};
+
+namespace ArborX::Details::Dispatch
+{
+
+template <typename OBB>
+struct equals<OBBTag, OBB>
+{
+  KOKKOS_FUNCTION static constexpr bool apply(OBB const &l, OBB const &r)
+  {
+    constexpr int DIM = GeometryTraits::dimension_v<OBB>;
+    for (int i = 0; i < DIM; ++i)
+      for (int j = 0; j < DIM; ++j)
+        if (l.matrix()(i, j) != r.matrix()(i, j))
+          return false;
+    return Details::equals(l._box, r._box);
+  }
+};
+
+template <typename OBB>
+struct isValid<OBBTag, OBB>
+{
+  KOKKOS_FUNCTION static constexpr bool apply(OBB const &obb)
+  {
+    constexpr int DIM = GeometryTraits::dimension_v<OBB>;
+
+    // Slight modification on isValid(Box) in that Box{p, p} would be valid
+    // here
+    auto const &b = obb._box;
+    for (int d = 0; d < DIM; ++d)
+    {
+      auto const r_d = b.maxCorner()[d] - b.minCorner()[d];
+      if (!Kokkos::isfinite(r_d) || r_d < 0)
+        return false;
+    }
+    return true;
+  }
+};
+
+template <typename OBB, typename Point>
+struct expand<OBBTag, PointTag, OBB, Point>
+{
+  KOKKOS_FUNCTION static void apply(OBB &obb, Point const &point)
+  {
+    constexpr int DIM = GeometryTraits::dimension_v<OBB>;
+    using Coordinate = GeometryTraits::coordinate_type_t<OBB>;
+
+    using HyperPoint = ExperimentalHyperGeometry::Point<DIM, Coordinate>;
+    auto hyper_point = Kokkos::bit_cast<HyperPoint>(point);
+
+    if (!Details::isValid(obb))
+    {
+      obb = OBB({hyper_point});
+      return;
+    }
+
+    auto const corners = obb.corners();
+    int const num_corners = corners.size();
+
+    Details::StaticVector<HyperPoint, corners.capacity() + 1> points;
+    for (int i = 0; i < num_corners; ++i)
+      points.emplaceBack(corners[i]);
+    points.emplaceBack(hyper_point);
+
+    obb = OBB(Kokkos::View<HyperPoint *, Kokkos::AnonymousSpace,
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
+        points.data(), points.size()));
+  }
+};
+
+template <typename OBB, typename Box>
+struct expand<OBBTag, BoxTag, OBB, Box>
+{
+  KOKKOS_FUNCTION static void apply(OBB &obb, Box const &box)
+  {
+    constexpr int DIM = GeometryTraits::dimension_v<OBB>;
+
+    OBB other;
+    // Set matrix to identity
+    for (int i = 0; i < DIM; ++i)
+      for (int j = 0; j < DIM; ++j)
+        other.matrix()(i, j) = (i == j ? 1 : 0);
+    // FIXME: doing expand instead of _box = box to accomodate both regular and
+    // hyper-dimensional box
+    Details::expand(other._box, box);
+
+    if (!Details::isValid(obb))
+      obb = other;
+    else
+      Details::expand(obb, other);
+  }
+};
+
+template <typename Box, typename OBB>
+struct expand<BoxTag, OBBTag, Box, OBB>
+{
+  KOKKOS_FUNCTION static void apply(Box &box, OBB const &obb)
+  {
+    if (!Details::isValid(obb))
+      return;
+
+    auto const corners = obb.corners();
+    int const num_corners = corners.size();
+    for (int i = 0; i < num_corners; ++i)
+      Details::expand(box, corners[i]);
+  }
+};
+
+template <typename OBB1, typename OBB2>
+struct expand<OBBTag, OBBTag, OBB1, OBB2>
+{
+  KOKKOS_FUNCTION static void apply(OBB1 &obb, OBB2 const &other)
+  {
+    KOKKOS_ASSERT(Details::isValid(other));
+
+    if (!Details::isValid(obb))
+    {
+      obb = other;
+      return;
+    }
+
+    auto corners1 = obb.corners();
+    auto corners2 = other.corners();
+    int const num_corners1 = corners1.size();
+    int const num_corners2 = corners2.size();
+
+    using Point = typename decltype(corners1)::value_type;
+
+    Details::StaticVector<Point, corners1.capacity() + corners2.capacity()>
+        points;
+    for (int i = 0; i < num_corners1; ++i)
+      points.emplaceBack(corners1[i]);
+    for (int i = 0; i < num_corners2; ++i)
+      points.emplaceBack(corners2[i]);
+
+    obb = OBB1(Kokkos::View<Point *, Kokkos::AnonymousSpace,
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
+        points.data(), points.size()));
+  }
+};
+
+template <typename OBB>
+struct centroid<OBBTag, OBB>
+{
+  KOKKOS_FUNCTION static auto apply(OBB const &obb)
+  {
+    return obb.transform_back(Details::returnCentroid(obb._box));
+  }
+};
+
+template <typename Point, typename OBB>
+struct intersects<PointTag, OBBTag, Point, OBB>
+{
+  KOKKOS_FUNCTION static constexpr bool apply(Point const &point,
+                                              OBB const &obb)
+  {
+    return Details::intersects(obb.transform(point), obb._box);
+  }
+};
+
+template <typename Sphere, typename OBB>
+struct intersects<SphereTag, OBBTag, Sphere, OBB>
+{
+  KOKKOS_FUNCTION static constexpr bool apply(Sphere const &sphere,
+                                              OBB const &obb)
+  {
+    return Details::intersects(
+        Sphere{obb.transform(sphere.centroid()), sphere.radius()}, obb._box);
+  }
+};
+
+template <typename Point, typename OBB>
+struct distance<PointTag, OBBTag, Point, OBB>
+{
+  KOKKOS_FUNCTION static auto apply(Point const &point, OBB const &obb)
+  {
+    return Details::distance(obb.transform(point), obb._box);
+  }
+};
+
+} // namespace ArborX::Details::Dispatch
+
+#endif

--- a/src/interpolation/details/ArborX_DetailsSymmetricSVD.hpp
+++ b/src/interpolation/details/ArborX_DetailsSymmetricSVD.hpp
@@ -9,8 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#ifndef ARBORX_INTERP_DETAILS_SYMMETRIC_PSEUDO_INVERSE_SVD_HPP
-#define ARBORX_INTERP_DETAILS_SYMMETRIC_PSEUDO_INVERSE_SVD_HPP
+#ifndef ARBORX_DETAILS_SYMMETRIC_SVD_HPP
+#define ARBORX_DETAILS_SYMMETRIC_SVD_HPP
 
 #include <ArborX_DetailsKokkosExtAccessibilityTraits.hpp>
 #include <ArborX_Exception.hpp>

--- a/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/details/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -18,7 +18,7 @@
 #include <ArborX_HyperPoint.hpp>
 #include <ArborX_InterpDetailsCompactRadialBasisFunction.hpp>
 #include <ArborX_InterpDetailsPolynomialBasis.hpp>
-#include <ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp>
+#include <ArborX_DetailsSymmetricSVD.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(ArborX_Test_Geometry.exe
   tstCompileOnlyGeometry.cpp
   tstRay.cpp
   tstKDOP.cpp
+  tstOBB.cpp
 )
 target_link_libraries(ArborX_Test_Geometry.exe PRIVATE ArborX Boost::unit_test_framework)
 target_compile_definitions(ArborX_Test_Geometry.exe PRIVATE BOOST_TEST_DYN_LINK)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,26 @@ foreach(_test Callbacks Degenerate ManufacturedSolution ComparisonWithBoost)
     "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp" COPYONLY
   )
   list(APPEND ARBORX_TEST_QUERY_TREE_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH.cpp")
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH_OBB.cpp.tmp"
+    "#include <ArborX_LinearBVH.hpp>\n"
+    "#include <ArborX_OBB.hpp>\n"
+    "#include \"ArborXTest_LegacyTree.hpp\"\n"
+    "template <class MemorySpace>\n"
+    "using ArborX_Legacy_BVH_OBB =\n"
+    "    LegacyTree<ArborX::BoundingVolumeHierarchy<\n"
+    "        MemorySpace, ArborX::PairValueIndex<ArborX::Experimental::OBB<3>>,\n"
+    "        ArborX::Details::DefaultIndexableGetter, ArborX::Experimental::OBB<3>>>;\n"
+    "#define ARBORX_TEST_TREE_TYPES Tuple<ArborX_Legacy_BVH_OBB>\n"
+    "#define ARBORX_TEST_DEVICE_TYPES std::tuple<${ARBORX_DEVICE_TYPES}>\n"
+    "#define ARBORX_TEST_DISABLE_SPATIAL_QUERY_INTERSECTS_BOX\n"
+    "#define ARBORX_TEST_DISABLE_NEAREST_QUERY_BOX\n"
+    "#include <tstQueryTree${_test}.cpp>\n"
+  )
+  configure_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH_OBB.cpp.tmp"
+    "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH_OBB.cpp" COPYONLY
+  )
+  list(APPEND ARBORX_TEST_QUERY_TREE_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BVH_OBB.cpp")
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/tstQueryTree${_test}_BF.cpp.tmp"
     "#include <ArborX_BruteForce.hpp>\n"
     "#include <ArborX_Box.hpp>\n"

--- a/test/tstInterpDetailsSVD.cpp
+++ b/test/tstInterpDetailsSVD.cpp
@@ -16,28 +16,39 @@
 #include "BoostTest_CUDA_clang_workarounds.hpp"
 #include <boost/test/unit_test.hpp>
 
-template <typename MS, typename ES, typename V, int M, int N>
-void makeCase(ES const &es, V const (&src_arr)[M][N][N],
-              V const (&ref_arr)[M][N][N])
+template <typename MemorySpace, typename ExecutionSpace, typename Value, int M,
+          int N>
+void makeCase(ExecutionSpace const &exec, Value const (&src_arr)[M][N][N],
+              Value const (&ref_arr)[M][N][N])
 {
-  using DeviceView = Kokkos::View<V[M][N][N], MS>;
+  using DeviceView = Kokkos::View<Value[N][N], MemorySpace>;
   using HostView = typename DeviceView::HostMirror;
 
   HostView src("Testing::src");
   HostView ref("Testing::ref");
+
   DeviceView inv("Testing::inv");
+  DeviceView unit("Testing::unit");
+  Kokkos::View<Value[N], MemorySpace> diag("Testing::diag");
 
   for (int i = 0; i < M; i++)
+  {
     for (int j = 0; j < N; j++)
       for (int k = 0; k < N; k++)
       {
-        src(i, j, k) = src_arr[i][j][k];
-        ref(i, j, k) = ref_arr[i][j][k];
+        src(j, k) = src_arr[i][j][k];
+        ref(j, k) = ref_arr[i][j][k];
       }
+    Kokkos::deep_copy(exec, inv, src);
 
-  Kokkos::deep_copy(es, inv, src);
-  ArborX::Interpolation::Details::symmetricPseudoInverseSVD(es, inv);
-  ARBORX_MDVIEW_TEST_TOL(ref, inv, Kokkos::Experimental::epsilon_v<float>);
+    Kokkos::parallel_for(
+        "Testing::run_case", Kokkos::RangePolicy<ExecutionSpace>(exec, 0, 1),
+        KOKKOS_LAMBDA(int) {
+          ArborX::Interpolation::Details::symmetricPseudoInverseSVDKernel(
+              inv, diag, unit);
+        });
+    ARBORX_MDVIEW_TEST_TOL(ref, inv, Kokkos::Experimental::epsilon_v<float>);
+  }
 }
 
 // Pseudo-inverses were computed using numpy's "linalg.pinv" solver and
@@ -114,15 +125,4 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_scalar_like, DeviceType,
   double mat[2][1][1] = {{{2}}, {{0}}};
   double inv[2][1][1] = {{{1 / 2.}}, {{0}}};
   makeCase<MemorySpace>(space, mat, inv);
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(pseudo_inv_empty, DeviceType, ARBORX_DEVICE_TYPES)
-{
-  using ExecutionSpace = typename DeviceType::execution_space;
-  using MemorySpace = typename DeviceType::memory_space;
-  ExecutionSpace space{};
-
-  Kokkos::View<double ***, MemorySpace> mat("mat", 0, 0, 0);
-  ArborX::Interpolation::Details::symmetricPseudoInverseSVD(space, mat);
-  BOOST_TEST(mat.size() == 0);
 }

--- a/test/tstInterpDetailsSVD.cpp
+++ b/test/tstInterpDetailsSVD.cpp
@@ -11,7 +11,7 @@
 
 #include "ArborX_EnableDeviceTypes.hpp"
 #include "ArborX_EnableViewComparison.hpp"
-#include <ArborX_InterpDetailsSymmetricPseudoInverseSVD.hpp>
+#include <ArborX_DetailsSymmetricSVD.hpp>
 
 #include "BoostTest_CUDA_clang_workarounds.hpp"
 #include <boost/test/unit_test.hpp>

--- a/test/tstOBB.cpp
+++ b/test/tstOBB.cpp
@@ -1,0 +1,194 @@
+/****************************************************************************
+ * Copyright (c) 2024 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <ArborX_OBB.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+namespace tt = boost::test_tools;
+
+using ArborX::Experimental::OBB;
+
+BOOST_AUTO_TEST_SUITE(OrientedBoundingBox)
+
+BOOST_AUTO_TEST_CASE(equals_obb)
+{
+  using ArborX::Details::equals;
+
+  OBB<2, float> obb({{1, 0}, {0, 1}});
+  BOOST_TEST(equals(obb, obb));
+
+  OBB<2, float> obb1({{1, 0}, {0, 1}, {0, 0}});
+  BOOST_TEST(!equals(obb, obb1));
+
+  OBB<3, float> obb3({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+  BOOST_TEST(equals(obb3, obb3));
+}
+
+BOOST_AUTO_TEST_CASE(expand_obb_2D)
+{
+  using Point = ArborX::ExperimentalHyperGeometry::Point<2>;
+  using ArborX::Details::equals;
+  using ArborX::Details::expand;
+
+  Point points[3] = {{1, 0}, {0, 0}, {0, 1}};
+
+  OBB<2, float> obb;
+  expand(obb, points[0]);
+  BOOST_TEST(equals(obb, OBB({points[0]})));
+
+  expand(obb, OBB({points[1], points[2]}));
+  BOOST_TEST(equals(obb, OBB({points[0], points[1], points[2]})));
+}
+
+BOOST_AUTO_TEST_CASE(expand_obb_3D)
+{
+  using Point = ArborX::ExperimentalHyperGeometry::Point<3>;
+  using ArborX::Details::equals;
+  using ArborX::Details::expand;
+
+  Point points[5] = {{1, 0, 0}, {0, 0, 0}, {0, 2, 0}, {0, 0, 3}, {0, 2, 3}};
+
+  OBB<3, float> obb;
+  expand(obb, points[0]);
+  BOOST_TEST(equals(obb, OBB({points[0]})));
+
+  expand(obb, OBB({points[1], points[2], points[3], points[4]}));
+  BOOST_TEST(equals(
+      obb, OBB({points[0], points[1], points[2], points[3], points[4]})));
+}
+
+BOOST_AUTO_TEST_CASE(intersects_point_obb_2D)
+{
+  using Point = ArborX::ExperimentalHyperGeometry::Point<2>;
+  using ArborX::Details::intersects;
+
+  {
+    OBB<2, float> obb({{1, 0}});
+    BOOST_TEST(intersects(Point{1, 0}, obb));
+    BOOST_TEST(!intersects(Point{0, 0}, obb));
+  }
+  {
+    //   x
+    //    \
+    //     \
+    //      x
+    OBB<2, float> obb({{1, 0}, {0, 1}});
+    BOOST_TEST(intersects(Point{0.5f, 0.5f}, obb));
+    BOOST_TEST(intersects(Point{0, 1}, obb));
+    BOOST_TEST(intersects(Point{1, 0}, obb));
+    BOOST_TEST(!intersects(Point{0, 0}, obb));
+  }
+  {
+    //   x
+    //  / \
+    //  \  \
+    //   x  x
+    //    \/
+    OBB<2, float> obb({{1, 0}, {0, 1}, {0, 0}});
+    BOOST_TEST(intersects(Point{-0.25f, 0.26f}, obb));
+    BOOST_TEST(!intersects(Point{-0.5f, 0.49f}, obb));
+    BOOST_TEST(intersects(Point{-0.25f, 0.74f}, obb));
+    BOOST_TEST(intersects(Point{0.25f, -0.24f}, obb));
+    BOOST_TEST(!intersects(Point{0.5f, 0.51f}, obb));
+    BOOST_TEST(intersects(Point{0.75f, 0.24f}, obb));
+  }
+  {
+    // OBB is not necessarily the tightest box around the points. Here's an
+    // example where the covariance matrix is proportional to identity, and
+    // we simply choose the default axes, i.e.,
+    //
+    //  This      Not this
+    //  +-x-+        x
+    //  |   |       / \
+    //  x   x      x   x
+    //  |   |       \ /
+    //  +-x-+        x
+    OBB<2, float> obb({{1, 0}, {0, 1}, {1, 2}, {2, 1}});
+    BOOST_TEST(intersects(Point{0, 1.f}, obb));
+    BOOST_TEST(intersects(Point{1.f, 2.f}, obb));
+    BOOST_TEST(intersects(Point{0.49f, 0.49f}, obb));
+    BOOST_TEST(intersects(Point{0.49f, 1.51f}, obb));
+    BOOST_TEST(intersects(Point{1.51f, 1.51f}, obb));
+    BOOST_TEST(intersects(Point{1.51f, 0.49f}, obb));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(distance_point_obb_2D)
+{
+  using Point = ArborX::ExperimentalHyperGeometry::Point<2>;
+  using ArborX::Details::distance;
+
+  {
+    OBB<2, float> obb({{1, 0}});
+    BOOST_TEST(distance(Point{1, 0}, obb) == 0);
+    BOOST_TEST(distance(Point{0, 0}, obb) == 1);
+    BOOST_TEST(distance(Point{0, 1}, obb) == std::sqrt(2.f));
+  }
+  {
+    //   x
+    //    \
+    //     \
+    //      x
+    OBB<2, float> obb({{1, 0}, {0, 1}});
+    BOOST_TEST(distance(Point{0.5f, 0.5f}, obb) == 0);
+    BOOST_TEST(distance(Point{-1, 0}, obb) == std::sqrt(2.f));
+  }
+  {
+    //   x
+    //  / \
+    //  \  \
+    //   x  x
+    //    \/
+    OBB<2, float> obb({{1, 0}, {0, 1}, {0, 0}});
+    BOOST_TEST(distance(Point{1, 1}, obb) == std::sqrt(0.5f));
+    BOOST_TEST(distance(Point{0.5f, -1.f}, obb) == 0.5f, tt::tolerance(1e-7f));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(centroid_obb_2D, *boost::unit_test::tolerance(1e-7f))
+{
+  using ArborX::Details::returnCentroid;
+
+  {
+    OBB<2, float> obb({{1, 0}});
+    auto center = returnCentroid(obb);
+    BOOST_TEST(center[0] == 1);
+    BOOST_TEST(center[1] == 0);
+  }
+  {
+    //   x
+    //    \
+    //     \
+    //      x
+    OBB<2, float> obb({{1, 0}, {0, 1}});
+    auto center = returnCentroid(obb);
+    BOOST_TEST(center[0] == 0.5f);
+    BOOST_TEST(center[1] == 0.5f);
+  }
+  {
+    //   x
+    //  / \
+    //  \  \
+    //   x  x
+    //    \/
+    OBB<2, float> obb({{1, 0}, {0, 1}, {0, 0}});
+    auto center = returnCentroid(obb);
+    BOOST_TEST(center[0] == 0.25f);
+    BOOST_TEST(center[1] == 0.25f);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/tstQueryTreeCallbacks.cpp
+++ b/test/tstQueryTreeCallbacks.cpp
@@ -85,6 +85,7 @@ std::vector<Kokkos::pair<int, float>> initialize_values(View const &points,
   return values;
 }
 
+#ifndef ARBORX_TEST_DISABLE_SPATIAL_QUERY_INTERSECTS_BOX
 BOOST_AUTO_TEST_CASE_TEMPLATE(callback_spatial_predicate, TreeTypeTraits,
                               TreeTypeTraitsList)
 {
@@ -119,6 +120,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_spatial_predicate, TreeTypeTraits,
                                   CustomPostCallback<DeviceType>{points},
                                   make_compressed_storage(offsets, values));
 }
+#endif
 
 #ifndef ARBORX_TEST_DISABLE_NEAREST_QUERY
 BOOST_AUTO_TEST_CASE_TEMPLATE(callback_nearest_predicate, TreeTypeTraits,
@@ -158,7 +160,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_nearest_predicate, TreeTypeTraits,
 }
 #endif
 
-#ifndef ARBORX_TEST_DISABLE_CALLBACK_EARLY_EXIT
+#if !defined(ARBORX_TEST_DISABLE_CALLBACK_EARLY_EXIT) &&                       \
+    !defined(ARBORX_TEST_DISABLE_SPATIAL_QUERY_INTERSECTS_BOX)
 template <class DeviceType>
 struct Experimental_CustomCallbackEarlyExit
 {
@@ -255,6 +258,7 @@ struct CustomPostCallbackWithAttachment
   }
 };
 
+#ifndef ARBORX_TEST_DISABLE_SPATIAL_QUERY_INTERSECTS_BOX
 BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_spatial_predicate,
                               TreeTypeTraits, TreeTypeTraitsList)
 {
@@ -291,6 +295,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_spatial_predicate,
       CustomPostCallbackWithAttachment<DeviceType>{points},
       make_compressed_storage(offsets, values));
 }
+#endif
 
 #ifndef ARBORX_TEST_DISABLE_NEAREST_QUERY
 BOOST_AUTO_TEST_CASE_TEMPLATE(callback_with_attachment_nearest_predicate,

--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -175,9 +175,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
 
   BoostExt::RTree<decltype(cloud)::value_type> rtree(ExecutionSpace{}, cloud);
 
+#ifndef ARBORX_TEST_DISABLE_SPATIAL_QUERY_INTERSECTS_BOX
   ARBORX_TEST_QUERY_TREE(
       ExecutionSpace{}, tree, intersects_queries,
       query(ExecutionSpace{}, rtree, intersects_queries_host));
+#endif
+
 #ifndef ARBORX_TEST_DISABLE_SPATIAL_QUERY_INTERSECTS_SPHERE
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, within_queries,
                          query(ExecutionSpace{}, rtree, within_queries_host));
@@ -196,6 +199,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate_point,
                                 ArborX::Point>();
 }
 
+#ifndef ARBORX_TEST_DISABLE_NEAREST_QUERY_BOX
 BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate_box, TreeTypeTraits,
                               TreeTypeTraitsList)
 {
@@ -206,6 +210,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_nearest_predicate_box, TreeTypeTraits,
   boost_rtree_nearest_predicate<Tree, ExecutionSpace, DeviceType,
                                 ArborX::Box>();
 }
+#endif
 #endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -26,6 +26,7 @@ BOOST_AUTO_TEST_SUITE(ManufacturedSolution)
 
 namespace tt = boost::test_tools;
 
+#ifndef ARBORX_TEST_DISABLE_SPATIAL_QUERY_INTERSECTS_BOX
 BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
                               TreeTypeTraitsList)
 {
@@ -252,5 +253,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
   ARBORX_TEST_QUERY_TREE(ExecutionSpace{}, tree, queries,
                          make_reference_solution(indices_ref, offset_ref));
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
[Currently contains #1128]

This PR adds oriented bounding box geometry. This geometry consists of an orthonormal transformation matrix and a AABB in the new coordinate system. We use SVD to solve the eigenvalue problem. 

There are some nuances with the implementation. Due to using floating point operations, there could be false positives and negatives for intersection tests, as well as an error in the distance metric. The only way to get rid of that is to expand the box by some amount in each direction. However, this makes the testing pretty hard to do. Right now, in this draft form, the box is not expanded so that we can have discussion. Because of the false stuff, using OBB for MST won't work, it will break down (my understanding is that that distance to the OBB may be larger than the distance to the contained primitives, which results in problems).

I'd like to have a discussion about how much to expand a box by, as well as how to deal with that in the testing.