### PR TITLE
Remove PrimitivesTag and PredicatesTag

### DIFF
--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -41,7 +41,7 @@ struct Iota
 };
 
 template <typename MemorySpace>
-struct ArborX::AccessTraits<Iota<MemorySpace>, ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<Iota<MemorySpace>>
 {
   using Self = Iota<MemorySpace>;
 

--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -294,7 +294,7 @@ bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
 
   static_assert(Kokkos::is_view<LabelsView>{});
 
-  using Points = Details::AccessValues<Primitives, PrimitivesTag>;
+  using Points = Details::AccessValues<Primitives>;
   using MemorySpace = typename Points::memory_space;
 
   static_assert(std::is_same<typename LabelsView::value_type, int>{});

--- a/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
+++ b/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
@@ -35,7 +35,7 @@ struct Triangles
 };
 
 template <typename MemorySpace>
-class ArborX::AccessTraits<Triangles<MemorySpace>, ArborX::PrimitivesTag>
+class ArborX::AccessTraits<Triangles<MemorySpace>>
 {
   using Self = Triangles<MemorySpace>;
 

--- a/examples/access_traits/example_cuda_access_traits.cpp
+++ b/examples/access_traits/example_cuda_access_traits.cpp
@@ -35,7 +35,7 @@ struct Spheres
 };
 
 template <>
-struct ArborX::AccessTraits<PointCloud, ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<PointCloud>
 {
   static KOKKOS_FUNCTION std::size_t size(PointCloud const &cloud)
   {
@@ -49,7 +49,7 @@ struct ArborX::AccessTraits<PointCloud, ArborX::PrimitivesTag>
 };
 
 template <>
-struct ArborX::AccessTraits<Spheres, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<Spheres>
 {
   static KOKKOS_FUNCTION std::size_t size(Spheres const &d) { return d.N; }
   static KOKKOS_FUNCTION auto get(Spheres const &d, std::size_t i)

--- a/examples/access_traits/example_host_access_traits.cpp
+++ b/examples/access_traits/example_host_access_traits.cpp
@@ -17,8 +17,8 @@
 #include <random>
 #include <vector>
 
-template <typename T, typename Tag>
-struct ArborX::AccessTraits<std::vector<T>, Tag>
+template <typename T>
+struct ArborX::AccessTraits<std::vector<T>>
 {
   static std::size_t size(std::vector<T> const &v) { return v.size(); }
   static T const &get(std::vector<T> const &v, std::size_t i) { return v[i]; }

--- a/examples/brute_force/example_brute_force.cpp
+++ b/examples/brute_force/example_brute_force.cpp
@@ -32,7 +32,7 @@ struct Iota
 };
 
 template <typename MemorySpace>
-struct ArborX::AccessTraits<Iota<MemorySpace>, ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<Iota<MemorySpace>>
 {
   using Self = Iota<MemorySpace>;
 
@@ -54,7 +54,7 @@ struct DummyIndexableGetter
 };
 
 template <>
-struct ArborX::AccessTraits<Dummy, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<Dummy>
 {
   using memory_space = MemorySpace;
   using size_type = typename MemorySpace::size_type;

--- a/examples/callback/example_callback.cpp
+++ b/examples/callback/example_callback.cpp
@@ -29,7 +29,7 @@ struct NearestToOrigin
 };
 
 template <>
-struct ArborX::AccessTraits<FirstOctant, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<FirstOctant>
 {
   static KOKKOS_FUNCTION std::size_t size(FirstOctant) { return 1; }
   static KOKKOS_FUNCTION auto get(FirstOctant, std::size_t)
@@ -40,7 +40,7 @@ struct ArborX::AccessTraits<FirstOctant, ArborX::PredicatesTag>
 };
 
 template <>
-struct ArborX::AccessTraits<NearestToOrigin, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<NearestToOrigin>
 {
   static KOKKOS_FUNCTION std::size_t size(NearestToOrigin) { return 1; }
   static KOKKOS_FUNCTION auto get(NearestToOrigin d, std::size_t)

--- a/examples/molecular_dynamics/example_molecular_dynamics.cpp
+++ b/examples/molecular_dynamics/example_molecular_dynamics.cpp
@@ -24,7 +24,7 @@ struct Neighbors
 };
 
 template <class MemorySpace>
-struct ArborX::AccessTraits<Neighbors<MemorySpace>, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<Neighbors<MemorySpace>>
 {
   using memory_space = MemorySpace;
   using size_type = std::size_t;

--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -87,8 +87,7 @@ struct DepositEnergy
 } // namespace OrderedIntersectsBased
 
 template <typename MemorySpace>
-struct ArborX::AccessTraits<OrderedIntersectsBased::Rays<MemorySpace>,
-                            ArborX::PredicatesTag>
+struct ArborX::AccessTraits<OrderedIntersectsBased::Rays<MemorySpace>>
 {
   using memory_space = MemorySpace;
   using size_type = std::size_t;

--- a/src/cluster/ArborX_DBSCAN.hpp
+++ b/src/cluster/ArborX_DBSCAN.hpp
@@ -96,8 +96,7 @@ struct MixedBoxPrimitives
 
 template <typename Primitives, typename PermuteFilter>
 struct AccessTraits<Details::PrimitivesWithRadiusReorderedAndFiltered<
-                        Primitives, PermuteFilter>,
-                    PredicatesTag>
+    Primitives, PermuteFilter>>
 {
   using memory_space = typename Primitives::memory_space;
   using Predicates =
@@ -125,8 +124,7 @@ struct AccessTraits<Details::PrimitivesWithRadiusReorderedAndFiltered<
 template <typename Points, typename MixedOffsets, typename CellIndices,
           typename Permutation>
 struct AccessTraits<
-    Details::MixedBoxPrimitives<Points, MixedOffsets, CellIndices, Permutation>,
-    ArborX::PrimitivesTag>
+    Details::MixedBoxPrimitives<Points, MixedOffsets, CellIndices, Permutation>>
 {
   using Primitives = Details::MixedBoxPrimitives<Points, MixedOffsets,
                                                  CellIndices, Permutation>;
@@ -200,8 +198,7 @@ struct Parameters
 } // namespace DBSCAN
 
 template <typename ExecutionSpace, typename Primitives>
-Kokkos::View<int *,
-             typename AccessTraits<Primitives, PrimitivesTag>::memory_space>
+Kokkos::View<int *, typename AccessTraits<Primitives>::memory_space>
 dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
        float eps, int core_min_size,
        DBSCAN::Parameters const &parameters = DBSCAN::Parameters())
@@ -210,7 +207,7 @@ dbscan(ExecutionSpace const &exec_space, Primitives const &primitives,
 
   namespace KokkosExt = ArborX::Details::KokkosExt;
 
-  using Points = Details::AccessValues<Primitives, PrimitivesTag>;
+  using Points = Details::AccessValues<Primitives>;
   using MemorySpace = typename Points::memory_space;
 
   static_assert(

--- a/src/cluster/ArborX_MinimumSpanningTree.hpp
+++ b/src/cluster/ArborX_MinimumSpanningTree.hpp
@@ -43,13 +43,13 @@ struct MinimumSpanningTree
                       int k = 1)
       : edges(Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                                  "ArborX::MST::edges"),
-              AccessTraits<Primitives, PrimitivesTag>::size(primitives) - 1)
+              AccessTraits<Primitives>::size(primitives) - 1)
       , dendrogram_parents("ArborX::MST::dendrogram_parents", 0)
       , dendrogram_parent_heights("ArborX::MST::dendrogram_parent_heights", 0)
   {
     Kokkos::Profiling::pushRegion("ArborX::MST::MST");
 
-    using Points = Details::AccessValues<Primitives, PrimitivesTag>;
+    using Points = Details::AccessValues<Primitives>;
     using Point = typename Points::value_type;
     static_assert(GeometryTraits::is_point_v<Point>);
 

--- a/src/distributed/ArborX_DistributedTree.hpp
+++ b/src/distributed/ArborX_DistributedTree.hpp
@@ -89,7 +89,7 @@ public:
         Details::KokkosExt::is_accessible_from<MemorySpace,
                                                ExecutionSpace>::value);
 
-    using Predicates = Details::AccessValues<UserPredicates, PredicatesTag>;
+    using Predicates = Details::AccessValues<UserPredicates>;
     static_assert(Details::KokkosExt::is_accessible_from<
                       typename Predicates::memory_space, ExecutionSpace>::value,
                   "Predicates must be accessible from the execution space");
@@ -156,9 +156,9 @@ KOKKOS_DEDUCTION_GUIDE
 #else
 KOKKOS_FUNCTION
 #endif
-    DistributedTree(MPI_Comm, ExecutionSpace, Values) -> DistributedTree<
-        typename Details::AccessValues<Values, PrimitivesTag>::memory_space,
-        typename Details::AccessValues<Values, PrimitivesTag>::value_type>;
+    DistributedTree(MPI_Comm, ExecutionSpace, Values)
+        -> DistributedTree<typename Details::AccessValues<Values>::memory_space,
+                           typename Details::AccessValues<Values>::value_type>;
 
 template <typename BottomTree>
 template <typename ExecutionSpace, typename... Args>

--- a/src/distributed/detail/ArborX_DistributedTreeNearestHelpers.hpp
+++ b/src/distributed/detail/ArborX_DistributedTreeNearestHelpers.hpp
@@ -148,7 +148,7 @@ KOKKOS_INLINE_FUNCTION auto approx_expand_by_radius(Geometry const &geometry,
 
 template <class Predicates, class Distances>
 struct AccessTraits<
-    Details::WithinDistanceFromPredicates<Predicates, Distances>, PredicatesTag>
+    Details::WithinDistanceFromPredicates<Predicates, Distances>>
 {
   using Predicate = typename Predicates::value_type;
   using Geometry =

--- a/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
+++ b/src/interpolation/ArborX_InterpMovingLeastSquares.hpp
@@ -80,9 +80,8 @@ public:
         "Memory space must be accessible from the execution space");
 
     // SourcePoints is an access trait of points
-    ArborX::Details::check_valid_access_traits(PrimitivesTag{}, source_points);
-    using SourceAccess =
-        ArborX::Details::AccessValues<SourcePoints, PrimitivesTag>;
+    ArborX::Details::check_valid_access_traits(source_points);
+    using SourceAccess = ArborX::Details::AccessValues<SourcePoints>;
     static_assert(
         KokkosExt::is_accessible_from<typename SourceAccess::memory_space,
                                       ExecutionSpace>::value,
@@ -94,9 +93,8 @@ public:
     static constexpr int dimension = GeometryTraits::dimension_v<SourcePoint>;
 
     // TargetPoints is an access trait of points
-    ArborX::Details::check_valid_access_traits(PrimitivesTag{}, target_points);
-    using TargetAccess =
-        ArborX::Details::AccessValues<TargetPoints, PrimitivesTag>;
+    ArborX::Details::check_valid_access_traits(target_points);
+    using TargetAccess = ArborX::Details::AccessValues<TargetPoints>;
     static_assert(
         KokkosExt::is_accessible_from<typename TargetAccess::memory_space,
                                       ExecutionSpace>::value,

--- a/src/spatial/ArborX_LinearBVH.hpp
+++ b/src/spatial/ArborX_LinearBVH.hpp
@@ -100,7 +100,7 @@ public:
         check_valid_callback_if_first_argument_is_not_a_view<value_type>(
             callback_or_view, user_predicates, view);
 
-    using Predicates = Details::AccessValues<UserPredicates, PredicatesTag>;
+    using Predicates = Details::AccessValues<UserPredicates>;
     using Tag = typename Predicates::value_type::Tag;
 
     Details::CrsGraphWrapperImpl::queryDispatch(
@@ -148,8 +148,8 @@ KOKKOS_DEDUCTION_GUIDE
 KOKKOS_FUNCTION
 #endif
     BoundingVolumeHierarchy(ExecutionSpace, Values) -> BoundingVolumeHierarchy<
-        typename Details::AccessValues<Values, PrimitivesTag>::memory_space,
-        typename Details::AccessValues<Values, PrimitivesTag>::value_type>;
+        typename Details::AccessValues<Values>::memory_space,
+        typename Details::AccessValues<Values>::value_type>;
 
 template <typename ExecutionSpace, typename Values, typename IndexableGetter>
 #if KOKKOS_VERSION >= 40400
@@ -159,8 +159,8 @@ KOKKOS_FUNCTION
 #endif
     BoundingVolumeHierarchy(ExecutionSpace, Values, IndexableGetter)
         -> BoundingVolumeHierarchy<
-            typename Details::AccessValues<Values, PrimitivesTag>::memory_space,
-            typename Details::AccessValues<Values, PrimitivesTag>::value_type,
+            typename Details::AccessValues<Values>::memory_space,
+            typename Details::AccessValues<Values>::value_type,
             IndexableGetter>;
 
 template <typename MemorySpace, typename Value,
@@ -182,7 +182,7 @@ BoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter, BoundingVolume>::
                             UserValues const &user_values,
                             IndexableGetter const &indexable_getter,
                             SpaceFillingCurve const &curve)
-    : _size(AccessTraits<UserValues, PrimitivesTag>::size(user_values))
+    : _size(AccessTraits<UserValues>::size(user_values))
     , _leaf_nodes(Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                                      "ArborX::BVH::leaf_nodes"),
                   _size)
@@ -193,11 +193,9 @@ BoundingVolumeHierarchy<MemorySpace, Value, IndexableGetter, BoundingVolume>::
 {
   static_assert(Details::KokkosExt::is_accessible_from<MemorySpace,
                                                        ExecutionSpace>::value);
-  // FIXME redo with RangeTraits
-  Details::check_valid_access_traits<UserValues>(
-      PrimitivesTag{}, user_values, Details::DoNotCheckGetReturnType());
+  Details::check_valid_access_traits(user_values);
 
-  using Values = Details::AccessValues<UserValues, PrimitivesTag>;
+  using Values = Details::AccessValues<UserValues>;
   Values values{user_values}; // NOLINT
 
   static_assert(
@@ -275,10 +273,11 @@ void BoundingVolumeHierarchy<
 {
   static_assert(Details::KokkosExt::is_accessible_from<MemorySpace,
                                                        ExecutionSpace>::value);
-  Details::check_valid_access_traits(PredicatesTag{}, user_predicates);
+  Details::check_valid_access_traits(user_predicates,
+                                     Details::CheckReturnTypeTag{});
   Details::check_valid_callback<value_type>(callback, user_predicates);
 
-  using Predicates = Details::AccessValues<UserPredicates, PredicatesTag>;
+  using Predicates = Details::AccessValues<UserPredicates>;
   static_assert(
       Details::KokkosExt::is_accessible_from<typename Predicates::memory_space,
                                              ExecutionSpace>::value,

--- a/src/spatial/detail/ArborX_Callbacks.hpp
+++ b/src/spatial/detail/ArborX_Callbacks.hpp
@@ -98,8 +98,7 @@ void check_valid_callback(Callback const &callback, Predicates const &,
 {
   check_generic_lambda_support(callback);
 
-  using Predicate =
-      typename AccessValues<Predicates, PredicatesTag>::value_type;
+  using Predicate = typename AccessValues<Predicates>::value_type;
   using PredicateTag = typename Predicate::Tag;
 
   static_assert(!(std::is_same_v<PredicateTag, NearestPredicateTag> &&
@@ -149,8 +148,7 @@ void check_valid_callback(Callback const &callback, Predicates const &)
 {
   check_generic_lambda_support(callback);
 
-  using Predicate =
-      typename AccessValues<Predicates, PredicatesTag>::value_type;
+  using Predicate = typename AccessValues<Predicates>::value_type;
   using PredicateTag = typename Predicate::Tag;
 
   static_assert(is_valid_predicate_tag<PredicateTag>::value,

--- a/src/spatial/detail/ArborX_NeighborList.hpp
+++ b/src/spatial/detail/ArborX_NeighborList.hpp
@@ -52,7 +52,7 @@ void findHalfNeighborList(ExecutionSpace const &space,
   namespace KokkosExt = ArborX::Details::KokkosExt;
   using Details::HalfTraversal;
 
-  using Points = Details::AccessValues<Primitives, PrimitivesTag>;
+  using Points = Details::AccessValues<Primitives>;
 
   using MemorySpace = typename Points::memory_space;
   static_assert(
@@ -111,7 +111,7 @@ void findFullNeighborList(ExecutionSpace const &space,
   namespace KokkosExt = ArborX::Details::KokkosExt;
   using Details::HalfTraversal;
 
-  using Points = Details::AccessValues<Primitives, PrimitivesTag>;
+  using Points = Details::AccessValues<Primitives>;
 
   using MemorySpace = typename Points::memory_space;
   static_assert(

--- a/src/spatial/detail/ArborX_PermutedData.hpp
+++ b/src/spatial/detail/ArborX_PermutedData.hpp
@@ -53,8 +53,8 @@ struct PermutedData<Data, Permute, /*AttachIndices=*/true>
   KOKKOS_FUNCTION auto size() const { return _data.size(); }
 };
 
-template <typename Data, typename Permute, bool AttachIndices, typename Tag>
-class AccessValuesI<PermutedData<Data, Permute, AttachIndices>, Tag>
+template <typename Data, typename Permute, bool AttachIndices>
+class AccessValuesI<PermutedData<Data, Permute, AttachIndices>>
     : public PermutedData<Data, Permute, AttachIndices>
 {
 public:
@@ -64,8 +64,7 @@ public:
 } // namespace Details
 
 template <typename Predicates, typename Permute, bool AttachIndices>
-struct AccessTraits<Details::PermutedData<Predicates, Permute, AttachIndices>,
-                    PredicatesTag>
+struct AccessTraits<Details::PermutedData<Predicates, Permute, AttachIndices>>
 {
   using PermutedPredicates =
       Details::PermutedData<Predicates, Permute, AttachIndices>;

--- a/src/spatial/detail/ArborX_PredicateHelpers.hpp
+++ b/src/spatial/detail/ArborX_PredicateHelpers.hpp
@@ -25,7 +25,7 @@ namespace Experimental
 template <typename UserPrimitives>
 class PrimitivesIntersect
 {
-  using Primitives = Details::AccessValues<UserPrimitives, PrimitivesTag>;
+  using Primitives = Details::AccessValues<UserPrimitives>;
   // FIXME:
   // using Geometry = typename Primitives::value_type;
   // static_assert(GeometryTraits::is_valid_geometry<Geometry>{});
@@ -37,7 +37,7 @@ public:
 template <typename UserPrimitives>
 class PrimitivesOrderedIntersect
 {
-  using Primitives = Details::AccessValues<UserPrimitives, PrimitivesTag>;
+  using Primitives = Details::AccessValues<UserPrimitives>;
 
 public:
   Primitives _primitives;
@@ -46,7 +46,7 @@ public:
 template <typename UserPrimitives>
 class PrimitivesWithRadius
 {
-  using Primitives = Details::AccessValues<UserPrimitives, PrimitivesTag>;
+  using Primitives = Details::AccessValues<UserPrimitives>;
   using Point = typename Primitives::value_type;
   static_assert(GeometryTraits::is_point<Point>::value);
   using Coordinate = typename GeometryTraits::coordinate_type<Point>::type;
@@ -64,7 +64,7 @@ public:
 template <class UserPrimitives>
 class PrimitivesNearestK
 {
-  using Primitives = Details::AccessValues<UserPrimitives, PrimitivesTag>;
+  using Primitives = Details::AccessValues<UserPrimitives>;
   // FIXME:
   // using Geometry = typename Primitives::value_type;
   // static_assert(GeometryTraits::is_valid_geometry<Geometry>{});
@@ -77,39 +77,35 @@ public:
 template <typename Primitives>
 auto make_intersects(Primitives const &primitives)
 {
-  Details::check_valid_access_traits(PrimitivesTag{}, primitives,
-                                     Details::DoNotCheckGetReturnType());
+  Details::check_valid_access_traits(primitives);
   return PrimitivesIntersect<Primitives>{primitives};
 }
 
 template <typename Primitives, typename Coordinate>
 auto make_intersects(Primitives const &primitives, Coordinate r)
 {
-  Details::check_valid_access_traits(PrimitivesTag{}, primitives);
+  Details::check_valid_access_traits(primitives);
   return PrimitivesWithRadius<Primitives>(primitives, r);
 }
 
 template <typename Primitives>
 auto make_ordered_intersects(Primitives const &primitives)
 {
-  Details::check_valid_access_traits(PrimitivesTag{}, primitives,
-                                     Details::DoNotCheckGetReturnType());
+  Details::check_valid_access_traits(primitives);
   return PrimitivesOrderedIntersect<Primitives>{primitives};
 }
 
 template <typename Primitives>
 auto make_nearest(Primitives const &primitives, int k)
 {
-  Details::check_valid_access_traits(PrimitivesTag{}, primitives,
-                                     Details::DoNotCheckGetReturnType());
+  Details::check_valid_access_traits(primitives);
   return PrimitivesNearestK<Primitives>{primitives, k};
 }
 
 } // namespace Experimental
 
 template <class Primitives>
-struct AccessTraits<Experimental::PrimitivesIntersect<Primitives>,
-                    PredicatesTag>
+struct AccessTraits<Experimental::PrimitivesIntersect<Primitives>>
 {
 private:
   using Self = Experimental::PrimitivesIntersect<Primitives>;
@@ -129,8 +125,7 @@ public:
 };
 
 template <class Primitives>
-struct AccessTraits<Experimental::PrimitivesOrderedIntersect<Primitives>,
-                    PredicatesTag>
+struct AccessTraits<Experimental::PrimitivesOrderedIntersect<Primitives>>
 {
 private:
   using Self = Experimental::PrimitivesOrderedIntersect<Primitives>;
@@ -150,8 +145,7 @@ public:
 };
 
 template <class Primitives>
-struct AccessTraits<Experimental::PrimitivesWithRadius<Primitives>,
-                    PredicatesTag>
+struct AccessTraits<Experimental::PrimitivesWithRadius<Primitives>>
 {
 private:
   using Self = Experimental::PrimitivesWithRadius<Primitives>;
@@ -176,7 +170,7 @@ public:
 };
 
 template <class Primitives>
-struct AccessTraits<Experimental::PrimitivesNearestK<Primitives>, PredicatesTag>
+struct AccessTraits<Experimental::PrimitivesNearestK<Primitives>>
 {
 private:
   using Self = Experimental::PrimitivesNearestK<Primitives>;

--- a/test/ArborXTest_LegacyTree.hpp
+++ b/test/ArborXTest_LegacyTree.hpp
@@ -25,7 +25,7 @@ template <typename Primitives, typename BoundingVolume>
 class LegacyValues
 {
   Primitives _primitives;
-  using Access = ArborX::AccessTraits<Primitives, ArborX::PrimitivesTag>;
+  using Access = ArborX::AccessTraits<Primitives>;
 
 public:
   using memory_space = typename Access::memory_space;
@@ -66,8 +66,7 @@ public:
 };
 
 template <typename Primitives, typename BoundingVolume>
-struct ArborX::AccessTraits<LegacyValues<Primitives, BoundingVolume>,
-                            ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<LegacyValues<Primitives, BoundingVolume>>
 {
   using self_type = LegacyValues<Primitives, BoundingVolume>;
 

--- a/test/ArborX_BoostRTreeHelpers.hpp
+++ b/test/ArborX_BoostRTreeHelpers.hpp
@@ -192,8 +192,7 @@ performQueries(RTree<Indexable> const &rtree, UserPredicates const &predicates)
 {
   namespace KokkosExt = ArborX::Details::KokkosExt;
 
-  using Predicates =
-      ArborX::Details::AccessValues<UserPredicates, ArborX::PredicatesTag>;
+  using Predicates = ArborX::Details::AccessValues<UserPredicates>;
   static_assert(Kokkos::SpaceAccessibility<typename Predicates::memory_space,
                                            Kokkos::HostSpace>::accessible);
 

--- a/test/tstAttachIndices.cpp
+++ b/test/tstAttachIndices.cpp
@@ -23,8 +23,7 @@ BOOST_AUTO_TEST_CASE(attach_indices_to_primitives)
 
   Kokkos::View<ArborX::Point<3> *, Kokkos::HostSpace> p("Testing::p", 10);
   auto p_with_indices = attach_indices(p);
-  AccessValues<decltype(p_with_indices), ArborX::PrimitivesTag> p_values{
-      p_with_indices};
+  AccessValues<decltype(p_with_indices)> p_values{p_with_indices};
   static_assert(std::is_same_v<decltype(p_values(0).index), unsigned>);
   BOOST_TEST(p_values(0).index == 0);
   BOOST_TEST(p_values(9).index == 9);
@@ -38,8 +37,7 @@ BOOST_AUTO_TEST_CASE(attach_indices_to_predicates)
   using IntersectsPredicate = decltype(ArborX::intersects(ArborX::Point<3>{}));
   Kokkos::View<IntersectsPredicate *, Kokkos::HostSpace> q("Testing::q", 10);
   auto q_with_indices = attach_indices<long>(q);
-  AccessValues<decltype(q_with_indices), ArborX::PredicatesTag> q_values{
-      q_with_indices};
+  AccessValues<decltype(q_with_indices)> q_values{q_with_indices};
   BOOST_TEST(ArborX::getData(q_values(0)) == 0);
   BOOST_TEST(ArborX::getData(q_values(9)) == 9);
 }

--- a/test/tstCompileOnlyAccessTraits.cpp
+++ b/test/tstCompileOnlyAccessTraits.cpp
@@ -15,9 +15,8 @@
 
 #include <Kokkos_Core.hpp>
 
-using ArborX::PredicatesTag;
-using ArborX::PrimitivesTag;
 using ArborX::Details::check_valid_access_traits;
+using ArborX::Details::CheckReturnTypeTag;
 
 // NOTE Let's not bother with __host__ __device__ annotations here
 
@@ -38,6 +37,14 @@ struct ArborX::AccessTraits<InvalidMemorySpace, Tag>
   using memory_space = void;
 };
 
+struct MissingSizeMemberFunction
+{};
+template <typename Tag>
+struct ArborX::AccessTraits<MissingSizeMemberFunction, Tag>
+{
+  using memory_space = Kokkos::HostSpace;
+};
+
 struct SizeMemberFunctionNotStatic
 {};
 template <typename Tag>
@@ -47,9 +54,38 @@ struct ArborX::AccessTraits<SizeMemberFunctionNotStatic, Tag>
   int size(SizeMemberFunctionNotStatic) { return 255; }
 };
 
-template <class V, class Tag>
+struct MissingGetMemberFunction
+{};
+template <typename Tag>
+struct ArborX::AccessTraits<MissingGetMemberFunction, Tag>
+{
+  using memory_space = Kokkos::HostSpace;
+  static int size(MissingGetMemberFunction) { return 255; }
+};
+
+struct GetMemberFunctionNotStatic
+{};
+template <typename Tag>
+struct ArborX::AccessTraits<GetMemberFunctionNotStatic, Tag>
+{
+  using memory_space = Kokkos::HostSpace;
+  static int size(GetMemberFunctionNotStatic) { return 255; }
+  ArborX::Point<3> get(GetMemberFunctionNotStatic, int) { return {}; }
+};
+
+struct GetMemberFunctionVoid
+{};
+template <typename Tag>
+struct ArborX::AccessTraits<GetMemberFunctionVoid, Tag>
+{
+  using memory_space = Kokkos::HostSpace;
+  static int size(GetMemberFunctionVoid) { return 255; }
+  static void get(GetMemberFunctionVoid, int) {}
+};
+
+template <class V>
 using deduce_type_t =
-    decltype(ArborX::AccessTraits<V, Tag>::get(std::declval<V>(), 0));
+    decltype(ArborX::AccessTraits<V>::get(std::declval<V>(), 0));
 
 void test_access_traits_compile_only()
 {
@@ -57,28 +93,25 @@ void test_access_traits_compile_only()
 
   Kokkos::View<Point *> p;
   Kokkos::View<float **> v;
-  check_valid_access_traits(PrimitivesTag{}, p);
-  check_valid_access_traits(PrimitivesTag{}, v);
+  check_valid_access_traits(p);
+  check_valid_access_traits(v);
 
   auto p_with_indices = ArborX::Experimental::attach_indices(p);
-  check_valid_access_traits(PrimitivesTag{}, p_with_indices,
-                            ArborX::Details::DoNotCheckGetReturnType());
-  static_assert(
-      std::is_same_v<deduce_type_t<decltype(p_with_indices), PrimitivesTag>,
-                     ArborX::PairValueIndex<Point, unsigned>>);
+  check_valid_access_traits(p_with_indices);
+  static_assert(std::is_same_v<deduce_type_t<decltype(p_with_indices)>,
+                               ArborX::PairValueIndex<Point, unsigned>>);
 
   auto p_with_indices_long = ArborX::Experimental::attach_indices<long>(p);
-  static_assert(std::is_same_v<
-                deduce_type_t<decltype(p_with_indices_long), PrimitivesTag>,
-                ArborX::PairValueIndex<Point, long>>);
+  static_assert(std::is_same_v<deduce_type_t<decltype(p_with_indices_long)>,
+                               ArborX::PairValueIndex<Point, long>>);
 
   using NearestPredicate = decltype(ArborX::nearest(Point{}));
   Kokkos::View<NearestPredicate *> q;
-  check_valid_access_traits(PredicatesTag{}, q);
+  check_valid_access_traits(q, CheckReturnTypeTag{});
 
   auto q_with_indices = ArborX::Experimental::attach_indices<long>(q);
-  check_valid_access_traits(PredicatesTag{}, q_with_indices);
-  using predicate = deduce_type_t<decltype(q_with_indices), PredicatesTag>;
+  check_valid_access_traits(q_with_indices, CheckReturnTypeTag{});
+  using predicate = deduce_type_t<decltype(q_with_indices)>;
   static_assert(
       std::is_same_v<
           std::decay_t<decltype(ArborX::getData(std::declval<predicate>()))>,
@@ -91,38 +124,40 @@ void test_access_traits_compile_only()
   };
   auto q_with_custom_indices =
       ArborX::Experimental::attach_indices<CustomIndex>(q);
-  check_valid_access_traits(PredicatesTag{}, q_with_custom_indices);
-  using predicate_custom =
-      deduce_type_t<decltype(q_with_custom_indices), PredicatesTag>;
+  check_valid_access_traits(q_with_custom_indices, CheckReturnTypeTag{});
+  using predicate_custom = deduce_type_t<decltype(q_with_custom_indices)>;
   static_assert(std::is_same_v<std::decay_t<decltype(ArborX::getData(
                                    std::declval<predicate_custom>()))>,
                                CustomIndex>);
 
   // Uncomment to see error messages
 
-  // check_valid_access_traits(PrimitivesTag{}, NoAccessTraitsSpecialization{});
+  // check_valid_access_traits(NoAccessTraitsSpecialization{});
 
-  // check_valid_access_traits(PrimitivesTag{}, EmptySpecialization{});
+  // check_valid_access_traits(EmptySpecialization{});
 
-  // check_valid_access_traits(PrimitivesTag{}, InvalidMemorySpace{});
+  // check_valid_access_traits(InvalidMemorySpace{});
 
-  // check_valid_access_traits(PrimitivesTag{}, SizeMemberFunctionNotStatic{});
+  // check_valid_access_traits(MissingSizeMemberFunction{});
+
+  // check_valid_access_traits(SizeMemberFunctionNotStatic{});
+
+  // check_valid_access_traits(MissingGetMemberFunction{});
+
+  // check_valid_access_traits(GetMemberFunctionNotStatic{});
+
+  // check_valid_access_traits(GetMemberFunctionVoid{});
 }
 
 void test_deduce_point_type_from_view()
 {
   using ArborX::Point;
-  using ArborX::PrimitivesTag;
   static_assert(
-      std::is_same_v<deduce_type_t<Kokkos::View<float **>, PrimitivesTag>,
-                     Point<3>>);
+      std::is_same_v<deduce_type_t<Kokkos::View<float **>>, Point<3>>);
   static_assert(
-      std::is_same_v<deduce_type_t<Kokkos::View<float *[3]>, PrimitivesTag>,
-                     Point<3>>);
+      std::is_same_v<deduce_type_t<Kokkos::View<float *[3]>>, Point<3>>);
   static_assert(
-      std::is_same_v<deduce_type_t<Kokkos::View<float *[2]>, PrimitivesTag>,
-                     Point<2>>);
+      std::is_same_v<deduce_type_t<Kokkos::View<float *[2]>>, Point<2>>);
   static_assert(
-      std::is_same_v<deduce_type_t<Kokkos::View<float *[5]>, PrimitivesTag>,
-                     Point<5>>);
+      std::is_same_v<deduce_type_t<Kokkos::View<float *[5]>>, Point<5>>);
 }

--- a/test/tstCompileOnlyCallbacks.cpp
+++ b/test/tstCompileOnlyCallbacks.cpp
@@ -20,7 +20,7 @@
 struct NearestPredicates
 {};
 template <>
-struct ArborX::AccessTraits<NearestPredicates, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<NearestPredicates>
 {
   using memory_space = Kokkos::HostSpace;
   static int size(NearestPredicates const &) { return 1; }
@@ -33,7 +33,7 @@ struct ArborX::AccessTraits<NearestPredicates, ArborX::PredicatesTag>
 struct SpatialPredicates
 {};
 template <>
-struct ArborX::AccessTraits<SpatialPredicates, ArborX::PredicatesTag>
+struct ArborX::AccessTraits<SpatialPredicates>
 {
   using memory_space = Kokkos::HostSpace;
   static int size(SpatialPredicates const &) { return 1; }

--- a/test/tstDBSCAN.cpp
+++ b/test/tstDBSCAN.cpp
@@ -22,7 +22,7 @@ struct HiddenView
   View _view;
 };
 template <typename View>
-struct ArborX::AccessTraits<HiddenView<View>, ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<HiddenView<View>>
 {
   using Data = HiddenView<View>;
   static KOKKOS_FUNCTION std::size_t size(Data const &data)

--- a/test/tstDetailsCrsGraphWrapperImpl.cpp
+++ b/test/tstDetailsCrsGraphWrapperImpl.cpp
@@ -32,7 +32,7 @@ struct Test1
              ArborX::Experimental::TraversalPolicy const & =
                  ArborX::Experimental::TraversalPolicy()) const
   {
-    using Access = ArborX::AccessTraits<Predicates, ArborX::PredicatesTag>;
+    using Access = ArborX::AccessTraits<Predicates>;
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy(space, 0, Access::size(predicates)),

--- a/test/tstIndexableGetter.cpp
+++ b/test/tstIndexableGetter.cpp
@@ -28,7 +28,7 @@ struct PointCloud
 };
 
 template <typename MemorySpace>
-struct ArborX::AccessTraits<PointCloud<MemorySpace>, ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<PointCloud<MemorySpace>>
 {
   using Points = PointCloud<MemorySpace>;
 
@@ -51,8 +51,7 @@ struct PairPointIndexCloud
 };
 
 template <typename MemorySpace>
-struct ArborX::AccessTraits<PairPointIndexCloud<MemorySpace>,
-                            ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<PairPointIndexCloud<MemorySpace>>
 {
   using Points = PairPointIndexCloud<MemorySpace>;
 
@@ -106,8 +105,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(indexables, DeviceType, ARBORX_DEVICE_TYPES)
   {
     PointCloud<MemorySpace> points_cloud{points.data(), (int)points.size()};
 
-    using Primitives = ArborX::Details::AccessValues<decltype(points_cloud),
-                                                     ArborX::PrimitivesTag>;
+    using Primitives = ArborX::Details::AccessValues<decltype(points_cloud)>;
     Primitives primitives(points_cloud);
 
     ArborX::Details::Indexables indexables{primitives, indexable_getter};
@@ -121,8 +119,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(indexables, DeviceType, ARBORX_DEVICE_TYPES)
     PairPointIndexCloud<MemorySpace> points_cloud{points.data(),
                                                   (int)points.size()};
 
-    using Primitives = ArborX::Details::AccessValues<decltype(points_cloud),
-                                                     ArborX::PrimitivesTag>;
+    using Primitives = ArborX::Details::AccessValues<decltype(points_cloud)>;
     Primitives primitives(points_cloud);
 
     ArborX::Details::Indexables indexables{primitives, indexable_getter};

--- a/test/tstQueryTreeIntersectsKDOP.cpp
+++ b/test/tstQueryTreeIntersectsKDOP.cpp
@@ -27,7 +27,7 @@ struct Iota
 };
 
 template <typename MemorySpace>
-struct ArborX::AccessTraits<Iota<MemorySpace>, ArborX::PrimitivesTag>
+struct ArborX::AccessTraits<Iota<MemorySpace>>
 {
   using Self = Iota<MemorySpace>;
 


### PR DESCRIPTION
- Remove `PrimitivesTag` and `PredicatesTag`
- Update `check_valid_access_traits` and provide `CheckReturnTypeTag` for predicates
- Fix all examples, tests and benchmarks
- Beef up access traits testing

Newer version of #997. Don't know if we want to rename `AccessTraits` to `RangeTraits`.