### PR TITLE
Switch examples and most benchmarks to APIv2

### DIFF
--- a/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
+++ b/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
   std::cout << "#triangles        : " << triangles.size() << '\n';
   std::cout << "#queries          : " << random_points.size() << '\n';
 
-  ArborX::BVH<MemorySpace, Triangle> index(
+  ArborX::BoundingVolumeHierarchy<MemorySpace, Triangle> index(
       space, Triangles<MemorySpace>{vertices, triangles});
 
   Kokkos::View<int *, MemorySpace> offset("Benchmark::offsets", 0);

--- a/examples/access_traits/example_cuda_access_traits.cpp
+++ b/examples/access_traits/example_cuda_access_traits.cpp
@@ -79,7 +79,10 @@ int main(int argc, char *argv[])
   cudaMemcpyAsync(d_a, a.data(), sizeof(a), cudaMemcpyHostToDevice, stream);
 
   Kokkos::Cuda cuda{stream};
-  ArborX::BVH<Kokkos::CudaSpace> bvh{cuda, PointCloud{d_a, d_a, d_a, N}};
+  ArborX::BoundingVolumeHierarchy<Kokkos::CudaSpace,
+                                  ArborX::PairValueIndex<ArborX::Point<3>>>
+      bvh{cuda,
+          ArborX::Experimental::attach_indices(PointCloud{d_a, d_a, d_a, N})};
 
   Kokkos::View<int *, Kokkos::CudaSpace> indices("Example::indices", 0);
   Kokkos::View<int *, Kokkos::CudaSpace> offset("Example::offset", 0);

--- a/examples/access_traits/example_host_access_traits.cpp
+++ b/examples/access_traits/example_host_access_traits.cpp
@@ -41,14 +41,18 @@ int main(int argc, char *argv[])
   });
 
   // Pass directly the vector of points to use the access traits defined above
-  ArborX::BVH<Kokkos::HostSpace> bvh{Kokkos::DefaultHostExecutionSpace{},
-                                     points};
+  ArborX::BoundingVolumeHierarchy<Kokkos::HostSpace,
+                                  ArborX::PairValueIndex<Point>>
+      bvh{Kokkos::DefaultHostExecutionSpace{},
+          ArborX::Experimental::attach_indices(points)};
 
   // As a supported alternative, wrap the vector in an unmanaged View
-  bvh = ArborX::BVH<Kokkos::HostSpace>{
+  bvh = ArborX::BoundingVolumeHierarchy<Kokkos::HostSpace,
+                                        ArborX::PairValueIndex<Point>>{
       Kokkos::DefaultHostExecutionSpace{},
-      Kokkos::View<Point *, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>{
-          points.data(), points.size()}};
+      ArborX::Experimental::attach_indices(
+          Kokkos::View<Point *, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>{
+              points.data(), points.size()})};
 
   return 0;
 }

--- a/examples/brute_force/example_brute_force.cpp
+++ b/examples/brute_force/example_brute_force.cpp
@@ -74,7 +74,9 @@ int main(int argc, char *argv[])
 
   unsigned int out_count;
   {
-    ArborX::BoundingVolumeHierarchy<MemorySpace> bvh{space, primitives};
+    ArborX::BoundingVolumeHierarchy<MemorySpace,
+                                    ArborX::PairValueIndex<ArborX::Point<3>>>
+        bvh{space, ArborX::Experimental::attach_indices(primitives)};
 
     Kokkos::View<int *, ExecutionSpace> indices("Example::indices_ref", 0);
     Kokkos::View<int *, ExecutionSpace> offset("Example::offset_ref", 0);

--- a/examples/molecular_dynamics/example_molecular_dynamics.cpp
+++ b/examples/molecular_dynamics/example_molecular_dynamics.cpp
@@ -40,10 +40,12 @@ struct ArborX::AccessTraits<Neighbors<MemorySpace>, ArborX::PredicatesTag>
 
 struct ExcludeSelfCollision
 {
-  template <class Predicate, class OutputFunctor>
-  KOKKOS_FUNCTION void operator()(Predicate const &predicate, int i,
+  template <class Predicate, typename Value, class OutputFunctor>
+  KOKKOS_FUNCTION void operator()(Predicate const &predicate,
+                                  Value const &value,
                                   OutputFunctor const &out) const
   {
+    int const i = value.index;
     int const j = getData(predicate);
     if (i != j)
     {
@@ -115,7 +117,9 @@ int main(int argc, char *argv[])
   // TODO scale velocities
   Kokkos::Profiling::popRegion();
 
-  ArborX::BVH<MemorySpace> index(execution_space, particles);
+  ArborX::BoundingVolumeHierarchy<MemorySpace,
+                                  ArborX::PairValueIndex<ArborX::Point<3>>>
+      index(execution_space, ArborX::Experimental::attach_indices(particles));
 
   Kokkos::View<int *, MemorySpace> indices("Example::indices", 0);
   Kokkos::View<int *, MemorySpace> offsets("Example::offsets", 0);

--- a/examples/simple_intersection/example_intersection.cpp
+++ b/examples/simple_intersection/example_intersection.cpp
@@ -50,8 +50,9 @@ int main(int argc, char *argv[])
 
   ExecutionSpace space;
 
-  ArborX::BVH<MemorySpace, ArborX::PairValueIndex<Box>> const tree(
-      space, ArborX::Experimental::attach_indices(boxes));
+  ArborX::BoundingVolumeHierarchy<MemorySpace,
+                                  ArborX::PairValueIndex<Box>> const
+      tree(space, ArborX::Experimental::attach_indices(boxes));
 
   // The query will resize indices and offsets accordingly
   Kokkos::View<int *, MemorySpace> indices("Example::indices", 0);

--- a/examples/triangle_intersection/triangle_intersection.cpp
+++ b/examples/triangle_intersection/triangle_intersection.cpp
@@ -84,8 +84,9 @@ int main(int argc, char *argv[])
 
   ExecutionSpace space;
 
-  ArborX::BVH<MemorySpace, ArborX::PairValueIndex<Triangle>> const tree(
-      space, ArborX::Experimental::attach_indices(triangles));
+  ArborX::BoundingVolumeHierarchy<MemorySpace,
+                                  ArborX::PairValueIndex<Triangle>> const
+      tree(space, ArborX::Experimental::attach_indices(triangles));
 
   // The query will resize indices and offsets accordingly
   Kokkos::View<unsigned *, MemorySpace> indices("Example::indices", 0);

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -521,13 +521,22 @@ template <typename Point, typename Box>
 struct intersects<PointTag, BoxTag, Point, Box>
 {
   KOKKOS_FUNCTION static constexpr bool apply(Point const &point,
-                                              Box const &other)
+                                              Box const &box)
   {
     constexpr int DIM = GeometryTraits::dimension_v<Point>;
     for (int d = 0; d < DIM; ++d)
-      if (point[d] > other.maxCorner()[d] || point[d] < other.minCorner()[d])
+      if (point[d] > box.maxCorner()[d] || point[d] < box.minCorner()[d])
         return false;
     return true;
+  }
+};
+template <typename Box, typename Point>
+struct intersects<BoxTag, PointTag, Box, Point>
+{
+  KOKKOS_FUNCTION static constexpr bool apply(Box const &box,
+                                              Point const &point)
+  {
+    return Details::intersects(point, box);
   }
 };
 


### PR DESCRIPTION
This converts examples and all but one benchmarks to use APIv2. Without CTAD for now.
I also replaced `BVH` with `BoundingVolumeHierarchy` in preparation for later CTAD introduction.

Skipped `benchmarks/bvh_driver` because it's more involved. Will do in a separate PR.

Right now, it looks a bit ugly. I'm ignoring that, as the primary goal right now is to get rid of APIv1. Everything would require cleaning afterwards.