### PR TITLE
Clean up ArborX.hpp

### DIFF
--- a/src/ArborX.hpp
+++ b/src/ArborX.hpp
@@ -14,22 +14,21 @@
 
 #include <ArborX_Config.hpp>
 
-#include <ArborX_Box.hpp>
+// Indexes
 #include <ArborX_BruteForce.hpp>
 #ifdef ARBORX_ENABLE_MPI
 #include <ArborX_DistributedTree.hpp>
 #endif
 #include <ArborX_CrsGraphWrapper.hpp>
 #include <ArborX_LinearBVH.hpp>
-#include <ArborX_Point.hpp>
-#include <ArborX_Sphere.hpp>
+
+// Indexes helpers
+#include <detail/ArborX_AttachIndices.hpp>
+#include <detail/ArborX_NeighborList.hpp>
 #include <detail/ArborX_PredicateHelpers.hpp>
 #include <detail/ArborX_Predicates.hpp>
+
+// Misc
 #include <misc/ArborX_Exception.hpp>
-// FIXME: we include ArborX_Utils.hpp only for backward compatibility for
-// users using deprecated functions in ArborX namespace (min, max,
-// adjacentDifference, ...). This header should be removed when we remove those
-// functions.
-#include <misc/ArborX_Utils.hpp>
 
 #endif


### PR DESCRIPTION
This is mostly to start a discussion about what headers should a user get when including `ArborX.hpp`. 

As I see it, there are two options:
1. A user gets no geometries at all through `ArborX.hpp` (other than included through indexes), and has to include each individual geometry they want to use
2. A user gets all the geometries

I see an issue with the first approach as a user will be transitively dependent on the geometries. If we change anything internally about inclusions, that will break user's code through no fault of their own. On the other hand, including all geometries is including a lot of code.

I'd like feedback on this.