### PR TITLE
Add centroid for Tetrahedron

### DIFF
--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -33,6 +33,7 @@ using GeometryTraits::KDOPTag;
 using GeometryTraits::PointTag;
 using GeometryTraits::RayTag;
 using GeometryTraits::SphereTag;
+using GeometryTraits::TetrahedronTag;
 using GeometryTraits::TriangleTag;
 
 template <typename Tag, typename Geometry>
@@ -757,6 +758,20 @@ struct centroid<TriangleTag, Triangle>
     auto c = triangle.a;
     for (int d = 0; d < DIM; ++d)
       c[d] = (c[d] + triangle.b[d] + triangle.c[d]) / 3;
+    return c;
+  }
+};
+
+template <typename Tetrahedron>
+struct centroid<TetrahedronTag, Tetrahedron>
+{
+  KOKKOS_FUNCTION static constexpr auto apply(Tetrahedron const &tet)
+  {
+    constexpr int DIM = GeometryTraits::dimension_v<Tetrahedron>;
+    static_assert(DIM == 3);
+    auto c = tet.a;
+    for (int d = 0; d < DIM; ++d)
+      c[d] = (c[d] + tet.b[d] + tet.c[d] + tet.d[d]) / 4;
     return c;
   }
 };

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -373,6 +373,12 @@ BOOST_AUTO_TEST_CASE(centroid)
   BOOST_TEST(tri3_center[0] == 1);
   BOOST_TEST(tri3_center[1] == 1);
   BOOST_TEST(tri3_center[2] == 0);
+
+  Tetrahedron tet{{{0, 0, -2}}, {{-4, 3, 4}}, {{1, 9, 5}}, {{-1, 0, 1}}};
+  auto tet_center = returnCentroid(tet);
+  BOOST_TEST(tet_center[0] == -1);
+  BOOST_TEST(tet_center[1] == 3);
+  BOOST_TEST(tet_center[2] == 2);
 }
 
 BOOST_AUTO_TEST_CASE(is_valid)


### PR DESCRIPTION
Missed in #1079.

Tested that constructing a hierarchy on the tets compiles:
```cpp
#include <ArborX.hpp>
#include <ArborX_Tetrahedron.hpp>
#include <Kokkos_Core.hpp>

int main(int argc, char *argv[])
{
  Kokkos::ScopeGuard guard(argc, argv);

  using Tetrahedron = ArborX::ExperimentalHyperGeometry::Tetrahedron<>;
  using Point = ArborX::ExperimentalHyperGeometry::Point<3>;
  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
  using MemorySpace = typename ExecutionSpace::memory_space;

  ExecutionSpace exec;
  Kokkos::View<Tetrahedron *> tets("Example::tets", 5);
  ArborX::BVH<MemorySpace, ArborX::PairValueIndex<Tetrahedron>> bvh(
      exec, ArborX::Experimental::attach_indices(tets));
  Kokkos::View<decltype(ArborX::intersects(Point{})) *, MemorySpace> queries(
      "Example::queries", 3);

  Kokkos::View<int *> indices("Example::indices", 0);
  Kokkos::View<int *> offsets("Example::offsets", 0);
  bvh.query(exec, queries, indices, offsets);

  return 0;
}
```