### PR TITLE
Allow running DBSCAN in different precisions

### DIFF
--- a/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
+++ b/benchmarks/dbscan/ArborX_DBSCANVerification.hpp
@@ -295,9 +295,10 @@ struct IndexOnlyCallback
   }
 };
 
-template <typename ExecutionSpace, typename Primitives, typename LabelsView>
+template <typename ExecutionSpace, typename Primitives, typename LabelsView,
+          typename Coordinate>
 bool verifyDBSCAN(ExecutionSpace exec_space, Primitives const &primitives,
-                  float eps, int core_min_size, LabelsView const &labels,
+                  Coordinate eps, int core_min_size, LabelsView const &labels,
                   bool verbose = false)
 {
   Kokkos::Profiling::pushRegion("ArborX::DBSCAN::verify");

--- a/src/cluster/detail/ArborX_CartesianGrid.hpp
+++ b/src/cluster/detail/ArborX_CartesianGrid.hpp
@@ -141,6 +141,15 @@ private:
   size_t _n[DIM];
 };
 
+template <int DIM, typename Coordinate>
+#if KOKKOS_VERSION >= 40400
+KOKKOS_DEDUCTION_GUIDE
+#else
+KOKKOS_FUNCTION
+#endif
+    CartesianGrid(Box<DIM, Coordinate>, Coordinate)
+        -> CartesianGrid<DIM, Coordinate>;
+
 } // namespace ArborX::Details
 
 #endif

--- a/src/cluster/detail/ArborX_CartesianGrid.hpp
+++ b/src/cluster/detail/ArborX_CartesianGrid.hpp
@@ -23,13 +23,11 @@
 namespace ArborX::Details
 {
 
-template <int DIM>
+template <int DIM, typename Coordinate = float>
 struct CartesianGrid
 {
 public:
-  static constexpr int dim = DIM;
-
-  CartesianGrid(Box<DIM> const &bounds, float h)
+  CartesianGrid(Box<DIM, Coordinate> const &bounds, Coordinate h)
       : _bounds(bounds)
   {
     ARBORX_ASSERT(h > 0);
@@ -37,7 +35,7 @@ public:
       _h[d] = h;
     buildGrid();
   }
-  CartesianGrid(Box<DIM> const &bounds, float const h[DIM])
+  CartesianGrid(Box<DIM, Coordinate> const &bounds, Coordinate const h[DIM])
       : _bounds(bounds)
   {
     for (int d = 0; d < DIM; ++d)
@@ -80,7 +78,7 @@ public:
       max[d] = min[d] + (i + 1) * _h[d];
       min[d] += i * _h[d];
     }
-    return Box<DIM>{min, max};
+    return Box{min, max};
   }
 
   KOKKOS_FUNCTION
@@ -127,7 +125,7 @@ private:
     // run with a full NGSIM datasets, values below 3 could still produce wrong
     // results. This may still not be conservative enough, but all runs passed
     // verification when this warning was not triggered.
-    constexpr auto eps = 5 * std::numeric_limits<float>::epsilon();
+    constexpr auto eps = 5 * std::numeric_limits<Coordinate>::epsilon();
     for (int d = 0; d < DIM; ++d)
     {
       if (std::abs(_h[d] / min_corner[d]) < eps)
@@ -138,8 +136,8 @@ private:
     }
   }
 
-  Box<DIM> _bounds;
-  float _h[DIM];
+  Box<DIM, Coordinate> _bounds;
+  Coordinate _h[DIM];
   size_t _n[DIM];
 };
 

--- a/src/cluster/detail/ArborX_FDBSCANDenseBox.hpp
+++ b/src/cluster/detail/ArborX_FDBSCANDenseBox.hpp
@@ -30,20 +30,23 @@ template <typename MemorySpace, typename Primitives, typename DenseCellOffsets,
           typename Permutation>
 struct CountUpToN_DenseBox
 {
+  using Coordinate =
+      GeometryTraits::coordinate_type_t<typename Primitives::value_type>;
+
   Kokkos::View<int *, MemorySpace> _counts;
   Primitives _primitives;
   DenseCellOffsets _dense_cell_offsets;
   int _num_dense_cells;
   Permutation _permute;
   int core_min_size;
-  float eps;
+  Coordinate eps;
   int _n;
 
   CountUpToN_DenseBox(Kokkos::View<int *, MemorySpace> const &counts,
                       Primitives const &primitives,
                       DenseCellOffsets const &dense_cell_offsets,
                       Permutation const &permute, int core_min_size_in,
-                      float eps_in, int n)
+                      Coordinate eps_in, int n)
       : _counts(counts)
       , _primitives(primitives)
       , _dense_cell_offsets(dense_cell_offsets)
@@ -93,6 +96,9 @@ template <typename UnionFind, typename CorePointsType, typename Primitives,
           typename DenseCellOffsets, typename Permutation>
 struct FDBSCANDenseBoxCallback
 {
+  using Coordinate =
+      GeometryTraits::coordinate_type_t<typename Primitives::value_type>;
+
   UnionFind _union_find;
   CorePointsType _is_core_point;
   Primitives _primitives;
@@ -100,7 +106,7 @@ struct FDBSCANDenseBoxCallback
   int _num_dense_cells;
   int _num_points_in_dense_cells;
   Permutation _permute;
-  float eps;
+  Coordinate eps;
 
   template <typename ExecutionSpace>
   FDBSCANDenseBoxCallback(UnionFind const &union_find,
@@ -108,7 +114,7 @@ struct FDBSCANDenseBoxCallback
                           Primitives const &primitives,
                           DenseCellOffsets const &dense_cell_offsets,
                           ExecutionSpace const &exec_space,
-                          Permutation const &permute, float eps_in)
+                          Permutation const &permute, Coordinate eps_in)
       : _union_find(union_find)
       , _is_core_point(is_core_point)
       , _primitives(primitives)
@@ -182,11 +188,11 @@ struct FDBSCANDenseBoxCallback
 };
 
 template <typename ExecutionSpace, typename Primitives>
-Kokkos::View<size_t *, typename Primitives::memory_space>
-computeCellIndices(ExecutionSpace const &exec_space,
-                   Primitives const &primitives,
-                   CartesianGrid<GeometryTraits::dimension_v<
-                       typename Primitives::value_type>> const &grid)
+Kokkos::View<size_t *, typename Primitives::memory_space> computeCellIndices(
+    ExecutionSpace const &exec_space, Primitives const &primitives,
+    CartesianGrid<GeometryTraits::dimension_v<typename Primitives::value_type>,
+                  GeometryTraits::coordinate_type_t<
+                      typename Primitives::value_type>> const &grid)
 {
   using MemorySpace = typename Primitives::memory_space;
 

--- a/test/tstDBSCAN.cpp
+++ b/test/tstDBSCAN.cpp
@@ -44,7 +44,8 @@ BOOST_AUTO_TEST_SUITE(DBSCAN)
 BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
-  using Point = ArborX::Point<3>;
+  using Coordinate = float;
+  using Point = ArborX::Point<3, Coordinate>;
   using ArborX::Details::verifyDBSCAN;
 
   ExecutionSpace space;
@@ -52,13 +53,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
   {
     auto points = toView<DeviceType, Point>({{{0, 0, 0}}, {{1, 1, 1}}});
 
-    auto r = std::sqrt(3);
+    Coordinate r = std::sqrt(3);
 
-    BOOST_TEST(verifyDBSCAN(space, points, r - 0.1, 2,
+    BOOST_TEST(verifyDBSCAN(space, points, r - (Coordinate)0.1, 2,
                             toView<DeviceType, int>({-1, -1})));
-    BOOST_TEST(!verifyDBSCAN(space, points, r - 0.1, 2,
+    BOOST_TEST(!verifyDBSCAN(space, points, r - (Coordinate)0.1, 2,
                              toView<DeviceType, int>({1, 2})));
-    BOOST_TEST(!verifyDBSCAN(space, points, r - 0.1, 2,
+    BOOST_TEST(!verifyDBSCAN(space, points, r - (Coordinate)0.1, 2,
                              toView<DeviceType, int>({1, 1})));
     BOOST_TEST(
         verifyDBSCAN(space, points, r, 2, toView<DeviceType, int>({1, 1})));
@@ -74,9 +75,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
     auto points = toView<DeviceType, Point>(
         {{{0, 0, 0}}, {{1, 1, 1}}, {{3, 3, 3}}, {{6, 6, 6}}});
 
-    auto r = std::sqrt(3.f);
-    auto r2 = std::sqrt(12.f);
-    auto r3 = std::sqrt(48.f);
+    Coordinate r = std::sqrt(3);
+    Coordinate r2 = std::sqrt(12);
+    Coordinate r3 = std::sqrt(48);
 
     BOOST_TEST(verifyDBSCAN(space, points, r, 2,
                             toView<DeviceType, int>({1, 1, -1, -1})));
@@ -154,9 +155,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
 BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
 {
   using ExecutionSpace = typename DeviceType::execution_space;
+  using Coordinate = float;
   using ArborX::dbscan;
   using ArborX::Details::verifyDBSCAN;
-  using Point = ArborX::Point<3>;
+  using Point = ArborX::Point<3, Coordinate>;
 
   ExecutionSpace space;
 
@@ -168,10 +170,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
     {
       auto points = toView<DeviceType, Point>({{{0, 0, 0}}, {{1, 1, 1}}});
 
-      auto r = std::sqrt(3.1f);
+      Coordinate r = std::sqrt(3.1);
 
-      BOOST_TEST(verifyDBSCAN(space, points, r - 0.1, 2,
-                              dbscan(space, points, r - 0.1, 2, params)));
+      BOOST_TEST(
+          verifyDBSCAN(space, points, r - (Coordinate)0.1, 2,
+                       dbscan(space, points, r - (Coordinate)0.1, 2, params)));
       BOOST_TEST(verifyDBSCAN(space, points, r, 2,
                               dbscan(space, points, r, 2, params)));
       BOOST_TEST(verifyDBSCAN(space, points, r, 3,
@@ -179,9 +182,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
 
       // Test non-View primitives
       HiddenView<decltype(points)> hidden_points{points};
-      BOOST_TEST(
-          verifyDBSCAN(space, hidden_points, r - 0.1, 2,
-                       dbscan(space, hidden_points, r - 0.1, 2, params)));
+      BOOST_TEST(verifyDBSCAN(
+          space, hidden_points, r - (Coordinate)0.1, 2,
+          dbscan(space, hidden_points, r - (Coordinate)0.1, 2, params)));
       BOOST_TEST(verifyDBSCAN(space, hidden_points, r, 2,
                               dbscan(space, hidden_points, r, 2, params)));
       BOOST_TEST(verifyDBSCAN(space, hidden_points, r, 3,
@@ -192,7 +195,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
       auto points = toView<DeviceType, Point>(
           {{{0, 0, 0}}, {{1, 1, 1}}, {{3, 3, 3}}, {{6, 6, 6}}});
 
-      auto r = std::sqrt(3.1f);
+      Coordinate r = std::sqrt(3.1);
 
       BOOST_TEST(verifyDBSCAN(space, points, r, 2,
                               dbscan(space, points, r, 2, params)));
@@ -227,9 +230,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
                                                {{1, -0.5, 0}}});
 
       BOOST_TEST(verifyDBSCAN(space, points, 1.0, 3,
-                              dbscan(space, points, 1, 3, params)));
+                              dbscan(space, points, (Coordinate)1, 3, params)));
       BOOST_TEST(verifyDBSCAN(space, points, 1.0, 4,
-                              dbscan(space, points, 1, 4, params)));
+                              dbscan(space, points, (Coordinate)1, 4, params)));
     }
   }
 
@@ -256,7 +259,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
 
     // This does *not* guarantee to trigger the issue, as it depends on the
     // specific implementation and runtime. But it may.
-    BOOST_TEST(verifyDBSCAN(space, points, 1, 4, dbscan(space, points, 1, 4)));
+    BOOST_TEST(verifyDBSCAN(space, points, (Coordinate)1, 4,
+                            dbscan(space, points, (Coordinate)1, 4)));
   }
 }
 

--- a/test/tstDBSCAN.cpp
+++ b/test/tstDBSCAN.cpp
@@ -41,10 +41,10 @@ using ArborXTest::toView;
 
 BOOST_AUTO_TEST_SUITE(DBSCAN)
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
+template <typename DeviceType, typename Coordinate>
+void dbscan_verifier_f()
 {
   using ExecutionSpace = typename DeviceType::execution_space;
-  using Coordinate = float;
   using Point = ArborX::Point<3, Coordinate>;
   using ArborX::Details::verifyDBSCAN;
 
@@ -152,10 +152,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
   }
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
+template <typename DeviceType, typename Coordinate>
+void dbscan_f()
 {
   using ExecutionSpace = typename DeviceType::execution_space;
-  using Coordinate = float;
   using ArborX::dbscan;
   using ArborX::Details::verifyDBSCAN;
   using Point = ArborX::Point<3, Coordinate>;
@@ -262,6 +262,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
     BOOST_TEST(verifyDBSCAN(space, points, (Coordinate)1, 4,
                             dbscan(space, points, (Coordinate)1, 4)));
   }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan_verifier, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  dbscan_verifier_f<DeviceType, float>();
+  dbscan_verifier_f<DeviceType, double>();
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(dbscan, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  dbscan_f<DeviceType, float>();
+  dbscan_f<DeviceType, double>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Change internals of DBSCAN to be precision-agnostic
- Change DBSCAN test to run both float and double