### PR TITLE
Increase minimum NVCC version requirement

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -97,12 +97,12 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-11.1.1-NVCC') {
+                stage('CUDA-11.7.1-NVCC') {
                     agent {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.1.1-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.4.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.7.1-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.4.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ find_package(Kokkos 4.3 REQUIRED CONFIG)
 message(STATUS "Found Kokkos: ${Kokkos_DIR} (version \"${Kokkos_VERSION}\")")
 
 # We use minimum compiler versions from Kokkos, with the exception for NVCC (>= 11.5)
-SET(ARBORX_NVCC_MINIMUM 11.5.0)
-if(Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS ${ARBORX_NVCC_MINIMUM})
+if(Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS 11.5.0)
   message(FATAL_ERROR "NVCC versions prior to 11.5 are not supported by ArborX")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ endif()
 find_package(Kokkos 4.3 REQUIRED CONFIG)
 message(STATUS "Found Kokkos: ${Kokkos_DIR} (version \"${Kokkos_VERSION}\")")
 
+# We use minimum compiler versions from Kokkos, with the exception for NVCC (>= 11.5)
+SET(ARBORX_NVCC_MINIMUM 11.5.0)
+if(Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS ${ARBORX_NVCC_MINIMUM})
+  message(FATAL_ERROR "NVCC versions prior to 11.5 are not supported by ArborX")
+endif()
+
 add_library(ArborX INTERFACE)
 target_link_libraries(ArborX INTERFACE Kokkos::kokkos)
 set_target_properties(ArborX PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)

--- a/src/ArborX_DBSCAN.hpp
+++ b/src/ArborX_DBSCAN.hpp
@@ -264,16 +264,8 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
     {
       // Perform the queries and build clusters through callback
       using CorePoints = Details::CCSCorePoints;
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1140)
-      // Workaround a compiler bug
-      using HalfTraversal = Details::HalfTraversal<
-          decltype(bvh), Details::FDBSCANCallback<UnionFind, CorePoints>,
-          Details::WithinRadiusGetter>;
-#else
-      using Details::HalfTraversal;
-#endif
       Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters::query");
-      HalfTraversal(
+      Details::HalfTraversal(
           exec_space, bvh,
           Details::FDBSCANCallback<UnionFind, CorePoints>{labels, CorePoints{}},
           Details::WithinRadiusGetter{eps});
@@ -292,21 +284,13 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
       Kokkos::Profiling::popRegion();
 
       using CorePoints = Details::DBSCANCorePoints<MemorySpace>;
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1140)
-      // Workaround a compiler bug
-      using HalfTraversal = Details::HalfTraversal<
-          decltype(bvh), Details::FDBSCANCallback<UnionFind, CorePoints>,
-          Details::WithinRadiusGetter>;
-#else
-      using Details::HalfTraversal;
-#endif
 
       // Perform the queries and build clusters through callback
       Kokkos::Profiling::pushRegion("ArborX::DBSCAN::clusters::query");
-      HalfTraversal(exec_space, bvh,
-                    Details::FDBSCANCallback<UnionFind, CorePoints>{
-                        labels, CorePoints{num_neigh, core_min_size}},
-                    Details::WithinRadiusGetter{eps});
+      Details::HalfTraversal(exec_space, bvh,
+                             Details::FDBSCANCallback<UnionFind, CorePoints>{
+                                 labels, CorePoints{num_neigh, core_min_size}},
+                             Details::WithinRadiusGetter{eps});
       Kokkos::Profiling::popRegion();
     }
   }

--- a/test/ArborXTest_LegacyTree.hpp
+++ b/test/ArborXTest_LegacyTree.hpp
@@ -56,7 +56,7 @@ public:
       return value_type{bounding_volume, (index_type)i};
     }
 #if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2021)
-    // FIXME_INTEL: workaround for spurios "missing return
+    // FIXME_INTEL: workaround for spurious "missing return
     // statement at end of non-void function" warning
     return value_type{};
 #endif

--- a/test/ArborXTest_LegacyTree.hpp
+++ b/test/ArborXTest_LegacyTree.hpp
@@ -55,9 +55,8 @@ public:
       expand(bounding_volume, Access::get(_primitives, i));
       return value_type{bounding_volume, (index_type)i};
     }
-#if (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)) ||        \
-    (defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2021))
-    // FIXME_NVCC, FIXME_INTEL: workaround for spurios "missing return
+#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2021)
+    // FIXME_INTEL: workaround for spurios "missing return
     // statement at end of non-void function" warning
     return value_type{};
 #endif


### PR DESCRIPTION
I propose we increase our requirement to 11.5 (released Oct 2021) right now. It is the minimum available version available on the platforms we care about (see [comment](https://github.com/arborx/ArborX/issues/974#issuecomment-2377210975)).

While I understand @dalg24 wants to go all the way to C++20 requirements (which would mean NVCC 12.0, released Dec 2022), I'm hesitant to do this right now. If we do decide to require C++20 for the release, we would do it then. Right now, this is blocking some of the work. 

I'm not saying that this is the minimum requirement we will do for ArborX 2.0 release. This is just an incremental update within the release cycle.

This PR:
- Switches CUDA-11.1.1 build to 11.7.1
- Removes pre 11.5 workarounds

This would unlock more code cleanup in #1141  and #1158, while still being conservative.

Fix #974.