### PR TITLE
Remove requirement on knowing geometry types in IndexableGetter

### DIFF
--- a/src/spatial/detail/ArborX_IndexableGetter.hpp
+++ b/src/spatial/detail/ArborX_IndexableGetter.hpp
@@ -27,29 +27,30 @@ struct DefaultIndexableGetter
   KOKKOS_DEFAULTED_FUNCTION
   DefaultIndexableGetter() = default;
 
-  template <typename Geometry, typename Enable = std::enable_if_t<
-                                   GeometryTraits::is_valid_geometry<Geometry>>>
+  template <typename Geometry>
   KOKKOS_FUNCTION auto const &operator()(Geometry const &geometry) const
   {
     return geometry;
   }
 
-  template <typename Geometry, typename Enable = std::enable_if_t<
-                                   GeometryTraits::is_valid_geometry<Geometry>>>
+  template <typename Geometry,
+            typename Enable = std::enable_if_t<
+                !Details::is_pair_value_index_v<std::decay_t<Geometry>>>>
   KOKKOS_FUNCTION auto operator()(Geometry &&geometry) const
   {
     return geometry;
   }
 
-  template <typename Value, typename Index>
-  KOKKOS_FUNCTION Value const &
-  operator()(PairValueIndex<Value, Index> const &pair) const
+  template <typename Geometry, typename Index>
+  KOKKOS_FUNCTION Geometry const &
+  operator()(PairValueIndex<Geometry, Index> const &pair) const
   {
     return pair.value;
   }
 
-  template <typename Value, typename Index>
-  KOKKOS_FUNCTION Value operator()(PairValueIndex<Value, Index> &&pair) const
+  template <typename Geometry, typename Index>
+  KOKKOS_FUNCTION Geometry
+  operator()(PairValueIndex<Geometry, Index> &&pair) const
   {
     return pair.value;
   }

--- a/src/spatial/detail/ArborX_PairValueIndex.hpp
+++ b/src/spatial/detail/ArborX_PairValueIndex.hpp
@@ -31,6 +31,21 @@ struct PairValueIndex
   Index index;
 };
 
+namespace Details
+{
+template <typename T>
+struct is_pair_value_index : public std::false_type
+{};
+
+template <typename Value, typename Index>
+struct is_pair_value_index<PairValueIndex<Value, Index>> : public std::true_type
+{};
+
+template <typename T>
+inline constexpr bool is_pair_value_index_v = is_pair_value_index<T>::value;
+
+} // namespace Details
+
 } // namespace ArborX
 
 #endif

--- a/test/tstCompileOnlyTypeRequirements.cpp
+++ b/test/tstCompileOnlyTypeRequirements.cpp
@@ -91,3 +91,37 @@ void check_bounding_volume_and_predicate_geometry_type_requirements()
              KOKKOS_LAMBDA(NearestPredicate, auto){});
 #endif
 }
+
+namespace Test
+{
+
+// clang-format off
+struct FakePrimitiveGeometry {};
+
+KOKKOS_FUNCTION void expand(ArborX::Box<3> &, FakePrimitiveGeometry) {}
+KOKKOS_FUNCTION ArborX::Point<3> returnCentroid(FakePrimitiveGeometry) { return {}; }
+// clang-format on
+
+} // namespace Test
+
+template <>
+struct ArborX::GeometryTraits::dimension<Test::FakePrimitiveGeometry>
+{
+  static constexpr int value = 3;
+};
+template <>
+struct ArborX::GeometryTraits::coordinate_type<Test::FakePrimitiveGeometry>
+{
+  using type = float;
+};
+
+// Compile-only
+void check_hierarchy_for_custom_types()
+{
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using MemorySpace = ExecutionSpace::memory_space;
+
+  Kokkos::View<Test::FakePrimitiveGeometry *, MemorySpace> primitives(
+      "primitives", 0);
+  ArborX::BoundingVolumeHierarchy tree(ExecutionSpace{}, primitives);
+}


### PR DESCRIPTION
In the current iteration, if a user has a custom geometry type that they try to build hierarchy on, it has to be tagged with one of the ArborX tags, which would call ArborX routines. This patch relaxes this requirement. Now, a user only needs to specify dimension and coordinate type.

I added a compile-only test that shows the requirements.