### PR TITLE
Change BOOST_URL to archives.boost.io

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ ENV BOOST_DIR=/opt/boost
 RUN BOOST_VERSION=1.75.0 && \
     BOOST_VERSION_UNDERSCORE=$(echo "$BOOST_VERSION" | sed -e "s/\./_/g") && \
     BOOST_KEY=379CE192D401AB61 && \
-    BOOST_URL=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source && \
+    BOOST_URL=https://archives.boost.io/release/${BOOST_VERSION}/source && \
     BOOST_ARCHIVE=boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2 && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE} && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -57,7 +57,7 @@ ENV BOOST_DIR=/opt/boost
 RUN BOOST_VERSION=1.79.0 && \
     BOOST_VERSION_UNDERSCORE=$(echo "$BOOST_VERSION" | sed -e "s/\./_/g") && \
     BOOST_KEY=379CE192D401AB61 && \
-    BOOST_URL=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source && \
+    BOOST_URL=https://archives.boost.io/release/${BOOST_VERSION}/source && \
     BOOST_ARCHIVE=boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2 && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE} && \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -94,7 +94,7 @@ RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
     BOOST_VERSION=1.81.0 && \
     BOOST_VERSION_UNDERSCORE=$(echo "$BOOST_VERSION" | sed -e "s/\./_/g") && \
     BOOST_KEY=379CE192D401AB61 && \
-    BOOST_URL=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source && \
+    BOOST_URL=https://archives.boost.io/release/${BOOST_VERSION}/source && \
     BOOST_ARCHIVE=boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2 && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE} && \


### PR DESCRIPTION
Related to boostorg/boost#924

The agreement of Boost with JFrog came to an end in December 2024.