### PR TITLE
Add GeometryReducer and remove Box::operator+=

### DIFF
--- a/src/details/ArborX_DetailsTreeConstruction.hpp
+++ b/src/details/ArborX_DetailsTreeConstruction.hpp
@@ -22,23 +22,6 @@
 namespace ArborX::Details::TreeConstruction
 {
 
-template <typename Indexables, typename BoundingVolume>
-struct SceneReductionFunctor
-{
-  Indexables _indexables;
-
-  KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
-  {
-    using Details::expand;
-    expand(update, _indexables(i));
-  }
-  KOKKOS_FUNCTION void join(BoundingVolume &result,
-                            BoundingVolume const &update) const
-  {
-    expand(result, update);
-  }
-};
-
 template <typename ExecutionSpace, typename Indexables, typename Box>
 inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
                                            Indexables const &indexables,
@@ -47,7 +30,11 @@ inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
   Kokkos::parallel_reduce(
       "ArborX::TreeConstruction::calculate_bounding_box_of_the_scene",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, indexables.size()),
-      SceneReductionFunctor<Indexables, Box>{indexables}, scene_bounding_box);
+      KOKKOS_LAMBDA(int i, Box &update) {
+        using Details::expand;
+        expand(update, indexables(i));
+      },
+      GeometryReducer<Box>(scene_bounding_box));
 }
 
 template <typename ExecutionSpace, typename Indexables,

--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -58,43 +58,6 @@ struct Box
       {Details::KokkosExt::ArithmeticTraits::finite_min<float>::value,
        Details::KokkosExt::ArithmeticTraits::finite_min<float>::value,
        Details::KokkosExt::ArithmeticTraits::finite_min<float>::value}};
-
-  [[deprecated("Use expand(Box, Box) instead.")]] KOKKOS_FUNCTION Box &
-  operator+=(Box const &other)
-  {
-    using Kokkos::max;
-    using Kokkos::min;
-
-    for (int d = 0; d < 3; ++d)
-    {
-      minCorner()[d] = min(minCorner()[d], other.minCorner()[d]);
-      maxCorner()[d] = max(maxCorner()[d], other.maxCorner()[d]);
-    }
-    return *this;
-  }
-
-  [[deprecated("Use expand(Box, Point) instead.")]] KOKKOS_FUNCTION Box &
-  operator+=(Point<3> const &point)
-  {
-    using Kokkos::max;
-    using Kokkos::min;
-
-    for (int d = 0; d < 3; ++d)
-    {
-      minCorner()[d] = min(minCorner()[d], point[d]);
-      maxCorner()[d] = max(maxCorner()[d], point[d]);
-    }
-    return *this;
-  }
-
-// FIXME Temporary workaround until we clarify requirements on the Kokkos side.
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_SYCL)
-private:
-  [[deprecated]] friend KOKKOS_FUNCTION Box operator+(Box box, Box const &other)
-  {
-    return box += other;
-  }
-#endif
 };
 
 template <>

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -16,10 +16,8 @@
 #include <ArborX_DetailsVector.hpp>
 #include <ArborX_GeometryTraits.hpp>
 
-#include <Kokkos_Assert.hpp> // KOKKOS_ASSERT
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Core.hpp>
 #include <Kokkos_MathematicalFunctions.hpp> // isfinite
-#include <Kokkos_MinMax.hpp>
 
 namespace ArborX
 {
@@ -111,6 +109,53 @@ KOKKOS_INLINE_FUNCTION decltype(auto) returnCentroid(Geometry const &geometry)
   return Dispatch::centroid<typename GeometryTraits::tag_t<Geometry>,
                             Geometry>::apply(geometry);
 }
+
+template <class Geometry, class Space = Kokkos::HostSpace>
+struct GeometryReducer
+{
+  static_assert(GeometryTraits::is_valid_geometry<Geometry>);
+
+  using reducer = GeometryReducer<Geometry, Space>;
+  using value_type = std::remove_cv_t<Geometry>;
+  static_assert(!std::is_pointer_v<value_type> && !std::is_array_v<value_type>);
+
+  using result_view_type = Kokkos::View<value_type, Space>;
+
+private:
+  result_view_type _value;
+  bool _references_scalar;
+
+public:
+  KOKKOS_FUNCTION
+  GeometryReducer(value_type &value)
+      : _value(&value)
+      , _references_scalar(true)
+  {}
+
+  KOKKOS_FUNCTION
+  GeometryReducer(result_view_type const &value)
+      : _value(value)
+      , _references_scalar(false)
+  {}
+
+  KOKKOS_FUNCTION
+  void join(value_type &dest, value_type const &src) const
+  {
+    expand(dest, src);
+  }
+
+  KOKKOS_FUNCTION
+  void init(value_type &value) const { value = {}; }
+
+  KOKKOS_FUNCTION
+  value_type &reference() const { return *_value.data(); }
+
+  KOKKOS_FUNCTION
+  result_view_type view() const { return _value; }
+
+  KOKKOS_FUNCTION
+  bool references_scalar() const { return _references_scalar; }
+};
 
 namespace Dispatch
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(ArborX_Test_DetailsUtils.exe
   tstAttachIndices.cpp
   tstDetailsVector.cpp
   tstDetailsUtils.cpp
+  tstDetailsGeometryReducer.cpp
   tstDetailsKokkosExtStdAlgorithms.cpp
   tstDetailsKokkosExtKernelStdAlgorithms.cpp
   tstDetailsKokkosExtUninitializedMemoryAlgorithms.cpp

--- a/test/tstDetailsGeometryReducer.cpp
+++ b/test/tstDetailsGeometryReducer.cpp
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * Copyright (c) 2024 by the ArborX authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include <ArborX_Box.hpp>
+#include <ArborX_DetailsAlgorithms.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+template <typename DeviceType, typename Geometry>
+Geometry reduce(std::vector<Geometry> const &g)
+{
+  using MemorySpace = typename DeviceType::memory_space;
+  using ExecutionSpace = typename DeviceType::execution_space;
+
+  auto const n = g.size();
+  Kokkos::View<Geometry *, MemorySpace> geometries("Testing::geometries", n);
+  Kokkos::deep_copy(geometries,
+                    Kokkos::View<Geometry const *, Kokkos::HostSpace,
+                                 Kokkos::MemoryUnmanaged>(g.data(), n));
+
+  Geometry result;
+  Kokkos::parallel_reduce(
+      "Testing::reduce_geometries",
+      Kokkos::RangePolicy<ExecutionSpace>(ExecutionSpace{}, 0, n),
+      KOKKOS_LAMBDA(int i, Geometry &update) {
+        using ArborX::Details::expand;
+        expand(update, geometries(i));
+      },
+      ArborX::Details::GeometryReducer<Geometry>(result));
+  return result;
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(reducer, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using ArborX::Details::equals;
+
+  using Box = ArborX::Box;
+  BOOST_TEST(equals(reduce<DeviceType, Box>({{{{0.f, 0.f}}, {{1.f, 1.f}}},
+                                             {{{2.f, 2.f}}, {{3.f, 3.f}}}}),
+                    Box{{{0.f, 0.f}}, {{3.f, 3.f}}}));
+}

--- a/test/tstIndexableGetter.cpp
+++ b/test/tstIndexableGetter.cpp
@@ -67,22 +67,6 @@ struct ArborX::AccessTraits<PairPointIndexCloud<MemorySpace>,
   using memory_space = MemorySpace;
 };
 
-template <typename Indexables, typename BoundingVolume>
-struct SceneReductionFunctor
-{
-  Indexables _indexables;
-
-  KOKKOS_FUNCTION void operator()(int i, BoundingVolume &update) const
-  {
-    ArborX::Details::expand(update, _indexables(i));
-  }
-  KOKKOS_FUNCTION void join(BoundingVolume &result,
-                            BoundingVolume const &update)
-  {
-    expand(result, update);
-  }
-};
-
 template <typename ExecutionSpace, typename Indexables, typename Box>
 inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
                                            Indexables const &indexables,
@@ -91,7 +75,8 @@ inline void calculateBoundingBoxOfTheScene(ExecutionSpace const &space,
   Kokkos::parallel_reduce(
       "ArborX::TreeConstruction::calculate_bounding_box_of_the_scene",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, indexables.size()),
-      SceneReductionFunctor<Indexables, Box>{indexables}, scene_bounding_box);
+      KOKKOS_LAMBDA(int i, Box &update) { expand(update, indexables(i)); },
+      ArborX::Details::GeometryReducer<Box>{scene_bounding_box});
 }
 
 BOOST_AUTO_TEST_SUITE(IndexableGetterAccess)


### PR DESCRIPTION
Redoing #1082. Removing Box's `+=` operator exposed that it did not work. 

It should not be possible to reduce all geometries, not just `Box`.