### PR TITLE
Switch ArborX version to 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ install(EXPORT ArborXTargets
   DESTINATION lib/cmake/ArborX
 )
 
-set(ARBORX_VERSION_STRING "1.8 (dev)")
+set(ARBORX_VERSION_STRING "2.0 (dev)")
 
 # Make sure that the git hash in ArborX_Version.hpp is considered to be always
 # out of date, and thus is updated every recompile.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   cmake_minimum_required(VERSION 3.16)
   project(ArborXExamples CXX)
-  find_package(ArborX 1.8 REQUIRED)
+  find_package(ArborX 2.0 REQUIRED)
   enable_testing()
 endif()
 


### PR DESCRIPTION
Figure it would be safer to allow us to start breaking backwards compatibility.