### PR TITLE
Require C++20

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,33 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,-performance-noexcept-swap,-performance-inefficient-string-concatenation,mpi-*,modernize-*,-modernize-pass-by-value,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard,-modernize-concat-nested-namespaces,readability-*,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-function-cognitive-complexity,-readability-redundant-string-cstr,-readability-inconsistent-declaration-parameter-name'
+Checks: >
+  -*,
+  clang-analyzer-*,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
+  -clang-analyzer-deadcode.DeadStores,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-security.insecureAPI.strcpy,
+  clang-diagnostic-*,
+  modernize-*,
+  -modernize-avoid-c-arrays,
+  -modernize-concat-nested-namespaces,
+  -modernize-pass-by-value,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  mpi-*,
+  performance-*,
+  -performance-inefficient-string-concatenation,
+  -performance-noexcept-swap,
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-inconsistent-declaration-parameter-name,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-redundant-string-cstr,
+  -readability-uppercase-literal-suffix,
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -98,12 +98,12 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-12.8.0-NVCC') {
+                stage('CUDA-12.8.1-NVCC') {
                     agent {
                         dockerfile {
                             filename "Dockerfile.nvcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.8.0-devel-ubuntu22.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.8.1-devel-ubuntu24.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -158,70 +158,70 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-12.5.1-Clang') {
-                    agent {
-                        dockerfile {
-                            filename "Dockerfile"
-                            dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.5.1-devel-ubuntu24.04 --build-arg KOKKOS_VERSION="4.5.00" --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
-                            args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
-                            label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
-                        }
-                    }
-                    steps {
-                        sh 'ccache --zero-stats'
-                        sh 'rm -rf build && mkdir -p build'
-                        dir('build') {
-                            sh '''
-                                cmake \
-                                    -D CMAKE_INSTALL_PREFIX=$ARBORX_DIR \
-                                    -D CMAKE_BUILD_TYPE=Debug \
-                                    -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                                    -D CMAKE_CXX_COMPILER=clang++ \
-                                    -D CMAKE_CXX_EXTENSIONS=OFF \
-                                    -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra" \
-                                    -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
-                                    -D ARBORX_ENABLE_MPI=OFF \
-                                    -D ARBORX_ENABLE_TESTS=ON \
-                                    -D ARBORX_ENABLE_EXAMPLES=ON \
-                                    -D ARBORX_ENABLE_BENCHMARKS=ON \
-                                ..
-                            '''
-                            sh 'make -j8 VERBOSE=1'
-                            sh 'ctest $CTEST_OPTIONS'
-                        }
-                    }
-                    post {
-                        always {
-                            sh 'ccache --show-stats'
-                            xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-                        }
-                        success {
-                            sh 'cd build && make install'
-                            sh 'rm -rf test_install && mkdir -p test_install'
-                            dir('test_install') {
-                                sh 'cp -r ../examples .'
-                                sh '''
-                                    cmake \
-                                        -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                                        -D CMAKE_CXX_COMPILER=clang++ \
-                                        -D CMAKE_CXX_EXTENSIONS=OFF \
-                                        -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
-                                    examples \
-                                '''
-                                sh 'make VERBOSE=1'
-                                sh 'make test'
-                            }
-                        }
-                    }
-                }
+                // stage('CUDA-12.8.1-Clang') {
+                    // agent {
+                        // dockerfile {
+                            // filename "Dockerfile"
+                            // dir "docker"
+                            // additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.8.1-devel-ubuntu24.04 --build-arg ADDITIONAL_PACKAGES="clang-19" --build-arg KOKKOS_VERSION="4.5.00" --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++-19 -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            // args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
+                            // label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+                        // }
+                    // }
+                    // steps {
+                        // sh 'ccache --zero-stats'
+                        // sh 'rm -rf build && mkdir -p build'
+                        // dir('build') {
+                            // sh '''
+                                // cmake \
+                                    // -D CMAKE_INSTALL_PREFIX=$ARBORX_DIR \
+                                    // -D CMAKE_BUILD_TYPE=Debug \
+                                    // -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                                    // -D CMAKE_CXX_COMPILER=clang++-19 \
+                                    // -D CMAKE_CXX_EXTENSIONS=OFF \
+                                    // -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra" \
+                                    // -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
+                                    // -D ARBORX_ENABLE_MPI=OFF \
+                                    // -D ARBORX_ENABLE_TESTS=ON \
+                                    // -D ARBORX_ENABLE_EXAMPLES=ON \
+                                    // -D ARBORX_ENABLE_BENCHMARKS=ON \
+                                // ..
+                            // '''
+                            // sh 'make -j8 VERBOSE=1'
+                            // sh 'ctest $CTEST_OPTIONS'
+                        // }
+                    // }
+                    // post {
+                        // always {
+                            // sh 'ccache --show-stats'
+                            // xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+                        // }
+                        // success {
+                            // sh 'cd build && make install'
+                            // sh 'rm -rf test_install && mkdir -p test_install'
+                            // dir('test_install') {
+                                // sh 'cp -r ../examples .'
+                                // sh '''
+                                    // cmake \
+                                        // -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                                        // -D CMAKE_CXX_COMPILER=clang++-19 \
+                                        // -D CMAKE_CXX_EXTENSIONS=OFF \
+                                        // -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
+                                    // examples \
+                                // '''
+                                // sh 'make VERBOSE=1'
+                                // sh 'make test'
+                            // }
+                        // }
+                    // }
+                // }
 
                 stage('Clang') {
                     agent {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=ubuntu:22.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=ubuntu:22.04 --build-arg ADDITIONAL_PACKAGES="clang clang-tidy" --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                         }
@@ -281,7 +281,10 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=gcc:13.3 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            // We use gfortran- to avoid problems with openmpi
+                            // when using gcc images. See
+                            // https://github.com/docker-library/gcc/issues/57
+                            additionalBuildArgs '--build-arg BASE=gcc:13.3 --build-arg ADDITIONAL_PACKAGES="gfortran-" --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                         }

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -346,7 +346,7 @@ pipeline {
                             dir "docker"
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.6 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES} --env AMDGPU_TARGET=${AMDGPU_TARGET}'
-                            label 'rocm-docker && AMD_Radeon_Instinct_MI210'
+                            label 'rocm-docker'
                         }
                     }
                     steps {

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -98,12 +98,12 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-12.8.1-NVCC') {
+                stage('CUDA-12.8.0-NVCC') {
                     agent {
                         dockerfile {
                             filename "Dockerfile.nvcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.8.1-devel-ubuntu24.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.8.0-devel-ubuntu22.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -37,12 +37,12 @@ pipeline {
 
         stage('Build') {
             parallel {
-                stage('CUDA-11.5.2-NVCC-CUDA-AWARE-MPI') {
+                stage('CUDA-12.0.1-NVCC-CUDA-AWARE-MPI') {
                     agent {
                         dockerfile {
-                            filename "Dockerfile"
+                            filename "Dockerfile.nvcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.5.2-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.5.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON" --build-arg CUDA_AWARE_MPI=1'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.0.1-devel-ubuntu22.04 --build-arg KOKKOS_VERSION=4.5.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON" --build-arg CUDA_AWARE_MPI=1'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -86,7 +86,7 @@ pipeline {
                                 sh '''
                                     cmake \
                                         -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                                        -D CMAKE_CXX_COMPILER=$KOKKOS_DIR/bin/nvcc_wrapper \
+                                        -D CMAKE_CXX_COMPILER=nvcc_wrapper \
                                         -D CMAKE_CXX_EXTENSIONS=OFF \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
                                         -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
@@ -98,12 +98,12 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-11.7.1-NVCC') {
+                stage('CUDA-12.8.0-NVCC') {
                     agent {
                         dockerfile {
-                            filename "Dockerfile"
+                            filename "Dockerfile.nvcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.7.1-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.8.0-devel-ubuntu22.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -146,7 +146,7 @@ pipeline {
                                 sh '''
                                     cmake \
                                         -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                                        -D CMAKE_CXX_COMPILER=$KOKKOS_DIR/bin/nvcc_wrapper \
+                                        -D CMAKE_CXX_COMPILER=nvcc_wrapper \
                                         -D CMAKE_CXX_EXTENSIONS=OFF \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
                                         -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
@@ -158,12 +158,12 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-11.0.3-Clang') {
+                stage('CUDA-12.5.1-Clang') {
                     agent {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.0.3-devel-ubuntu18.04 --build-arg KOKKOS_VERSION="4.5.00" --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=clang++ -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:12.5.1-devel-ubuntu24.04 --build-arg KOKKOS_VERSION="4.5.00" --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -221,7 +221,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=ubuntu:18.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=ubuntu:22.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                         }
@@ -236,7 +236,6 @@ pipeline {
                                     -D CMAKE_BUILD_TYPE=Debug \
                                     -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                     -D CMAKE_CXX_COMPILER=clang++ \
-                                    -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra" \
                                     -D CMAKE_CXX_CLANG_TIDY="$LLVM_DIR/bin/clang-tidy;-warnings-as-errors=*" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
@@ -266,7 +265,6 @@ pipeline {
                                     cmake \
                                         -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                         -D CMAKE_CXX_COMPILER=clang++ \
-                                        -D CMAKE_CXX_EXTENSIONS=OFF \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
                                         -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
                                     examples \
@@ -278,12 +276,12 @@ pipeline {
                     }
                 }
 
-                stage('GCC-12.2') {
+                stage('GCC-13.3') {
                     agent {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=gcc:12.2.0 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_CXX_COMPILER=g++ -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=gcc:13.3 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                         }
@@ -298,7 +296,6 @@ pipeline {
                                     -D CMAKE_BUILD_TYPE=Debug \
                                     -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                     -D CMAKE_CXX_COMPILER=g++ \
-                                    -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
@@ -327,7 +324,6 @@ pipeline {
                                     cmake \
                                         -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                         -D CMAKE_CXX_COMPILER=g++ \
-                                        -D CMAKE_CXX_EXTENSIONS=OFF \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
                                         -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
                                     examples \
@@ -359,7 +355,6 @@ pipeline {
                                     -D CMAKE_BUILD_TYPE=Debug \
                                     -D CMAKE_CXX_COMPILER=hipcc \
                                     -D CMAKE_CXX_STANDARD=20 \
-                                    -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-DNDEBUG -Wpedantic -Wall -Wextra" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
@@ -391,7 +386,6 @@ pipeline {
                                         -D CMAKE_EXE_LINKER_FLAGS="-lopen-pal" \
                                         -D GPU_TARGETS=${AMDGPU_TARGET} \
                                         -D CMAKE_CXX_COMPILER=hipcc \
-                                        -D CMAKE_CXX_EXTENSIONS=OFF \
                                         -D CMAKE_CXX_STANDARD=20 \
                                         -D CMAKE_BUILD_TYPE=RelWithDebInfo \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
@@ -424,7 +418,6 @@ pipeline {
                                     -D CMAKE_INSTALL_PREFIX=$ARBORX_DIR \
                                     -D CMAKE_BUILD_TYPE=Release \
                                     -D CMAKE_CXX_COMPILER=${DPCPP} \
-                                    -D CMAKE_CXX_EXTENSIONS=OFF \
                                     -D CMAKE_CXX_FLAGS="-fp-model=precise -fsycl-device-code-split=per_kernel -Wpedantic -Wall -Wextra -Wno-sycl-target -Wno-unknown-cuda-version -Wno-deprecated-declarations" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR;$ONE_DPL_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
@@ -454,7 +447,6 @@ pipeline {
                                     cmake \
                                         -D CMAKE_BUILD_TYPE=Release \
                                         -D CMAKE_CXX_COMPILER=${DPCPP} \
-                                        -D CMAKE_CXX_EXTENSIONS=OFF \
                                         -D CMAKE_CXX_FLAGS="-Wno-sycl-target -Wno-unknown-cuda-version -Wno-deprecated-declarations" \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
                                         -D MPIEXEC_PREFLAGS="--allow-run-as-root" \

--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -8,16 +8,16 @@ pipeline {
 
         stage('Build') {
             parallel {
-                stage('CUDA-11.7.1') {
+                stage('CUDA-12.4.1') {
                     agent {
                         docker {
-                            image 'nvidia/cuda:11.7.1-devel-ubuntu22.04'
+                            image 'nvidia/cuda:12.4.1-devel-ubuntu22.04'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
                     }
                     environment {
                         CTEST_OPTIONS = '--timeout 180 --no-compress-output -T Test'
-                        CMAKE_OPTIONS = '-D CMAKE_BUILD_TYPE=Release -D CMAKE_CXX_STANDARD=17 -D CMAKE_CXX_EXTENSIONS=OFF'
+                        CMAKE_OPTIONS = '-D CMAKE_BUILD_TYPE=Release -D CMAKE_CXX_STANDARD=20 -D CMAKE_CXX_EXTENSIONS=OFF'
                     }
                     steps {
                         sh 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git cmake libboost-program-options-dev libboost-test-dev libbenchmark-dev'
@@ -48,16 +48,16 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-12.2.0-MPI') {
+                stage('CUDA-12.2.2-MPI') {
                     agent {
                         docker {
-                            image 'nvidia/cuda:12.2.0-devel-ubuntu22.04'
+                            image 'nvidia/cuda:12.2.2-devel-ubuntu22.04'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
                     }
                     environment {
                         CTEST_OPTIONS = '--timeout 180 --no-compress-output -T Test'
-                        CMAKE_OPTIONS = '-D CMAKE_BUILD_TYPE=Release -D CMAKE_CXX_STANDARD=17 -D CMAKE_CXX_EXTENSIONS=OFF'
+                        CMAKE_OPTIONS = '-D CMAKE_BUILD_TYPE=Release -D CMAKE_CXX_STANDARD=20 -D CMAKE_CXX_EXTENSIONS=OFF'
                     }
                     steps {
                         sh 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git cmake libboost-program-options-dev libboost-test-dev libbenchmark-dev libopenmpi-dev'
@@ -98,7 +98,7 @@ pipeline {
                     }
                     environment {
                         CTEST_OPTIONS = '--timeout 180 --no-compress-output -T Test'
-                        CMAKE_OPTIONS = '-D CMAKE_BUILD_TYPE=Release -D CMAKE_CXX_STANDARD=17 -D CMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=hipcc -DCMAKE_PREFIX_PATH=/opt/rocm'
+                        CMAKE_OPTIONS = '-D CMAKE_BUILD_TYPE=Release -D CMAKE_CXX_STANDARD=20 -D CMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=hipcc -DCMAKE_PREFIX_PATH=/opt/rocm'
                     }
                     steps {
                         sh 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git cmake libboost-program-options-dev libboost-test-dev libbenchmark-dev'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 add_library(ArborX INTERFACE)
 target_link_libraries(ArborX INTERFACE Kokkos::kokkos)
-set_target_properties(ArborX PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
+set_target_properties(ArborX PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_20)
 # As all executables using ArborX depend on it, depending on record_hash allows
 # updating hash each time executable is rebuilt, including when called from
 # within a subdirectory.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,26 +1,26 @@
-ARG BASE=nvidia/cuda:11.0.3-devel-ubuntu18.04
+ARG BASE=ubuntu:22.04
 FROM $BASE
 
 ARG NPROCS=4
 
-RUN if test ${NV_CUDA_LIB_VERSION}; then apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub; fi
-
+# We use gfortran- to avoid problems with openmpi when using gcc images
+# See https://github.com/docker-library/gcc/issues/57
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
         build-essential \
-        bc \
-        curl \
-        git \
-        wget \
-        jq \
-        vim \
-        lcov \
         ccache \
-        gdb \
-        ninja-build \
-        libbz2-dev \
-        libicu-dev \
-        python-dev \
-        autotools-dev \
+        cmake \
+        clang \
+        clang-tidy \
+        curl \
+        gfortran- \
+        git \
+        libomp-dev \
+        libopenmpi-dev \
+        libbenchmark-dev \
+        libboost-program-options-dev \
+        libboost-test-dev \
+        vim \
+        wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -33,115 +33,18 @@ RUN KEYDUMP_URL=https://cloud1.cees.ornl.gov/download && \
     gpg --verify ${KEYDUMP_FILE}.sig ${KEYDUMP_FILE} && \
     rm ${KEYDUMP_FILE}*
 
-# Install CMake
-ENV CMAKE_DIR=/opt/cmake
-RUN CMAKE_VERSION=3.22.6 && \
-    CMAKE_KEY=2D2CEF1034921684 && \
-    CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
-    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
-    CMAKE_SHA256=cmake-${CMAKE_VERSION}-SHA-256.txt && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256} && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256}.asc && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SCRIPT} && \
-    gpg --verify ${CMAKE_SHA256}.asc ${CMAKE_SHA256} && \
-    grep -i ${CMAKE_SCRIPT} ${CMAKE_SHA256} | sed -e s/linux/Linux/ | sha256sum --check && \
-    mkdir -p ${CMAKE_DIR} && \
-    sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
-    rm cmake*
-ENV PATH=${CMAKE_DIR}/bin:$PATH
-
-# Install Clang/LLVM
-ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=14.0.0 && \
-    LLVM_KEY="86419D8A 345AD05D" && \
-    LLVM_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
-    LLVM_ARCHIVE=llvm-${LLVM_VERSION}.tar.xz && \
-    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
-    wget --quiet ${LLVM_URL} --output-document=${LLVM_ARCHIVE} && \
-    wget --quiet ${LLVM_URL}.sig --output-document=${LLVM_ARCHIVE}.sig && \
-    gpg --verify ${LLVM_ARCHIVE}.sig ${LLVM_ARCHIVE} && \
-    mkdir -p ${LLVM_DIR} && \
-    tar -xvf ${LLVM_ARCHIVE} -C ${LLVM_DIR} --strip-components=1 && \
-    echo "${LLVM_DIR}/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig && \
-    rm -rf ${SCRATCH_DIR}
-ENV PATH=${LLVM_DIR}/bin:$PATH
-
-# Install OpenMPI
-ARG CUDA_AWARE_MPI
-ENV OPENMPI_DIR=/opt/openmpi
-RUN OPENMPI_VERSION=4.1.3 && \
-    OPENMPI_VERSION_SHORT=$(echo "$OPENMPI_VERSION" | cut -d. -f1,2) && \
-    OPENMPI_SHA1=be3ebb8df076677889198b73b0b033b956c3d88b && \
-    OPENMPI_URL=https://download.open-mpi.org/release/open-mpi/v${OPENMPI_VERSION_SHORT}/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
-    OPENMPI_ARCHIVE=openmpi-${OPENMPI_VERSION}.tar.bz2 && \
-    CUDA_OPTIONS=${CUDA_AWARE_MPI:+--with-cuda} && \
-    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
-    wget --quiet ${OPENMPI_URL} --output-document=${OPENMPI_ARCHIVE} && \
-    echo "${OPENMPI_SHA1} ${OPENMPI_ARCHIVE}" | sha1sum -c && \
-    mkdir -p openmpi && \
-    tar -xf ${OPENMPI_ARCHIVE} -C openmpi --strip-components=1 && \
-    mkdir -p build && cd build && \
-    ../openmpi/configure --prefix=${OPENMPI_DIR} ${CUDA_OPTIONS} CFLAGS=-w && \
-    make -j${NPROCS} install && \
-    rm -rf ${SCRATCH_DIR}
-ENV PATH=${OPENMPI_DIR}/bin:$PATH
-
-# Install Boost
-ENV BOOST_DIR=/opt/boost
-RUN BOOST_VERSION=1.75.0 && \
-    BOOST_VERSION_UNDERSCORE=$(echo "$BOOST_VERSION" | sed -e "s/\./_/g") && \
-    BOOST_KEY=379CE192D401AB61 && \
-    BOOST_URL=https://archives.boost.io/release/${BOOST_VERSION}/source && \
-    BOOST_ARCHIVE=boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2 && \
-    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
-    wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE} && \
-    wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE}.asc && \
-    wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE}.json && \
-    wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE}.json.asc && \
-    gpg --verify ${BOOST_ARCHIVE}.json.asc ${BOOST_ARCHIVE}.json && \
-    gpg --verify ${BOOST_ARCHIVE}.asc ${BOOST_ARCHIVE} && \
-    cat ${BOOST_ARCHIVE}.json | jq -r '. | .sha256 + "  " + .file' | sha256sum --check && \
-    mkdir -p boost && \
-    tar -xf ${BOOST_ARCHIVE} -C boost --strip-components=1 && \
-    cd boost && \
-    CXXFLAGS="-w" ./bootstrap.sh \
-        --prefix=${BOOST_DIR} \
-        && \
-    echo "using mpi ;" >> project-config.jam && \
-    ./b2 -j${NPROCS} \
-        hardcode-dll-paths=true dll-path=${BOOST_DIR}/lib \
-        link=shared \
-        variant=release \
-        cxxflags=-w \
-        install \
-        && \
-    rm -rf ${SCRATCH_DIR}
-
-# Install Google Benchmark support library
-ENV BENCHMARK_DIR=/opt/benchmark
-RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
-    git clone https://github.com/google/benchmark.git -b v1.6.1 && \
-    cd benchmark && \
-    mkdir build && cd build && \
-    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${BENCHMARK_DIR} -D BENCHMARK_ENABLE_TESTING=OFF .. && \
-    make -j${NPROCS} && make install && \
-    rm -rf ${SCRATCH_DIR}
-
-# Workaround for Kokkos to find libcudart
-ENV LD_LIBRARY_PATH=/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}
-
 # Install Kokkos
 ARG KOKKOS_VERSION=4.5.00
-ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON"
+ARG KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
-    KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \
+    KOKKOS_ARCHIVE=kokkos-${KOKKOS_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${KOKKOS_URL} --output-document=${KOKKOS_ARCHIVE} && \
     mkdir -p kokkos && \
     tar -xf ${KOKKOS_ARCHIVE} -C kokkos --strip-components=1 && \
     cd kokkos && \
     mkdir -p build && cd build && \
-    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${KOKKOS_DIR} -D CMAKE_CXX_COMPILER=/scratch/kokkos/bin/nvcc_wrapper ${KOKKOS_OPTIONS} .. && \
+    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${KOKKOS_DIR} ${KOKKOS_OPTIONS} .. && \
     make -j${NPROCS} install && \
     rm -rf ${SCRATCH_DIR}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,16 +3,13 @@ FROM $BASE
 
 ARG NPROCS=4
 
-# We use gfortran- to avoid problems with openmpi when using gcc images
-# See https://github.com/docker-library/gcc/issues/57
+ARG ADDITIONAL_PACKAGES=""
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+        ${ADDITIONAL_PACKAGES} \
         build-essential \
         ccache \
         cmake \
-        clang \
-        clang-tidy \
         curl \
-        gfortran- \
         git \
         libomp-dev \
         libopenmpi-dev \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -3,24 +3,19 @@ FROM $BASE
 
 ARG NPROCS=4
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-        build-essential \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -yq \
         bc \
-        curl \
-        git \
-        kmod \
-        wget \
-        jq \
-        vim \
-        gdb \
+        build-essential \
         ccache \
-        libbz2-dev \
-        libicu-dev \
-        python-dev \
-        autotools-dev \
+        curl \
+        gdb \
+        git \
+        jq \
         libopenmpi-dev \
+        ninja-build \
         rocthrust \
+        vim \
+        wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -90,10 +85,10 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 
 # Install Kokkos
 ARG KOKKOS_VERSION=4.5.00
-ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_OPENMP=ON"
+ARG KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_OPENMP=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
-    KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \
+    KOKKOS_ARCHIVE=kokkos-${KOKKOS_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${KOKKOS_URL} --output-document=${KOKKOS_ARCHIVE} && \
     mkdir -p kokkos && \

--- a/docker/Dockerfile.nvcc
+++ b/docker/Dockerfile.nvcc
@@ -1,0 +1,90 @@
+ARG BASE=nvidia/cuda:12.0.1-devel-ubuntu22.04
+FROM $BASE
+
+ARG NPROCS=4
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+        build-essential \
+        ccache \
+        cmake \
+        curl \
+        git \
+        libomp-dev \
+        libbenchmark-dev \
+        libbz2-dev \
+        vim \
+        wget \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN KEYDUMP_URL=https://cloud1.cees.ornl.gov/download && \
+    KEYDUMP_FILE=keydump && \
+    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE} && \
+    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE}.sig && \
+    gpg --import ${KEYDUMP_FILE} && \
+    gpg --verify ${KEYDUMP_FILE}.sig ${KEYDUMP_FILE} && \
+    rm ${KEYDUMP_FILE}*
+
+# Install OpenMPI
+ARG CUDA_AWARE_MPI
+ENV OPENMPI_DIR=/opt/openmpi
+RUN OPENMPI_VERSION=4.1.3 && \
+    OPENMPI_VERSION_SHORT=$(echo "$OPENMPI_VERSION" | cut -d. -f1,2) && \
+    OPENMPI_SHA1=be3ebb8df076677889198b73b0b033b956c3d88b && \
+    OPENMPI_URL=https://download.open-mpi.org/release/open-mpi/v${OPENMPI_VERSION_SHORT}/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    OPENMPI_ARCHIVE=openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    CUDA_OPTIONS=${CUDA_AWARE_MPI:+--with-cuda} && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${OPENMPI_URL} --output-document=${OPENMPI_ARCHIVE} && \
+    echo "${OPENMPI_SHA1} ${OPENMPI_ARCHIVE}" | sha1sum -c && \
+    mkdir -p openmpi && \
+    tar -xf ${OPENMPI_ARCHIVE} -C openmpi --strip-components=1 && \
+    mkdir -p build && cd build && \
+    ../openmpi/configure --prefix=${OPENMPI_DIR} ${CUDA_OPTIONS} CFLAGS=-w && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}
+ENV PATH=${OPENMPI_DIR}/bin:$PATH
+
+# Install Boost
+# Note: can't use libboost-program-options-dev and libboost-test-dev coming
+# with Ubuntu 22.04 (1.74.0 does not work with CUDA)
+ENV BOOST_DIR=/opt/boost
+RUN BOOST_VERSION=1.75.0 && \
+    BOOST_VERSION_UNDERSCORE=$(echo "$BOOST_VERSION" | sed -e "s/\./_/g") && \
+    BOOST_URL=https://archives.boost.io/release/${BOOST_VERSION}/source && \
+    BOOST_ARCHIVE=boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2 && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${BOOST_URL}/${BOOST_ARCHIVE} && \
+    mkdir -p boost && \
+    tar -xf ${BOOST_ARCHIVE} -C boost --strip-components=1 && \
+    cd boost && \
+    CXXFLAGS="-w" ./bootstrap.sh --prefix=${BOOST_DIR} && \
+    echo "using mpi ;" >> project-config.jam && \
+    ./b2 -j${NPROCS} \
+        hardcode-dll-paths=true dll-path=${BOOST_DIR}/lib \
+        link=shared \
+        variant=release \
+        cxxflags=-w \
+        install \
+        && \
+    rm -rf ${SCRATCH_DIR}
+
+# Workaround for Kokkos to find libcudart
+ENV LD_LIBRARY_PATH=/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}
+
+# Install Kokkos
+ARG KOKKOS_VERSION=4.5.00
+ENV KOKKOS_DIR=/opt/kokkos
+ARG KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON"
+RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
+    KOKKOS_ARCHIVE=kokkos-${KOKKOS_VERSION}.tar.gz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${KOKKOS_URL} --output-document=${KOKKOS_ARCHIVE} && \
+    mkdir -p kokkos && \
+    tar -xf ${KOKKOS_ARCHIVE} -C kokkos --strip-components=1 && \
+    cd kokkos && \
+    mkdir -p build && cd build && \
+    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${KOKKOS_DIR} -D CMAKE_CXX_COMPILER=/scratch/kokkos/bin/nvcc_wrapper ${KOKKOS_OPTIONS} .. && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -5,12 +5,11 @@ ARG NPROCS=4
 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -yq \
         bc \
         wget \
         ccache \
         ninja-build \
-        python3 \
         git \
         vim \
         jq \
@@ -128,11 +127,11 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 
 # Install Kokkos
 ARG KOKKOS_VERSION=4.5.00
-ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SYCL=ON -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON -DKokkos_ARCH_VOLTA70=ON -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS=-w"
+ARG KOKKOS_OPTIONS="-DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_SYCL=ON -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON -DKokkos_ARCH_VOLTA70=ON -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 -DCMAKE_CXX_FLAGS=-w"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
     KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
-    KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \
+    KOKKOS_ARCHIVE=kokkos-${KOKKOS_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${KOKKOS_URL} --output-document=${KOKKOS_ARCHIVE} && \
     mkdir -p kokkos && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ services:
   arborx_dev:
     build:
       args:
-        - BASE=nvidia/cuda:11.5.2-devel-ubuntu20.04
+        - BASE=nvidia/cuda:12.2.2-devel-ubuntu22.04
         - KOKKOS_VERSION=4.2.00
-        - KOKKOS_OPTIONS=-DCMAKE_CXX_STANDARD=17 -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_SNB=ON -DKokkos_ARCH_VOLTA70=ON
+        - KOKKOS_OPTIONS=-DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_SNB=ON -DKokkos_ARCH_VOLTA70=ON
 ```

--- a/src/spatial/detail/ArborX_IndexableGetter.hpp
+++ b/src/spatial/detail/ArborX_IndexableGetter.hpp
@@ -76,7 +76,10 @@ struct Indexables
   KOKKOS_FUNCTION auto size() const { return _values.size(); }
 };
 
-#ifdef KOKKOS_ENABLE_CXX17
+// FIXME_CLANG(Clang<17): Clang 16 or earlier does not support aggregate
+// initialization type deduction
+// https://github.com/llvm/llvm-project/issues/54050
+#if defined(__clang__) && (__clang_major__ < 17)
 template <typename Values, typename IndexableGetter>
 KOKKOS_DEDUCTION_GUIDE Indexables(Values, IndexableGetter)
     -> Indexables<Values, IndexableGetter>;


### PR DESCRIPTION
TODO:
- `Clang+CUDA` build
  Need to figure it out. Clang 14 seems to support up to cuda 11.5, and there are weird compilation failures with 12, it seems.
  llvm/llvm-project#61340
  It was only fixed in Clang 16
  Updated to run Clang 18 with CUDA 12.5. `triangulated_surface` benchmark runs into `ptxas` error.