### PR TITLE
CMake `AnyNewerVersion` -> `SameMajorVersion`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,17 +32,18 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -D CMAKE_INSTALL_PREFIX=C:\kokkos-install \
+        cmake -D CMAKE_BUILD_TYPE=Release \
+              -D CMAKE_INSTALL_PREFIX=C:\kokkos-install \
               -D Kokkos_ENABLE_THREADS=ON \
               ..
-        cmake --build . --target install -- -m
+        cmake --build . --config Release --target install -- -m
     - name: Configure ArborX
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="/EHsc /bigobj" -DKokkos_ROOT="C:\kokkos-install" ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -DARBORX_ENABLE_MPI=OFF -DARBORX_ENABLE_TESTS=ON -DARBORX_ENABLE_EXAMPLES=ON -DARBORX_ENABLE_BENCHMARKS=ON -DARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS=OFF ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/EHsc /bigobj" -DKokkos_ROOT="C:\kokkos-install" ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -DARBORX_ENABLE_MPI=OFF -DARBORX_ENABLE_TESTS=ON -DARBORX_ENABLE_EXAMPLES=ON -DARBORX_ENABLE_BENCHMARKS=ON -DARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS=OFF ..
     - name: Build ArborX
       shell: bash
       run: |
-        cmake --build build --target install -- -m
+        cmake --build build --config Release --target install -- -m
         cd build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,18 +32,15 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -D CMAKE_BUILD_TYPE=Release \
-              -D CMAKE_INSTALL_PREFIX=C:\kokkos-install \
-              -D Kokkos_ENABLE_THREADS=ON \
-              ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DCMAKE_INSTALL_PREFIX=C:\kokkos-install -DKokkos_ENABLE_THREADS=ON ..
         cmake --build . --config Release --target install -- -m
     - name: Configure ArborX
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/EHsc /bigobj" -DKokkos_ROOT="C:\kokkos-install" ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -DARBORX_ENABLE_MPI=OFF -DARBORX_ENABLE_TESTS=ON -DARBORX_ENABLE_EXAMPLES=ON -DARBORX_ENABLE_BENCHMARKS=ON -DARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS=OFF ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="/EHsc /bigobj" -DKokkos_ROOT="C:\kokkos-install" ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -DARBORX_ENABLE_MPI=OFF -DARBORX_ENABLE_TESTS=ON -DARBORX_ENABLE_EXAMPLES=ON -DARBORX_ENABLE_BENCHMARKS=ON -DARBORX_ENABLE_HEADER_SELF_CONTAINMENT_TESTS=OFF ..
     - name: Build ArborX
       shell: bash
       run: |
-        cmake --build build --config Release --target install -- -m
+        cmake --build build --config Debug --target install -- -m
         cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ArborX CXX)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
   message(STATUS "Setting policy CMP0167 to use FindBoost module")
-  cmake_policy(SET CMP0167 OLD)
+  cmake_policy(SET CMP0167 NEW)
 endif()
 
 # use gnu standard install directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 project(ArborX CXX)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ configure_package_config_file(cmake/ArborXConfig.cmake.in
 )
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ArborXConfigVersion.cmake
   VERSION ${ARBORX_VERSION_STRING}
-  COMPATIBILITY AnyNewerVersion
+  COMPATIBILITY SameMajorVersion
 )
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/ArborXConfig.cmake

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN KEYDUMP_URL=https://cloud1.cees.ornl.gov/download && \
 
 # Install CMake
 ENV CMAKE_DIR=/opt/cmake
-RUN CMAKE_VERSION=3.16.9 && \
+RUN CMAKE_VERSION=3.22.6 && \
     CMAKE_KEY=2D2CEF1034921684 && \
     CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
     CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  cmake_minimum_required(VERSION 3.16)
+  cmake_minimum_required(VERSION 3.22)
   project(ArborXExamples CXX)
   find_package(ArborX 2.0 REQUIRED)
   enable_testing()


### PR DESCRIPTION
We are not backwards compatible for version 2.0. Allowing users' 1.x code to build against 2.0 is almost 100% would lead to build failures. Would rather prevent that during configuration.

Switching to `SameMajorVersion` would likely be temporary, for a few 2.x releases, after which we would switch back.

An alternative to switching to `SameMajorVersion` would be to update CMake requirements to at least 3.19 (release 11/18/2020, so about a year older than CMake we are using right now) and do
```diff
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ configure_package_config_file(cmake/ArborXConfig.cmake.in
 )
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ArborXConfigVersion.cmake
   VERSION ${ARBORX_VERSION_STRING}
-  COMPATIBILITY AnyNewerVersion
+  COMPATIBILITY AnyNewerVersion <2.0
 )
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/ArborXConfig.cmake
```
This has a benefit of not having to revisit this again later.

Note: `AnyNewerVersion` was introduced in #984.