### PR TITLE
Add segment-segment intersection (2D only)

### DIFF
--- a/src/geometry/ArborX_Segment.hpp
+++ b/src/geometry/ArborX_Segment.hpp
@@ -22,8 +22,8 @@ namespace ArborX::Experimental
 template <int DIM, typename Coordinate = float>
 struct Segment
 {
-  ArborX::Point<DIM, Coordinate> _start;
-  ArborX::Point<DIM, Coordinate> _end;
+  ArborX::Point<DIM, Coordinate> a;
+  ArborX::Point<DIM, Coordinate> b;
 };
 
 template <int DIM, typename Coordinate>

--- a/src/geometry/algorithms/ArborX_Centroid.hpp
+++ b/src/geometry/algorithms/ArborX_Centroid.hpp
@@ -119,7 +119,7 @@ struct centroid<SegmentTag, Segment>
     // WARNING implicit requirement on KDOP first DIM directions
     Point<DIM, Coordinate> point;
     for (int d = 0; d < DIM; ++d)
-      point[d] = (segment._start[d] + segment._end[d]) / 2;
+      point[d] = (segment.a[d] + segment.b[d]) / 2;
     return point;
   }
 };

--- a/src/geometry/algorithms/ArborX_Distance.hpp
+++ b/src/geometry/algorithms/ArborX_Distance.hpp
@@ -255,20 +255,20 @@ struct distance<PointTag, SegmentTag, Point, Segment>
     constexpr int DIM = GeometryTraits::dimension_v<Point>;
     using Coordinate = GeometryTraits::coordinate_type_t<Point>;
 
-    if (Details::equals(segment._start, segment._end))
-      return Details::distance(point, segment._start);
+    if (Details::equals(segment.a, segment.b))
+      return Details::distance(point, segment.a);
 
-    auto const dir = segment._end - segment._start;
+    auto const dir = segment.b - segment.a;
 
     // The line of the segment [a,b] is parametrized as a + t * (b - a).
     // Find the projection of the point to that line, and clamp it.
     auto t =
-        Kokkos::clamp(dir.dot(point - segment._start) / dir.dot(dir),
+        Kokkos::clamp(dir.dot(point - segment.a) / dir.dot(dir),
                       static_cast<Coordinate>(0), static_cast<Coordinate>(1));
 
     Point projection;
     for (int d = 0; d < DIM; ++d)
-      projection[d] = segment._start[d] + t * dir[d];
+      projection[d] = segment.a[d] + t * dir[d];
 
     return Details::distance(point, projection);
   }

--- a/src/geometry/algorithms/ArborX_Expand.hpp
+++ b/src/geometry/algorithms/ArborX_Expand.hpp
@@ -230,8 +230,8 @@ struct expand<BoxTag, SegmentTag, Box, Segment>
 {
   KOKKOS_FUNCTION static void apply(Box &box, Segment const &segment)
   {
-    Details::expand(box, segment._start);
-    Details::expand(box, segment._end);
+    Details::expand(box, segment.a);
+    Details::expand(box, segment.b);
   }
 };
 

--- a/test/tstDetailsAlgorithms.cpp
+++ b/test/tstDetailsAlgorithms.cpp
@@ -313,6 +313,20 @@ BOOST_AUTO_TEST_CASE(intersects)
   BOOST_TEST(!intersects(Point{0, 0, 1.1}, tet));
   BOOST_TEST(!intersects(Point{0.5, 0.5, 0.5}, tet));
   BOOST_TEST(!intersects(Point{-0.5, 0.5, 0.5}, tet));
+
+  // segment
+  using Segment2 = ArborX::Experimental::Segment<2>;
+  constexpr Segment2 seg{{1, 1}, {2, 2}};
+  BOOST_TEST(intersects(Segment2{{2, 2}, {3, 3}}, seg));
+  BOOST_TEST(intersects(Segment2{{1.5, 1.5}, {1.7, 1.7}}, seg));
+  BOOST_TEST(intersects(Segment2{{0, 0}, {1, 1}}, seg));
+  BOOST_TEST(intersects(Segment2{{1, 2}, {2, 1}}, seg));
+  BOOST_TEST(intersects(Segment2{{2, 0}, {0, 2}}, seg));
+  BOOST_TEST(intersects(Segment2{{1, 3}, {3, 1}}, seg));
+  BOOST_TEST(!intersects(Segment2{{0, 0}, {0.9, 0.9}}, seg));
+  BOOST_TEST(!intersects(Segment2{{1.1, 1}, {2, 1}}, seg));
+  BOOST_TEST(!intersects(Segment2{{1, 0}, {2, 1}}, seg));
+  BOOST_TEST(!intersects(Segment2{{1, 3}, {3, 1.1}}, seg));
 }
 
 BOOST_AUTO_TEST_CASE(equals)


### PR DESCRIPTION
- Rename `segment.{_start,_end}` to `segment.{a,b}`
- Add 2D segment-segment intersection