### PR TITLE
First non-naive version of distributed DBSCAN

### DIFF
--- a/benchmarks/cluster/CMakeLists.txt
+++ b/benchmarks/cluster/CMakeLists.txt
@@ -4,18 +4,13 @@ add_library(cluster_benchmark_helpers
 )
 target_link_libraries(cluster_benchmark_helpers PRIVATE ArborX::ArborX)
 
-set(input_text_file "input.txt")
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${input_text_file} ${CMAKE_CURRENT_BINARY_DIR}/${input_text_file} COPYONLY)
-set(input_binary_file "input.arborx")
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${input_binary_file} ${CMAKE_CURRENT_BINARY_DIR}/${input_arborx_file} COPYONLY)
-
-set(input_file "input.arborx")
+set(input_file "input.txt")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${input_file} ${CMAKE_CURRENT_BINARY_DIR}/${input_file} COPYONLY)
 
 add_executable(ArborX_Benchmark_DBSCAN.exe dbscan.cpp)
 target_include_directories(ArborX_Benchmark_DBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(ArborX_Benchmark_DBSCAN.exe ArborX::ArborX Boost::program_options cluster_benchmark_helpers)
-add_test(NAME ArborX_Benchmark_DBSCAN COMMAND ArborX_Benchmark_DBSCAN.exe --filename=${input_text_file} --eps=1.4 --verify)
+add_test(NAME ArborX_Benchmark_DBSCAN COMMAND ArborX_Benchmark_DBSCAN.exe --filename=${input_file} --eps=1.4 --verify)
 
 add_executable(ArborX_Benchmark_MST.exe mst.cpp)
 target_include_directories(ArborX_Benchmark_MST.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -31,5 +26,5 @@ if (ARBORX_ENABLE_MPI)
   add_executable(ArborX_Benchmark_DistributedDBSCAN.exe distributed_dbscan.cpp)
   target_include_directories(ArborX_Benchmark_DistributedDBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   target_link_libraries(ArborX_Benchmark_DistributedDBSCAN.exe ArborX::ArborX Boost::program_options cluster_benchmark_helpers)
-  add_test(NAME ArborX_Benchmark_DistributedDBSCAN COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:ArborX_Benchmark_DistributedDBSCAN.exe> ${MPIEXEC_POSTFLAGS} --filename=${input_binary_file} --eps=1.4 --verify)
+  add_test(NAME ArborX_Benchmark_DistributedDBSCAN COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:ArborX_Benchmark_DistributedDBSCAN.exe> ${MPIEXEC_POSTFLAGS} --n 1000 --num-seq 4 --spacing 4 --core-min-size 2 --eps 2 --verify)
 endif()

--- a/benchmarks/cluster/distributed_data.hpp
+++ b/benchmarks/cluster/distributed_data.hpp
@@ -1,0 +1,143 @@
+/****************************************************************************
+ * Copyright (c) 2025, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DISTRIBUTED_DATA_HPP
+#define ARBORX_DISTRIBUTED_DATA_HPP
+
+#include <ArborX_Point.hpp>
+#include <misc/ArborX_Exception.hpp>
+
+#include <array>
+#include <vector>
+
+// Find closest DIM factors for a number. The factors are
+// sorted in the descending order.
+template <int DIM>
+std::array<int, DIM> closestFactors(int n)
+{
+  static_assert(DIM > 0);
+
+  std::array<int, DIM> result;
+  if constexpr (DIM == 1)
+  {
+    result[0] = n;
+    return result;
+  }
+
+  std::vector<int> factors;
+
+  // Find all prime factors
+  unsigned i = 2;
+  while (n > 1)
+  {
+    if (n % i != 0)
+    {
+      ++i;
+      continue;
+    }
+
+    factors.push_back(i);
+    n /= i;
+  }
+
+  // Reduce the list of factors
+  while (factors.size() > DIM)
+  {
+    // Combine two smallest factors
+    factors[1] *= factors[0];
+    factors.erase(factors.begin());
+
+    // Re-sort the list
+    std::sort(factors.begin(), factors.end());
+  }
+
+  int num_factors = factors.size();
+  assert(num_factors <= DIM);
+
+  result.fill(1); // for missing factors
+  for (int d = 0; d < num_factors; ++d)
+    result[d] = factors[num_factors - 1 - d];
+
+  return result;
+}
+
+template <int DIM, typename MemorySpace>
+Kokkos::View<ArborX::Point<DIM> *, MemorySpace>
+generateDistributedData(MPI_Comm comm,
+                        ArborXBenchmark::Parameters const &params)
+{
+  int comm_rank;
+  MPI_Comm_rank(comm, &comm_rank);
+  int comm_size;
+  MPI_Comm_size(comm, &comm_size);
+
+  auto n = params.n;
+
+  auto factors = closestFactors<DIM>(comm_size);
+
+  std::array<int, DIM> Is;
+  for (int d = 0, s = comm_rank; d < DIM; ++d)
+  {
+    Is[d] = s % factors[d];
+    s /= factors[d];
+  }
+
+  int nx = std::floor(std::pow(n, 1. / DIM));
+  n = std::pow(nx, DIM);
+
+  if (comm_rank == 0)
+    printf("n (global)        : %lld\n", ((long long)comm_size) * n);
+
+  // x x   x x   x x   x x
+  int num_seq = params.n_seq;
+  int spacing = params.spacing;
+
+  typename MemorySpace::execution_space space;
+  Kokkos::View<ArborX::Point<DIM> *, MemorySpace> points(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                         "Benchmark::distributed_data"),
+      n);
+  if constexpr (DIM == 2)
+  {
+    Kokkos::parallel_for(
+        "Benchmark::generateDistributedData",
+        Kokkos::MDRangePolicy(space, {0, 0}, {nx, nx}),
+        KOKKOS_LAMBDA(int i, int j) {
+          auto pos = [num_seq, spacing](int p) {
+            auto tile = num_seq + spacing - 1;
+            return static_cast<float>((p / num_seq) * tile + p % num_seq);
+          };
+          points(j * nx + i) = {pos(Is[0] * nx + i), pos(Is[1] * nx + j)};
+        });
+  }
+  else if constexpr (DIM == 3)
+  {
+    Kokkos::parallel_for(
+        "Benchmark::generateDistributedData",
+        Kokkos::MDRangePolicy(space, {0, 0, 0}, {nx, nx, nx}),
+        KOKKOS_LAMBDA(int i, int j, int k) {
+          auto pos = [num_seq, spacing](int p) {
+            auto tile = num_seq + spacing - 1;
+            return static_cast<float>((p / num_seq) * tile + p % num_seq);
+          };
+          points(k * nx * nx + j * nx + i) = {
+              pos(Is[0] * nx + i), pos(Is[1] * nx + j), pos(Is[2] * nx + k)};
+        });
+  }
+  else
+  {
+    ARBORX_ASSERT(false);
+  }
+
+  return points;
+}
+
+#endif

--- a/benchmarks/cluster/parameters.hpp
+++ b/benchmarks/cluster/parameters.hpp
@@ -30,6 +30,8 @@ struct Parameters
   std::string implementation;
   int max_num_points;
   int n;
+  int n_seq;
+  int spacing;
   int num_samples;
   bool variable_density;
   bool verbose;

--- a/src/cluster/ArborX_DistributedDBSCAN.hpp
+++ b/src/cluster/ArborX_DistributedDBSCAN.hpp
@@ -12,8 +12,10 @@
 #ifndef ARBORX_DISTRIBUTED_DBSCAN_HPP
 #define ARBORX_DISTRIBUTED_DBSCAN_HPP
 
+#include "kokkos_ext/ArborX_KokkosExtStdAlgorithms.hpp" // FIXME: remove
 #include <ArborX_DBSCAN.hpp>
 #include <detail/ArborX_AccessTraits.hpp>
+#include <detail/ArborX_DistributedDBSCANHelpers.hpp>
 
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 
@@ -24,12 +26,14 @@ namespace ArborX::Experimental
 
 template <typename ExecutionSpace, typename Primitives, typename Coordinate,
           typename Labels>
-void dbscan(MPI_Comm comm, ExecutionSpace const &exec_space,
+void dbscan(MPI_Comm comm, ExecutionSpace const &space,
             Primitives const &primitives, Coordinate eps, int core_min_size,
             Labels &labels,
-            DBSCAN::Parameters const &parameters = DBSCAN::Parameters())
+            DBSCAN::Parameters const &params = DBSCAN::Parameters())
 {
-  Kokkos::Profiling::ScopedRegion guard("ArborX::DistributedDBSCAN");
+  std::string prefix = "ArborX::DistributedDBSCAN";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
 
   namespace KokkosExt = ArborX::Details::KokkosExt;
 
@@ -42,6 +46,8 @@ void dbscan(MPI_Comm comm, ExecutionSpace const &exec_space,
 
   ARBORX_ASSERT(eps > 0);
   ARBORX_ASSERT(core_min_size >= 2);
+  if (core_min_size > 2)
+    Kokkos::abort("minPts > 2 is not supported yet");
 
   using Point = typename Points::value_type;
   static_assert(GeometryTraits::is_point_v<Point>);
@@ -50,82 +56,108 @@ void dbscan(MPI_Comm comm, ExecutionSpace const &exec_space,
                      Coordinate>);
 
   Points points{primitives}; // NOLINT
-  auto const n = points.size();
+  int const n_local = points.size();
 
-  int comm_size;
-  MPI_Comm_size(comm, &comm_size);
   int comm_rank;
   MPI_Comm_rank(comm, &comm_rank);
 
-  std::vector<int> counts(comm_size);
-  counts[comm_rank] = n;
-  MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, counts.data(), 1, MPI_INT,
-                comm);
-  std::vector<int> offsets(comm_size + 1);
-  offsets[0] = 0;
-  for (int i = 0; i < comm_size; ++i)
-    offsets[i + 1] = counts[i] + offsets[i];
+  // Step 1: receive ghost neighbors
+  Kokkos::View<int *, MemorySpace> ghost_ids(prefix + "ghost_ids", 0);
+  Kokkos::View<Point *, MemorySpace> ghost_points(prefix + "ghost_points", 0);
+  Kokkos::View<int *, MemorySpace> ghost_ranks(prefix + "ghost_ranks", 0);
+  Details::forwardNeighbors(comm, space, points, eps, ghost_points, ghost_ids,
+                            ghost_ranks);
+  int const n_ghost = ghost_points.size();
 
-  auto const total_n = offsets.back();
-  auto rank_offset = offsets[comm_rank];
-  auto slice = Kokkos::make_pair(offsets[comm_rank], offsets[comm_rank + 1]);
+  // Step 2: do local DBSCAN
+  auto local_labels =
+      dbscan(space,
+             Details::UnifiedPoints<Points, decltype(ghost_points)>{
+                 points, ghost_points},
+             eps, core_min_size, params);
 
-#ifdef ARBORX_ENABLE_GPU_AWARE_MPI
-  Kokkos::View<Point *, MemorySpace> send_data(
-      Kokkos::view_alloc(exec_space, Kokkos::WithoutInitializing,
-                         "ArborX::DistributedDBSCAN::send_data"),
-      total_n);
-#else
-  Kokkos::View<Point *, Kokkos::HostSpace> send_data(
-      Kokkos::view_alloc(Kokkos::DefaultHostExecutionSpace{},
-                         Kokkos::WithoutInitializing,
-                         "ArborX::DistributedDBSCAN::send_data"),
-      total_n);
-#endif
-
-  if constexpr (Kokkos::is_view_v<Primitives>)
+  // Step 3: convert local labels to global
+  Kokkos::View<long long *, MemorySpace> rank_offsets(prefix + "rank_offsets",
+                                                      0);
   {
-    Kokkos::deep_copy(exec_space, Kokkos::subview(send_data, slice),
-                      primitives);
+    std::vector<int> counts;
+    std::vector<long long> offsets;
+    Details::computeCountsAndOffsets(comm, (long long)n_local, counts, offsets);
+
+    Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing),
+                   rank_offsets, offsets.size());
+    Kokkos::deep_copy(
+        space, rank_offsets,
+        Kokkos::View<long long *, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(
+            offsets.data(), offsets.size()));
   }
-  else
-  {
-#ifdef ARBORX_ENABLE_GPU_AWARE_MPI
-    Kokkos::parallel_for(
-        "ArborX::DistributedDBSCAN::fill_data",
-        Kokkos::RangePolicy(exec_space, 0, n),
-        KOKKOS_LAMBDA(int i) { send_data(rank_offset + i) = points(i); });
-#else
-    Kokkos::View<Point *, MemorySpace> data(
-        Kokkos::view_alloc(exec_space, Kokkos::WithoutInitializing,
-                           "ArborX::DistributedDBSCAN::data"),
-        n);
-    Kokkos::parallel_for(
-        "ArborX::DistributedDBSCAN::fill_data",
-        Kokkos::RangePolicy(exec_space, 0, n),
-        KOKKOS_LAMBDA(int i) { data(i) = points(i); });
-    Kokkos::deep_copy(exec_space, Kokkos::subview(send_data, slice), data);
-#endif
-  }
-  exec_space.fence("ArborX::DistributedDBSCAN (data ready before sending)");
-
-  auto const sc = sizeof(Point);
-  std::for_each(counts.begin(), counts.end(), [sc](auto &x) { x *= sc; });
-  std::for_each(offsets.begin(), offsets.end(), [sc](auto &x) { x *= sc; });
-  MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, send_data.data(),
-                 counts.data(), offsets.data(), MPI_BYTE, MPI_COMM_WORLD);
-
-  auto data = Kokkos::create_mirror_view_and_copy(exec_space, send_data);
-  Kokkos::resize(send_data, 0); // deallocate
-
-  auto local_labels = dbscan(exec_space, data, eps, core_min_size, parameters);
-
-  Kokkos::resize(Kokkos::view_alloc(exec_space, Kokkos::WithoutInitializing),
-                 labels, n);
+  Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing), labels,
+                 local_labels.size());
   Kokkos::parallel_for(
-      "ArborX::DistributedDBSCAN::copy_labels",
-      Kokkos::RangePolicy(exec_space, 0, n),
-      KOKKOS_LAMBDA(int i) { labels(i) = local_labels(rank_offset + i); });
+      prefix + "convert_labels",
+      Kokkos::RangePolicy(space, 0, local_labels.size()), KOKKOS_LAMBDA(int i) {
+        auto label = local_labels(i);
+        if (label == -1)
+        {
+          labels(i) = -1;
+          return;
+        }
+
+        if (label < n_local)
+          labels(i) = rank_offsets(comm_rank) + label;
+        else
+          labels(i) = rank_offsets(ghost_ranks(label - n_local)) +
+                      ghost_ids(label - n_local);
+      });
+  Kokkos::resize(local_labels, 0); // free space
+
+  // Step 4: pack and communicate results back to owning ranks
+  Kokkos::View<long long *, MemorySpace> ghost_labels(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                         prefix + "ghost_labels"),
+      n_ghost);
+  Kokkos::deep_copy(
+      space, ghost_labels,
+      Kokkos::subview(labels, Kokkos::make_pair(n_local, n_local + n_ghost)));
+  Kokkos::resize(space, labels, n_local);
+  // Avoid communicating noise points
+  int num_compressed;
+  Kokkos::parallel_scan(
+      prefix + "compress", Kokkos::RangePolicy(space, 0, n_ghost),
+      KOKKOS_LAMBDA(int i, int &update, bool is_final) {
+        if (ghost_labels(i) != -1)
+        {
+          if (is_final)
+          {
+            ghost_ranks(update) = ghost_ranks(i);
+            ghost_ids(update) = ghost_ids(i);
+            ghost_labels(update) = ghost_labels(i);
+          }
+          ++update;
+        }
+      },
+      num_compressed);
+  Kokkos::resize(space, ghost_ranks, num_compressed);
+  Kokkos::resize(space, ghost_ids, num_compressed);
+  Kokkos::resize(space, ghost_labels, num_compressed);
+  Details::communicateNeighborDataBack(comm, space, ghost_ranks, ghost_ids,
+                                       ghost_labels);
+
+  // Step 5: process multi-labeled indices
+  Kokkos::View<Details::MergePair *, MemorySpace> local_merge_pairs(
+      prefix + "local_merge_pairs", 0);
+  Details::computeMergePairs(space, labels, ghost_ids, ghost_labels,
+                             local_merge_pairs);
+  sortAndFilterMergePairs(space, local_merge_pairs);
+
+  // Step 6: communicate merge pairs (all-to-all)
+  Kokkos::View<Details::MergePair *, MemorySpace> global_merge_pairs(
+      prefix + "global_merge_pairs", 0);
+  communicateMergePairs(comm, space, local_merge_pairs, global_merge_pairs);
+  Details::sortAndFilterMergePairs(space, global_merge_pairs);
+
+  // Step 7: flatten the labels
+  Details::relabel(space, global_merge_pairs, labels);
 }
 
 } // namespace ArborX::Experimental

--- a/src/cluster/detail/ArborX_DistributedDBSCANHelpers.hpp
+++ b/src/cluster/detail/ArborX_DistributedDBSCANHelpers.hpp
@@ -1,0 +1,546 @@
+/****************************************************************************
+ * Copyright (c) 2025, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_DISTRIBUTED_DBSCAN_HELPERS_HPP
+#define ARBORX_DISTRIBUTED_DBSCAN_HELPERS_HPP
+
+#include <ArborX_Box.hpp>
+#include <ArborX_BruteForce.hpp>
+#include <detail/ArborX_Distributor.hpp>
+#include <detail/ArborX_TreeConstruction.hpp>
+#include <kokkos_ext/ArborX_KokkosExtKernelStdAlgorithms.hpp>
+#include <kokkos_ext/ArborX_KokkosExtViewHelpers.hpp>
+#include <misc/ArborX_SortUtils.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Profiling_ScopedRegion.hpp>
+
+#include <mpi.h>
+
+namespace ArborX::Details
+{
+
+template <typename Points, typename GhostPoints>
+struct UnifiedPoints
+{
+  Points _points;
+  GhostPoints _ghost_points;
+};
+
+} // namespace ArborX::Details
+
+template <typename Points, typename GhostPoints>
+struct ArborX::AccessTraits<ArborX::Details::UnifiedPoints<Points, GhostPoints>>
+{
+  using Self = ArborX::Details::UnifiedPoints<Points, GhostPoints>;
+  using memory_space = typename Points::memory_space;
+
+  static KOKKOS_FUNCTION auto size(Self const &self)
+  {
+    return self._points.size() + self._ghost_points.size();
+  }
+  static KOKKOS_FUNCTION auto get(Self const &self, size_t i)
+  {
+    auto const num_local = self._points.size();
+    return (i < num_local ? self._points(i)
+                          : self._ghost_points(i - num_local));
+  }
+};
+
+namespace ArborX::Details
+{
+
+template <typename Index>
+void computeCountsAndOffsets(MPI_Comm comm, Index k, std::vector<int> &counts,
+                             std::vector<Index> &offsets)
+{
+  Kokkos::Profiling::ScopedRegion guard(
+      "ArborX::DistributedDBSCAN::computeRankOffset");
+
+  int comm_size;
+  MPI_Comm_size(comm, &comm_size);
+  int comm_rank;
+  MPI_Comm_rank(comm, &comm_rank);
+
+  counts.resize(comm_size);
+  counts[comm_rank] = k;
+  MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, counts.data(), 1, MPI_INT,
+                comm);
+
+  offsets.resize(comm_size + 1);
+  offsets[0] = 0;
+  for (int i = 0; i < comm_size; ++i)
+    offsets[i + 1] = counts[i] + offsets[i];
+}
+
+template <typename ExecutionSpace, typename Points>
+auto gatherGlobalBoxes(MPI_Comm comm, ExecutionSpace const &space,
+                       Points const &points)
+{
+  using MemorySpace = typename Points::memory_space;
+
+  using Point = typename Points::value_type;
+  constexpr int DIM = GeometryTraits::dimension_v<Point>;
+  using Coordinate = GeometryTraits::coordinate_type_t<Point>;
+  using Box = Box<DIM, Coordinate>;
+
+  int comm_size;
+  MPI_Comm_size(comm, &comm_size);
+  int comm_rank;
+  MPI_Comm_rank(comm, &comm_rank);
+
+  Box local_box;
+  Details::TreeConstruction::calculateBoundingBoxOfTheScene(
+      space,
+      Details::Indexables{points, Experimental::DefaultIndexableGetter{}},
+      local_box);
+
+  Kokkos::View<Box *, MemorySpace> global_boxes(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                         "ArborX::DistributedDBSCAN::rank_boxes"),
+      comm_size);
+#ifdef ARBORX_ENABLE_GPU_AWARE_MPI
+  Kokkos::deep_copy(space, Kokkos::subview(global_boxes, comm_rank), local_box);
+  space.fence(
+      "ArborX::DistributedDBSCAN (fill on device done before MPI_Allgather)");
+
+  MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                static_cast<void *>(global_boxes.data()), sizeof(Box), MPI_BYTE,
+                comm);
+#else
+  Kokkos::DefaultHostExecutionSpace host_exec;
+  auto global_boxes_host = Kokkos::create_mirror_view(
+      Kokkos::view_alloc(host_exec, Kokkos::WithoutInitializing), global_boxes);
+  host_exec.fence();
+  global_boxes_host(comm_rank) = local_box;
+
+  MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                static_cast<void *>(global_boxes_host.data()), sizeof(Box),
+                MPI_BYTE, comm);
+
+  Kokkos::deep_copy(space, global_boxes, global_boxes_host);
+#endif
+
+  return global_boxes;
+}
+
+struct IndexOnlyCallback
+{
+  template <typename Query, typename Value, typename Index, typename Output>
+  KOKKOS_FUNCTION auto operator()(Query const &,
+                                  PairValueIndex<Value, Index> const &value,
+                                  Output const &out) const
+  {
+    out(value.index);
+  }
+};
+
+template <typename ExecutionSpace, typename Points, typename Coordinate,
+          typename GhostPoints, typename GhostIds, typename GhostRanks>
+void forwardNeighbors(MPI_Comm comm, ExecutionSpace space, Points const &points,
+                      Coordinate eps, GhostPoints &ghost_points,
+                      GhostIds &ghost_ids, GhostRanks &ghost_ranks)
+{
+  std::string prefix = "ArborX::DistributedDBSCAN::forwardNeighbors";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
+
+  using MemorySpace = typename Points::memory_space;
+
+  using Point = typename Points::value_type;
+
+  int comm_size;
+  MPI_Comm_size(comm, &comm_size);
+  int comm_rank;
+  MPI_Comm_rank(comm, &comm_rank);
+
+  auto global_boxes = gatherGlobalBoxes(comm, space, points);
+  using Boxes = decltype(global_boxes);
+  using Box = typename Boxes::value_type;
+
+  // Reset local box so that it does not find anything
+  Kokkos::deep_copy(space, Kokkos::subview(global_boxes, comm_rank), Box{});
+
+  BruteForce index(space, Experimental::attach_indices<int>(global_boxes));
+  Kokkos::View<int *, MemorySpace> offsets(prefix + "offsets", 0);
+  Kokkos::View<int *, MemorySpace> ranks_to(prefix + "ranks_to", 0);
+  index.query(space, Experimental::make_intersects(points, eps),
+              IndexOnlyCallback{}, ranks_to, offsets);
+
+  // FIXME: very similar to DistributedTree::forwardQueries
+  Distributor<MemorySpace> distributor(comm);
+
+  auto const n_exports = ranks_to.size();
+  auto const n_imports = distributor.createFromSends(space, ranks_to);
+
+  // If tree is empty (running on one rank), the offsets.size() will consist of
+  // only one element, independent of the number of points.
+  // FIXME: not 100% sure what's going on. We construct a tree based on an
+  // invalid box. What's supposed to happen in this case?
+  auto const n_offset_points = (offsets.size() > 0 ? offsets.size() - 1 : 0);
+
+  {
+    Kokkos::View<Point *, MemorySpace> export_points(
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                           prefix + "::export_points"),
+        n_exports);
+    Kokkos::parallel_for(
+        prefix + "fill_export_points",
+        Kokkos::RangePolicy(space, 0, n_offset_points), KOKKOS_LAMBDA(int i) {
+          for (int j = offsets(i); j < offsets(i + 1); ++j)
+            export_points(j) = points(i);
+        });
+    KokkosExt::reallocWithoutInitializing(space, ghost_points, n_imports);
+    distributor.doPostsAndWaits(space, export_points, ghost_points);
+  }
+
+  {
+    Kokkos::View<int *, MemorySpace> export_ids(
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                           prefix + "export_ids"),
+        n_exports);
+    Kokkos::parallel_for(
+        prefix + "fill_export_ids",
+        Kokkos::RangePolicy(space, 0, n_offset_points), KOKKOS_LAMBDA(int i) {
+          for (int j = offsets(i); j < offsets(i + 1); ++j)
+            export_ids(j) = i;
+        });
+    KokkosExt::reallocWithoutInitializing(space, ghost_ids, n_imports);
+    distributor.doPostsAndWaits(space, export_ids, ghost_ids);
+  }
+
+  {
+    Kokkos::View<int *, MemorySpace> export_ranks(
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                           prefix + "export_ranks"),
+        n_exports);
+    Kokkos::deep_copy(space, export_ranks, comm_rank);
+    KokkosExt::reallocWithoutInitializing(space, ghost_ranks, n_imports);
+    distributor.doPostsAndWaits(space, export_ranks, ghost_ranks);
+  }
+}
+
+// FIXME: similar to DistributedTree::communicateResultsBack
+template <typename ExecutionSpace, typename Ranks, typename Ids,
+          typename Labels>
+void communicateNeighborDataBack(MPI_Comm comm, ExecutionSpace space,
+                                 Ranks const &ranks, Ids &ids, Labels &labels)
+{
+  std::string prefix = "ArborX::DistributedDBSCAN::communicateNeighborDataBack";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
+
+  using MemorySpace = typename Labels::memory_space;
+
+  // We are assuming here that if the same rank is related to multiple batches
+  // these batches appear consecutively. Hence, no reordering is necessary.
+  Distributor<MemorySpace> distributor(comm);
+  int const n_imports = distributor.createFromSends(space, ranks);
+
+  {
+    Kokkos::View<int *, MemorySpace> import_ids(
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing, ids.label()),
+        n_imports);
+    distributor.doPostsAndWaits(space, ids, import_ids);
+    ids = import_ids;
+  }
+
+  {
+    Labels import_labels(
+        Kokkos::view_alloc(space, Kokkos::WithoutInitializing, labels.label()),
+        n_imports);
+    distributor.doPostsAndWaits(space, labels, import_labels);
+    labels = import_labels;
+  }
+}
+
+struct MergePair
+{
+  long long from;
+  long long to;
+
+private:
+  // performs lexicographical comparison by comparing first the weights and then
+  // the unordered pair of vertices
+  friend KOKKOS_FUNCTION constexpr bool operator<(MergePair const &lhs,
+                                                  MergePair const &rhs)
+  {
+    if (lhs.from < rhs.from)
+      return true;
+    if (lhs.from == rhs.from)
+      return lhs.to < rhs.to;
+    return false;
+  }
+  friend KOKKOS_FUNCTION constexpr bool operator==(MergePair const &lhs,
+                                                   MergePair const &rhs)
+  {
+    return lhs.from == rhs.from && lhs.to == rhs.to;
+  }
+  friend std::ostream &operator<<(std::ostream &os, MergePair const &mp)
+  {
+    return os << "{" << mp.from << " -> " << mp.to << "}";
+  }
+};
+
+template <typename ExecutionSpace, typename Labels, typename ImportedIds,
+          typename ImportedLabels, typename MergePairs>
+void computeMergePairs(ExecutionSpace const &space, Labels &local_labels,
+                       ImportedIds &imported_ids,
+                       ImportedLabels &imported_labels, MergePairs &merge_pairs)
+{
+  std::string prefix = "ArborX::DistributedDBSCAN::computeMergePairs";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
+
+  using MemorySpace = typename Labels::memory_space;
+
+  int const n_import = imported_labels.size();
+
+  KokkosExt::sortByKey(space, imported_ids, imported_labels);
+
+  Kokkos::View<int *, MemorySpace> offsets(
+      Kokkos::view_alloc(space, prefix + "offsets"), n_import + 1);
+  int num_offsets;
+  Kokkos::parallel_scan(
+      prefix + "compute_offsets", Kokkos::RangePolicy(space, 0, n_import),
+      KOKKOS_LAMBDA(int i, int &update, bool is_final) {
+        if (i == n_import - 1 || imported_ids(i) != imported_ids(i + 1))
+        {
+          if (is_final)
+            offsets(update + 1) = i + 1;
+          ++update;
+        }
+      },
+      num_offsets);
+  ++num_offsets;
+  Kokkos::resize(space, offsets, num_offsets);
+
+  if (num_offsets < 2)
+  {
+    Kokkos::resize(space, merge_pairs, 0);
+    return;
+  }
+
+  Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing),
+                 merge_pairs, n_import);
+  int num_merge_pairs;
+  Kokkos::parallel_scan(
+      prefix + "process_labels", Kokkos::RangePolicy(space, 0, num_offsets - 1),
+      KOKKOS_LAMBDA(int const i, int &update, bool is_final) {
+        auto const begin = offsets(i);
+        auto const end = offsets(i + 1);
+        auto const id = imported_ids(begin);
+        auto local_label = local_labels(id);
+        bool const is_local_valid = (local_label != -1);
+
+        int num_valid = (end - begin) + (is_local_valid);
+        if (num_valid < 2)
+          return;
+
+        auto min_label = (is_local_valid ? local_label : LLONG_MAX);
+        for (int j = begin; j < end; ++j)
+        {
+          auto const label_j = imported_labels(j);
+          KOKKOS_ASSERT(label_j != -1);
+          min_label = Kokkos::min(label_j, min_label);
+        }
+
+        if (is_local_valid && local_label != min_label)
+        {
+          if (is_final)
+          {
+            merge_pairs(update) = {local_label, min_label};
+            local_labels(id) = min_label;
+          }
+          ++update;
+        }
+
+        for (int j = begin; j < end; ++j)
+        {
+          auto label_j = imported_labels(j);
+          if (label_j == min_label)
+            continue;
+
+          if (is_final)
+            merge_pairs(update) = {label_j, min_label};
+          ++update;
+        }
+      },
+      num_merge_pairs);
+  Kokkos::resize(space, merge_pairs, num_merge_pairs);
+}
+
+template <typename ExecutionSpace, typename MergePairs>
+void sortAndFilterMergePairs(ExecutionSpace const &space,
+                             MergePairs &merge_pairs)
+{
+  std::string prefix = "ArborX::DistributedDBSCAN::sortAndFilterMergePairs";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
+
+  if (merge_pairs.size() == 0)
+    return;
+
+  Kokkos::sort(space, merge_pairs);
+
+  int const n = merge_pairs.size();
+
+  auto new_merge_pairs =
+      KokkosExt::cloneWithoutInitializingNorCopying(space, merge_pairs);
+
+  int num_unique;
+  Kokkos::parallel_scan(
+      prefix + "filter", Kokkos::RangePolicy(space, 0, n),
+      KOKKOS_LAMBDA(int i, int &update, bool is_final) {
+        // For the same "from" value we are only intested in the lowest "to".
+        // As the merge pairs are sorted, we just need to grab the first one
+        // from the sequence with the same "from".
+        if (i > 0 && merge_pairs(i).from == merge_pairs(i - 1).from)
+          return;
+
+        if (is_final)
+          new_merge_pairs(update) = merge_pairs(i);
+        ++update;
+
+        // Insert other connections that may be required on other ranks
+        // FIXME: I need to convince myself that this is truly necessary, or
+        // if it's a fix for something that should be addressed in a different
+        // place
+        auto from_i = merge_pairs(i).from;
+        auto to = merge_pairs(i).to;
+        int j = i + 1;
+        while (j < n && merge_pairs(j).from == from_i)
+        {
+          if (merge_pairs(j).to != merge_pairs(j - 1).to)
+          {
+            if (is_final)
+            {
+              KOKKOS_ASSERT(merge_pairs(j).to != to);
+              new_merge_pairs(update) = {merge_pairs(j).to, to};
+            }
+            ++update;
+          }
+          ++j;
+        }
+      },
+      num_unique);
+  Kokkos::resize(space, new_merge_pairs, num_unique);
+  merge_pairs = new_merge_pairs;
+
+  // Re-sort after reinsertion
+  // FIXME: I don't know whether we have duplicates here or not. If we do, I
+  // don't think it matters
+  Kokkos::sort(space, merge_pairs);
+}
+
+template <typename ExecutionSpace, typename Pairs>
+void communicateMergePairs(MPI_Comm comm, ExecutionSpace const &space,
+                           Pairs const &local_merge_pairs,
+                           Pairs &global_merge_pairs)
+{
+  std::string prefix = "ArborX::DistributedDBSCAN::communicateMergePairs";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
+
+  std::vector<int> counts;
+  std::vector<int> offsets;
+  computeCountsAndOffsets(comm, (int)local_merge_pairs.size(), counts, offsets);
+
+  int comm_rank;
+  MPI_Comm_rank(comm, &comm_rank);
+
+  auto global_n = offsets.back();
+  auto slice = Kokkos::make_pair(offsets[comm_rank], offsets[comm_rank + 1]);
+
+  // Scale counts and offsets by sizeof(pair) as we send in MPI_BYTE
+  auto const sc = sizeof(typename Pairs::value_type);
+  std::for_each(counts.begin(), counts.end(), [sc](auto &x) { x *= sc; });
+  std::for_each(offsets.begin(), offsets.end(), [sc](auto &x) { x *= sc; });
+
+  Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing),
+                 global_merge_pairs, global_n);
+
+#ifdef ARBORX_ENABLE_GPU_AWARE_MPI
+  Kokkos::deep_copy(space, Kokkos::subview(global_merge_pairs, slice),
+                    local_merge_pairs);
+  space.fence(prefix + " (fill on device done before MPI_Allgatherv)");
+
+  MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                 static_cast<void *>(global_merge_pairs.data()), counts.data(),
+                 offsets.data(), MPI_BYTE, comm);
+#else
+  Kokkos::DefaultHostExecutionSpace host_exec;
+  auto global_merge_pairs_host = Kokkos::create_mirror_view(
+      Kokkos::view_alloc(host_exec, Kokkos::WithoutInitializing),
+      global_merge_pairs);
+  host_exec.fence();
+  Kokkos::deep_copy(space, Kokkos::subview(global_merge_pairs_host, slice),
+                    local_merge_pairs);
+  space.fence();
+
+  MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                 static_cast<void *>(global_merge_pairs_host.data()),
+                 counts.data(), offsets.data(), MPI_BYTE, comm);
+
+  Kokkos::deep_copy(space, global_merge_pairs, global_merge_pairs_host);
+#endif
+}
+
+template <typename ExecutionSpace, typename MergePairs, typename Labels>
+void relabel(ExecutionSpace const &space, MergePairs const &merge_pairs,
+             Labels &labels)
+{
+  std::string prefix = "ArborX::DistributedDBSCAN::relabel";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
+
+  using MemorySpace = typename Labels::memory_space;
+
+  int const num_merge_pairs = merge_pairs.size();
+
+  // unzip
+  Kokkos::View<long long *, MemorySpace> from(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, prefix + "from"),
+      num_merge_pairs);
+  Kokkos::View<long long *, MemorySpace> to(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, prefix + "to"),
+      num_merge_pairs);
+  Kokkos::parallel_for(
+      prefix + "unzip", Kokkos::RangePolicy(space, 0, num_merge_pairs),
+      KOKKOS_LAMBDA(int i) {
+        from(i) = merge_pairs(i).from;
+        to(i) = merge_pairs(i).to;
+      });
+
+  Kokkos::parallel_for(
+      prefix + "relabel", Kokkos::RangePolicy(space, 0, labels.size()),
+      KOKKOS_LAMBDA(int i) {
+        auto label = labels(i);
+        int pos = num_merge_pairs;
+        while (true)
+        {
+          int next = KokkosExt::lower_bound(
+                         from.data(), from.data() + num_merge_pairs, label) -
+                     from.data();
+          if (next == num_merge_pairs || from(next) != label)
+            break;
+
+          pos = next;
+          label = to(pos);
+        }
+        if (pos != num_merge_pairs)
+          labels(i) = label;
+      });
+}
+
+} // namespace ArborX::Details
+
+#endif

--- a/src/distributed/detail/ArborX_DistributedTreeUtils.hpp
+++ b/src/distributed/detail/ArborX_DistributedTreeUtils.hpp
@@ -45,10 +45,10 @@ void countResults(ExecutionSpace const &space, int n_queries,
   KokkosExt::exclusive_scan(space, offset, offset, 0);
 }
 
-template <typename ExecutionSpace, typename Predicates, typename Indices,
+template <typename ExecutionSpace, typename Predicates, typename RanksTo,
           typename Offset, typename FwdQueries, typename FwdIds, typename Ranks>
 void forwardQueries(MPI_Comm comm, ExecutionSpace const &space,
-                    Predicates const &queries, Indices const &indices,
+                    Predicates const &queries, RanksTo const &ranks_to,
                     Offset const &offset, FwdQueries &fwd_queries,
                     FwdIds &fwd_ids, Ranks &fwd_ranks)
 {
@@ -66,7 +66,7 @@ void forwardQueries(MPI_Comm comm, ExecutionSpace const &space,
 
   int const n_queries = queries.size();
   int const n_exports = KokkosExt::lastElement(space, offset);
-  int const n_imports = distributor.createFromSends(space, indices);
+  int const n_imports = distributor.createFromSends(space, ranks_to);
 
   {
     Kokkos::View<Query *, MemorySpace> export_queries(
@@ -112,10 +112,10 @@ void forwardQueries(MPI_Comm comm, ExecutionSpace const &space,
   }
 }
 
-template <typename ExecutionSpace, typename Predicates, typename Indices,
+template <typename ExecutionSpace, typename Predicates, typename RanksTo,
           typename Offset, typename FwdQueries>
 void forwardQueries(MPI_Comm comm, ExecutionSpace const &space,
-                    Predicates const &queries, Indices const &indices,
+                    Predicates const &queries, RanksTo const &ranks_to,
                     Offset const &offset, FwdQueries &fwd_queries)
 {
   std::string prefix =
@@ -129,7 +129,7 @@ void forwardQueries(MPI_Comm comm, ExecutionSpace const &space,
   Distributor<MemorySpace> distributor(comm);
 
   int const n_exports = KokkosExt::lastElement(space, offset);
-  int const n_imports = distributor.createFromSends(space, indices);
+  int const n_imports = distributor.createFromSends(space, ranks_to);
 
   Kokkos::View<Query *, MemorySpace> export_queries(
       Kokkos::view_alloc(space, Kokkos::WithoutInitializing,


### PR DESCRIPTION
So far, only `minPts = 2` (FOF). Full-featured DBSCAN will be done in April. Performance optimizations will continue throughout the next few months.

Need it in `master` right now, so ignoring the testing requirement. 

Ran on Frontier and Aurora.

Frontier (GPU-aware MPI) on 64 ranks (8 nodes) with ~700M per rank (44B total):
```
ArborX version    : 1.7.99
ArborX hash       : e0dab986
Kokkos version    : 4.5.1
#MPI ranks        : 64
eps               : 1.000000
minpts            : 2
implementation    : fdbscan
n                 : 700,000,000
n_seq             : 100
spacing           : 2
verify            : false
verbose           : true
n (global)        : 44,663,302,592
#global merge pairs: 14715
total time          :      5.274
```