### PR TITLE
Add upper_bound kernel

### DIFF
--- a/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
@@ -63,7 +63,8 @@ KOKKOS_FUNCTION void nth_element(Iterator first, Iterator nth, Iterator last)
 }
 
 template <typename Iterator, typename T>
-KOKKOS_FUNCTION auto upper_bound(Iterator first, Iterator last, T const &value)
+KOKKOS_FUNCTION Iterator upper_bound(Iterator first, Iterator last,
+                                     T const &value)
 {
   int count = last - first;
   while (count > 0)

--- a/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
@@ -62,6 +62,26 @@ KOKKOS_FUNCTION void nth_element(Iterator first, Iterator nth, Iterator last)
   }
 }
 
+template <typename Iterator, typename T>
+KOKKOS_FUNCTION auto upper_bound(Iterator first, Iterator last, T const &value)
+{
+  int count = last - first;
+  while (count > 0)
+  {
+    int step = count / 2;
+    if (!(value < *(first + step)))
+    {
+      first += step + 1;
+      count -= step + 1;
+    }
+    else
+    {
+      count = step;
+    }
+  }
+  return first;
+}
+
 } // namespace ArborX::Details::KokkosExt
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,13 @@ add_executable(ArborX_Test_DetailsUtils.exe
   tstDetailsVector.cpp
   tstDetailsUtils.cpp
   tstDetailsGeometryReducer.cpp
+  utf_main.cpp
+)
+target_link_libraries(ArborX_Test_DetailsUtils.exe PRIVATE ArborX Boost::unit_test_framework Boost::dynamic_linking)
+target_include_directories(ArborX_Test_DetailsUtils.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME ArborX_Test_DetailsUtils COMMAND ArborX_Test_DetailsUtils.exe)
+
+add_executable(ArborX_Test_KokkosExt.exe
   tstDetailsKokkosExtStdAlgorithms.cpp
   tstDetailsKokkosExtKernelStdAlgorithms.cpp
   tstDetailsKokkosExtUninitializedMemoryAlgorithms.cpp
@@ -57,9 +64,9 @@ add_executable(ArborX_Test_DetailsUtils.exe
   tstDetailsKokkosExtViewHelpers.cpp
   utf_main.cpp
 )
-target_link_libraries(ArborX_Test_DetailsUtils.exe PRIVATE ArborX Boost::unit_test_framework Boost::dynamic_linking)
-target_include_directories(ArborX_Test_DetailsUtils.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME ArborX_Test_DetailsUtils COMMAND ArborX_Test_DetailsUtils.exe)
+target_link_libraries(ArborX_Test_KokkosExt.exe PRIVATE ArborX Boost::unit_test_framework Boost::dynamic_linking)
+target_include_directories(ArborX_Test_KokkosExt.exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME ArborX_Test_KokkosExt COMMAND ArborX_Test_KokkosExt.exe)
 
 add_executable(ArborX_Test_Geometry.exe
   tstDetailsAlgorithms.cpp

--- a/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
+++ b/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
@@ -27,6 +27,10 @@
 
 namespace tt = boost::test_tools;
 
+template <typename T>
+using UnmanagedView = Kokkos::View<T *, Kokkos::HostSpace,
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(nth_element, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
@@ -41,13 +45,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(nth_element, DeviceType, ARBORX_DEVICE_TYPES)
   {
     int const n = v_ref.size();
 
-    Kokkos::View<float *, DeviceType> v("v", n);
-    Kokkos::deep_copy(
-        space, v,
-        Kokkos::View<float *, Kokkos::HostSpace,
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>(v_ref.data(), n));
+    Kokkos::View<float *, DeviceType> v("Testing::v", n);
+    Kokkos::deep_copy(space, v, UnmanagedView<float>(v_ref.data(), n));
 
-    Kokkos::View<float *, DeviceType> nth("nth", n);
+    Kokkos::View<float *, DeviceType> nth("Testing::nth", n);
     for (int i = 0; i < n; ++i)
     {
       auto v_copy = ArborX::Details::KokkosExt::clone(space, v);
@@ -64,4 +65,43 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(nth_element, DeviceType, ARBORX_DEVICE_TYPES)
     std::sort(v_ref.begin(), v_ref.end());
     BOOST_TEST(nth_host == v_ref, tt::per_element());
   }
+}
+
+template <typename DeviceType>
+int upperBound(std::vector<float> const &v_host, float x)
+{
+  typename DeviceType::execution_space space;
+
+  auto const n = v_host.size();
+  Kokkos::View<float *, DeviceType> v("Testing::v", n);
+
+  Kokkos::deep_copy(space, v, UnmanagedView<float const>(v_host.data(), n));
+
+  int result;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy(space, 0, 1),
+      KOKKOS_LAMBDA(int, int &update) {
+        update =
+            ArborX::Details::KokkosExt::upper_bound(v.data(), v.data() + n, x) -
+            v.data();
+      },
+      result);
+
+  return result;
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(upper_bound, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  BOOST_TEST(upperBound<DeviceType>({}, 0) == 0);
+  BOOST_TEST(upperBound<DeviceType>({0}, -1) == 0);
+  BOOST_TEST(upperBound<DeviceType>({0}, 0) == 1);
+  BOOST_TEST(upperBound<DeviceType>({0}, 1) == 1);
+  BOOST_TEST(upperBound<DeviceType>({1, 1}, 0) == 0);
+  BOOST_TEST(upperBound<DeviceType>({1, 1}, 1) == 2);
+  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 1) == 1);
+  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 2) == 1);
+  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 3) == 2);
+  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 4) == 2);
+  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 5) == 3);
+  BOOST_TEST(upperBound<DeviceType>({1, 3, 5, 7, 9, 11, 13}, 8) == 4);
 }

--- a/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
+++ b/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
@@ -28,8 +28,8 @@
 namespace tt = boost::test_tools;
 
 template <typename T>
-using UnmanagedView = Kokkos::View<T *, Kokkos::HostSpace,
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+using UnmanagedHostView = Kokkos::View<T *, Kokkos::HostSpace,
+                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(nth_element, DeviceType, ARBORX_DEVICE_TYPES)
 {
@@ -45,8 +45,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(nth_element, DeviceType, ARBORX_DEVICE_TYPES)
   {
     int const n = v_ref.size();
 
-    Kokkos::View<float *, DeviceType> v("Testing::v", n);
-    Kokkos::deep_copy(space, v, UnmanagedView<float>(v_ref.data(), n));
+    Kokkos::View<float *, DeviceType> v("Testing::v", 0);
+    v = Kokkos::create_mirror_view_and_copy(
+        space, UnmanagedHostView<float>(v_ref.data(), n));
 
     Kokkos::View<float *, DeviceType> nth("Testing::nth", n);
     for (int i = 0; i < n; ++i)
@@ -68,40 +69,37 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(nth_element, DeviceType, ARBORX_DEVICE_TYPES)
 }
 
 template <typename DeviceType>
-int upperBound(std::vector<float> const &v_host, float x)
+int findUpperBound(std::vector<float> const &v_host, float x)
 {
-  typename DeviceType::execution_space space;
-
   auto const n = v_host.size();
   Kokkos::View<float *, DeviceType> v("Testing::v", n);
+  Kokkos::deep_copy(v, UnmanagedHostView<float const>(v_host.data(), n));
 
-  Kokkos::deep_copy(space, v, UnmanagedView<float const>(v_host.data(), n));
-
-  int result;
+  int pos;
   Kokkos::parallel_reduce(
-      Kokkos::RangePolicy(space, 0, 1),
+      Kokkos::RangePolicy<typename DeviceType::execution_space>(0, 1),
       KOKKOS_LAMBDA(int, int &update) {
         update =
             ArborX::Details::KokkosExt::upper_bound(v.data(), v.data() + n, x) -
             v.data();
       },
-      result);
+      pos);
 
-  return result;
+  return pos;
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(upper_bound, DeviceType, ARBORX_DEVICE_TYPES)
 {
-  BOOST_TEST(upperBound<DeviceType>({}, 0) == 0);
-  BOOST_TEST(upperBound<DeviceType>({0}, -1) == 0);
-  BOOST_TEST(upperBound<DeviceType>({0}, 0) == 1);
-  BOOST_TEST(upperBound<DeviceType>({0}, 1) == 1);
-  BOOST_TEST(upperBound<DeviceType>({1, 1}, 0) == 0);
-  BOOST_TEST(upperBound<DeviceType>({1, 1}, 1) == 2);
-  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 1) == 1);
-  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 2) == 1);
-  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 3) == 2);
-  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 4) == 2);
-  BOOST_TEST(upperBound<DeviceType>({1, 3, 5}, 5) == 3);
-  BOOST_TEST(upperBound<DeviceType>({1, 3, 5, 7, 9, 11, 13}, 8) == 4);
+  BOOST_TEST(findUpperBound<DeviceType>({}, 0) == 0);
+  BOOST_TEST(findUpperBound<DeviceType>({0}, -1) == 0);
+  BOOST_TEST(findUpperBound<DeviceType>({0}, 0) == 1);
+  BOOST_TEST(findUpperBound<DeviceType>({0}, 1) == 1);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 1}, 0) == 0);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 1}, 1) == 2);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 3, 5}, 1) == 1);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 3, 5}, 2) == 1);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 3, 5}, 3) == 2);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 3, 5}, 4) == 2);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 3, 5}, 5) == 3);
+  BOOST_TEST(findUpperBound<DeviceType>({1, 3, 5, 7, 9, 11, 13}, 8) == 4);
 }

--- a/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
+++ b/test/tstDetailsKokkosExtKernelStdAlgorithms.cpp
@@ -54,7 +54,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(nth_element, DeviceType, ARBORX_DEVICE_TYPES)
     {
       auto v_copy = ArborX::Details::KokkosExt::clone(space, v);
       Kokkos::parallel_for(
-          Kokkos::RangePolicy(space, 0, 1), KOKKOS_LAMBDA(int) {
+          "Testing::run_nth_element", Kokkos::RangePolicy(space, 0, 1),
+          KOKKOS_LAMBDA(int) {
             nth_element(v_copy.data(), v_copy.data() + i, v_copy.data() + n);
             nth(i) = v_copy(i);
           });
@@ -77,6 +78,7 @@ int findUpperBound(std::vector<float> const &v_host, float x)
 
   int pos;
   Kokkos::parallel_reduce(
+      "Testing::run_upper_bound",
       Kokkos::RangePolicy<typename DeviceType::execution_space>(0, 1),
       KOKKOS_LAMBDA(int, int &update) {
         update =


### PR DESCRIPTION
- Add `KokkosExt::upper_bound` kernel and tests
- Move KokkosExt tests out of `ArborX_Test_DetailsUtils`