### PR TITLE
Add convert() for geometries

### DIFF
--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -62,11 +62,11 @@ struct WithinRadiusGetter
   {
     static_assert(GeometryTraits::is_point_v<Point>);
 
-    constexpr int dim = GeometryTraits::dimension_v<Point>;
-    auto const &hyper_point =
-        reinterpret_cast<::ArborX::Point<dim> const &>(pair.value);
+    constexpr int DIM = GeometryTraits::dimension_v<Point>;
+    using Coordinate = GeometryTraits::coordinate_type_t<Point>;
     using ArborX::intersects;
-    return intersects(Sphere{hyper_point, _r});
+    return intersects(
+        Sphere{convert<::ArborX::Point<DIM, Coordinate>>(pair.value), _r});
   }
 };
 

--- a/src/details/ArborX_DetailsDistributedTreeNearestHelpers.hpp
+++ b/src/details/ArborX_DetailsDistributedTreeNearestHelpers.hpp
@@ -90,7 +90,7 @@ struct approx_expand_by_radius<PointTag, Point>
   {
     constexpr int DIM = GeometryTraits::dimension_v<Point>;
     using Coordinate = GeometryTraits::coordinate_type_t<Point>;
-    return Sphere{Kokkos::bit_cast<::ArborX::Point<DIM, Coordinate>>(point), r};
+    return Sphere{Details::convert<::ArborX::Point<DIM, Coordinate>>(point), r};
   }
 };
 

--- a/src/details/ArborX_NeighborList.hpp
+++ b/src/details/ArborX_NeighborList.hpp
@@ -36,10 +36,9 @@ struct NeighborListPredicateGetter
 
     constexpr int dim = GeometryTraits::dimension_v<Point>;
     using Coordinate = typename GeometryTraits::coordinate_type_t<Point>;
-
-    auto const &hyper_point =
-        reinterpret_cast<::ArborX::Point<dim, Coordinate> const &>(pair.value);
-    return intersects(Sphere{hyper_point, _radius});
+    return intersects(
+        Sphere{Details::convert<::ArborX::Point<dim, Coordinate>>(pair.value),
+               _radius});
   }
 };
 

--- a/src/details/ArborX_PredicateHelpers.hpp
+++ b/src/details/ArborX_PredicateHelpers.hpp
@@ -169,11 +169,8 @@ public:
     using Point = std::decay_t<decltype(point)>;
     constexpr int dim = GeometryTraits::dimension_v<Point>;
     using Coordinate = typename GeometryTraits::coordinate_type<Point>::type;
-    // FIXME reinterpret_cast is dangerous here if access traits return user
-    // point structure (e.g., struct MyPoint { float y; float x; })
-    auto const &hyper_point =
-        reinterpret_cast<::ArborX::Point<dim, Coordinate> const &>(point);
-    return intersects(Sphere(hyper_point, x._r));
+    return intersects(Sphere(
+        Details::convert<::ArborX::Point<dim, Coordinate>>(point), x._r));
   }
 };
 

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -162,7 +162,7 @@ public:
 };
 
 template <typename GeometryTo, typename GeometryFrom>
-KOKKOS_INLINE_FUNCTION auto convert(GeometryFrom const &geometry)
+KOKKOS_INLINE_FUNCTION GeometryTo convert(GeometryFrom const &geometry)
 {
   static_assert(GeometryTraits::dimension_v<GeometryFrom> ==
                 GeometryTraits::dimension_v<GeometryTo>);

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -49,6 +49,10 @@ struct expand;
 template <typename Tag1, typename Tag2, typename Geometry1, typename Geometry2>
 struct intersects;
 
+template <typename TagFrom, typename TagTo, typename GeometryFrom,
+          typename GeometryTo>
+struct convert;
+
 template <typename Tag, typename Geometry>
 struct centroid;
 
@@ -156,6 +160,16 @@ public:
   KOKKOS_FUNCTION
   bool references_scalar() const { return _references_scalar; }
 };
+
+template <typename GeometryTo, typename GeometryFrom>
+KOKKOS_INLINE_FUNCTION auto convert(GeometryFrom const &geometry)
+{
+  static_assert(GeometryTraits::dimension_v<GeometryFrom> ==
+                GeometryTraits::dimension_v<GeometryTo>);
+  return Dispatch::convert<typename GeometryTraits::tag_t<GeometryFrom>,
+                           typename GeometryTraits::tag_t<GeometryTo>,
+                           GeometryFrom, GeometryTo>::apply(geometry);
+}
 
 namespace Dispatch
 {
@@ -760,6 +774,30 @@ struct intersects<TriangleTag, BoxTag, Triangle, Box>
                                               Box const &box)
   {
     return intersects<BoxTag, TriangleTag, Box, Triangle>::apply(box, triangle);
+  }
+};
+
+template <typename PointFrom, typename PointTo>
+struct convert<PointTag, PointTag, PointFrom, PointTo>
+{
+  KOKKOS_FUNCTION static constexpr auto apply(PointFrom const &point)
+  {
+    PointTo converted;
+    constexpr int DIM = GeometryTraits::dimension_v<PointFrom>;
+    for (int d = 0; d < DIM; ++d)
+      converted[d] = point[d];
+    return converted;
+  }
+};
+
+template <int DIM, typename Coordinate>
+struct convert<PointTag, PointTag, Point<DIM, Coordinate>,
+               Point<DIM, Coordinate>>
+{
+  KOKKOS_FUNCTION static constexpr auto
+  apply(Point<DIM, Coordinate> const &point)
+  {
+    return point;
   }
 };
 

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -348,6 +348,18 @@ BOOST_AUTO_TEST_CASE(expand)
   BOOST_TEST(equals(box, Box{{-5, -5, -3}, {5, 8, 7}}));
 }
 
+BOOST_AUTO_TEST_CASE(convert)
+{
+  using ArborX::Point;
+  using ArborX::Details::convert;
+  using ArborX::Details::equals;
+  BOOST_TEST(equals(convert<Point<2, double>>(Point{3.f, 2.f}), Point{3., 2.}));
+  BOOST_TEST(
+      equals(convert<Point<2, float>>(Point{3.f, 2.f}), Point{3.f, 2.f}));
+  BOOST_TEST(
+      !equals(convert<Point<2, float>>(Point{3.f, 2.f}), Point{2.f, 2.f}));
+}
+
 BOOST_AUTO_TEST_CASE(centroid)
 {
   using ArborX::Details::returnCentroid;


### PR DESCRIPTION
Spurred by the discussion in #1146.

Add a convert function. Currently only for points.

The interface differs from [Boost's convert](https://live.boost.org/doc/libs/1_86_0/libs/geometry/doc/html/geometry/reference/algorithms/convert.html), as to streamline its usage in our code (right now, we only use its result to immediately construct spheres). May change in the future should we want it.