### PR TITLE
Decrease number of procs used to build ArborX in the nightly

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -150,7 +150,7 @@ pipeline {
                         sh 'cmake --build build-kokkos --parallel 7'
                         sh 'cmake --install build-kokkos'
                         sh 'cmake -B build-arborx -D CMAKE_INSTALL_PREFIX=$PWD/install-arborx -D Kokkos_ROOT=$PWD/install-kokkos $CMAKE_OPTIONS -D ARBORX_ENABLE_BENCHMARKS=ON -D ARBORX_ENABLE_TESTS=ON -D ARBORX_ENABLE_EXAMPLES=ON'
-                        sh 'cmake --build build-arborx --parallel 7'
+                        sh 'cmake --build build-arborx --parallel 4'
                         dir('build-arborx') {
                             sh 'ctest $CTEST_OPTIONS'
                         }


### PR DESCRIPTION
The nightly randomly fails on GCC 14. Decreasing the number of processors to see if that fixes the issue.