### PR TITLE
Add lower_bound kernel

### DIFF
--- a/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
+++ b/src/kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp
@@ -83,6 +83,27 @@ KOKKOS_FUNCTION Iterator upper_bound(Iterator first, Iterator last,
   return first;
 }
 
+template <typename Iterator, typename T>
+KOKKOS_FUNCTION Iterator lower_bound(Iterator first, Iterator last,
+                                     T const &value)
+{
+  int count = last - first;
+  while (count > 0)
+  {
+    int step = count / 2;
+    if (*(first + step) < value)
+    {
+      first += step + 1;
+      count -= step + 1;
+    }
+    else
+    {
+      count = step;
+    }
+  }
+  return first;
+}
+
 } // namespace ArborX::Details::KokkosExt
 
 #endif


### PR DESCRIPTION
Need to do binary_search on device within a Kokkos lambda. Could have used upper_bound, but it is slightly less clear. 