### PR TITLE
Fix return type of getIndexable in HappyTreeFriends

### DIFF
--- a/src/details/ArborX_DetailsHappyTreeFriends.hpp
+++ b/src/details/ArborX_DetailsHappyTreeFriends.hpp
@@ -51,7 +51,7 @@ struct HappyTreeFriends
   }
 
   template <class BVH>
-  static KOKKOS_FUNCTION auto const &getIndexable(BVH const &bvh, int i)
+  static KOKKOS_FUNCTION decltype(auto) getIndexable(BVH const &bvh, int i)
   {
     return bvh._indexable_getter(getValue(bvh, i));
   }


### PR DESCRIPTION
First push is the test to make sure CI gets the warning.
Second push is the fix.