### PR TITLE
Allow make_{intersects,nearest} work with `AccessTraits` data

### DIFF
--- a/src/spatial/detail/ArborX_PredicateHelpers.hpp
+++ b/src/spatial/detail/ArborX_PredicateHelpers.hpp
@@ -26,11 +26,12 @@ template <typename UserPrimitives>
 class PrimitivesIntersect
 {
   using Primitives = Details::AccessValues<UserPrimitives>;
-  // FIXME:
-  // using Geometry = typename Primitives::value_type;
-  // static_assert(GeometryTraits::is_valid_geometry<Geometry>{});
 
 public:
+  KOKKOS_FUNCTION PrimitivesIntersect(UserPrimitives const &primitives)
+      : _primitives(primitives)
+  {}
+
   Primitives _primitives;
 };
 
@@ -40,6 +41,10 @@ class PrimitivesOrderedIntersect
   using Primitives = Details::AccessValues<UserPrimitives>;
 
 public:
+  KOKKOS_FUNCTION PrimitivesOrderedIntersect(UserPrimitives const &primitives)
+      : _primitives(primitives)
+  {}
+
   Primitives _primitives;
 };
 
@@ -52,24 +57,26 @@ class PrimitivesWithRadius
   using Coordinate = typename GeometryTraits::coordinate_type<Point>::type;
 
 public:
-  Primitives _primitives;
-  Coordinate _r;
-
   PrimitivesWithRadius(UserPrimitives const &user_primitives, Coordinate r)
       : _primitives(user_primitives)
       , _r(r)
   {}
+
+  Primitives _primitives;
+  Coordinate _r;
 };
 
 template <class UserPrimitives>
 class PrimitivesNearestK
 {
   using Primitives = Details::AccessValues<UserPrimitives>;
-  // FIXME:
-  // using Geometry = typename Primitives::value_type;
-  // static_assert(GeometryTraits::is_valid_geometry<Geometry>{});
 
 public:
+  PrimitivesNearestK(UserPrimitives const &user_primitives, int k)
+      : _primitives(user_primitives)
+      , _k(k)
+  {}
+
   Primitives _primitives;
   int _k;
 };
@@ -84,6 +91,7 @@ auto make_intersects(Primitives const &primitives)
 template <typename Primitives, typename Coordinate>
 auto make_intersects(Primitives const &primitives, Coordinate r)
 {
+  KOKKOS_ASSERT(r > 0);
   Details::check_valid_access_traits(primitives);
   return PrimitivesWithRadius<Primitives>(primitives, r);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -157,6 +157,7 @@ list(APPEND ARBORX_TEST_QUERY_TREE_SOURCES
   tstQueryTreeRay.cpp
   tstQueryTreeTraversalPolicy.cpp
   tstQueryTreeIntersectsKDOP.cpp
+  tstPredicateHelpers.cpp
   tstKokkosToolsAnnotations.cpp
   tstKokkosToolsExecutionSpaceInstances.cpp
   utf_main.cpp

--- a/test/tstPredicateHelpers.cpp
+++ b/test/tstPredicateHelpers.cpp
@@ -1,0 +1,141 @@
+/****************************************************************************
+ * Copyright (c) 2025, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborX_EnableDeviceTypes.hpp" // ARBORX_DEVICE_TYPES
+#include <ArborX_Point.hpp>
+#include <ArborX_Sphere.hpp>
+#include <algorithms/ArborX_Equals.hpp>
+#include <detail/ArborX_PredicateHelpers.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+#include <tuple>
+#include <vector>
+
+template <typename MemorySpace>
+struct Placeholder
+{
+  using memory_space = MemorySpace;
+  int n;
+};
+
+template <typename MemorySpace>
+struct ArborX::AccessTraits<Placeholder<MemorySpace>>
+{
+  using Self = Placeholder<MemorySpace>;
+  using memory_space = MemorySpace;
+
+  KOKKOS_FUNCTION static auto size(Self const &self) { return self.n; }
+  KOKKOS_FUNCTION static auto get(Self const &, int i)
+  {
+    return ArborX::Point<2>{(float)i, (float)i};
+  }
+};
+
+struct IntersectsTag
+{};
+struct IntersectsWithRadiusTag
+{};
+struct NearestTag
+{};
+
+template <typename Tag, typename ExecutionSpace, typename Predicates,
+          typename Data, typename... Args>
+bool checkPredicates(Tag, ExecutionSpace const &space,
+                     Predicates const &user_predicates, Data const &user_data,
+                     Args... args)
+{
+  using namespace ArborX::Details;
+
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  AccessValues<Data> data{user_data};
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  AccessValues<Predicates> predicates{user_predicates};
+
+  // Check that the predicates of the same type
+  static_assert(std::is_same_v<
+                typename AccessValues<Predicates>::value_type::Tag,
+                std::conditional_t<std::is_same_v<Tag, NearestTag>,
+                                   NearestPredicateTag, SpatialPredicateTag>>);
+
+  // Check that the predicates are of the same size
+  if (predicates.size() != data.size())
+    return false;
+
+  int const n = data.size();
+
+  // Check that the predicates have the same geometry
+  int num_equal = 0;
+  Kokkos::parallel_reduce(
+      "Testing::check_predicates", Kokkos::RangePolicy(space, 0, n),
+      KOKKOS_LAMBDA(int i, int &update) {
+        if constexpr (std::is_same_v<Tag, IntersectsTag>)
+        {
+          update += equals(data(i), ArborX::getGeometry(predicates(i)));
+        }
+        else if constexpr (std::is_same_v<Tag, IntersectsWithRadiusTag>)
+        {
+          update += equals(ArborX::Sphere(data(i), args...),
+                           ArborX::getGeometry(predicates(i)));
+        }
+        else if constexpr (std::is_same_v<Tag, NearestTag>)
+        {
+          update += equals(data(i), ArborX::getGeometry(predicates(i))) &&
+                    (ArborX::getK(predicates(i)) ==
+                     std::get<0>(std::make_tuple(args...)));
+        }
+      },
+      num_equal);
+
+  return num_equal == n;
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(make_predicates, DeviceType, ARBORX_DEVICE_TYPES)
+{
+  using MemorySpace = typename DeviceType::memory_space;
+  using ExecutionSpace = typename DeviceType::execution_space;
+
+  using namespace ArborX::Experimental;
+
+  using Point = ArborX::Point<2>;
+
+  ExecutionSpace space;
+
+  Kokkos::View<Point *, MemorySpace> points_view("Testing::points", 3);
+  std::vector<Point> v = {Point{0, 0}, Point{1, 1}, Point{2, 2}};
+  Kokkos::deep_copy(
+      points_view,
+      Kokkos::View<Point *, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(
+          v.data(), v.size()));
+
+  Placeholder<MemorySpace> points_access{3};
+
+  BOOST_TEST(checkPredicates(IntersectsTag{}, space,
+                             make_intersects(points_view), points_view));
+  BOOST_TEST(checkPredicates(IntersectsTag{}, space,
+                             make_intersects(points_access), points_access));
+
+  float r = 1.f;
+  BOOST_TEST(checkPredicates(IntersectsWithRadiusTag{}, space,
+                             make_intersects(points_view, r), points_view, r));
+  BOOST_TEST(checkPredicates(IntersectsWithRadiusTag{}, space,
+                             make_intersects(points_access, r), points_access,
+                             r));
+
+  int const k = 3;
+  BOOST_TEST(checkPredicates(NearestTag{}, space, make_nearest(points_view, k),
+                             points_view, k));
+  BOOST_TEST(checkPredicates(NearestTag{}, space,
+                             make_nearest(points_access, k), points_access, k));
+}

--- a/test/tstPredicateHelpers.cpp
+++ b/test/tstPredicateHelpers.cpp
@@ -88,22 +88,23 @@ bool checkPredicates(Tag, ExecutionSpace const &space,
   }
   else if constexpr (std::is_same_v<Tag, IntersectsWithRadiusTag>)
   {
+    auto r = static_cast<float>(std::get<0>(std::make_tuple(args...)));
     Kokkos::parallel_reduce(
         "Testing::check_predicates", Kokkos::RangePolicy(space, 0, n),
         KOKKOS_LAMBDA(int i, int &update) {
-          update += equals(ArborX::Sphere(data(i), args...),
+          update += equals(ArborX::Sphere(data(i), r),
                            ArborX::getGeometry(predicates(i)));
         },
         num_equal);
   }
   else if constexpr (std::is_same_v<Tag, NearestTag>)
   {
+    auto k = static_cast<int>(std::get<0>(std::make_tuple(args...)));
     Kokkos::parallel_reduce(
         "Testing::check_predicates", Kokkos::RangePolicy(space, 0, n),
         KOKKOS_LAMBDA(int i, int &update) {
           update += equals(data(i), ArborX::getGeometry(predicates(i))) &&
-                    (ArborX::getK(predicates(i)) ==
-                     std::get<0>(std::make_tuple(args...)));
+                    ArborX::getK(predicates(i)) == k;
         },
         num_equal);
   }

--- a/test/tstPredicateHelpers.cpp
+++ b/test/tstPredicateHelpers.cpp
@@ -77,26 +77,36 @@ bool checkPredicates(Tag, ExecutionSpace const &space,
 
   // Check that the predicates have the same geometry
   int num_equal = 0;
-  Kokkos::parallel_reduce(
-      "Testing::check_predicates", Kokkos::RangePolicy(space, 0, n),
-      KOKKOS_LAMBDA(int i, int &update) {
-        if constexpr (std::is_same_v<Tag, IntersectsTag>)
-        {
+  if constexpr (std::is_same_v<Tag, IntersectsTag>)
+  {
+    Kokkos::parallel_reduce(
+        "Testing::check_predicates", Kokkos::RangePolicy(space, 0, n),
+        KOKKOS_LAMBDA(int i, int &update) {
           update += equals(data(i), ArborX::getGeometry(predicates(i)));
-        }
-        else if constexpr (std::is_same_v<Tag, IntersectsWithRadiusTag>)
-        {
+        },
+        num_equal);
+  }
+  else if constexpr (std::is_same_v<Tag, IntersectsWithRadiusTag>)
+  {
+    Kokkos::parallel_reduce(
+        "Testing::check_predicates", Kokkos::RangePolicy(space, 0, n),
+        KOKKOS_LAMBDA(int i, int &update) {
           update += equals(ArborX::Sphere(data(i), args...),
                            ArborX::getGeometry(predicates(i)));
-        }
-        else if constexpr (std::is_same_v<Tag, NearestTag>)
-        {
+        },
+        num_equal);
+  }
+  else if constexpr (std::is_same_v<Tag, NearestTag>)
+  {
+    Kokkos::parallel_reduce(
+        "Testing::check_predicates", Kokkos::RangePolicy(space, 0, n),
+        KOKKOS_LAMBDA(int i, int &update) {
           update += equals(data(i), ArborX::getGeometry(predicates(i))) &&
                     (ArborX::getK(predicates(i)) ==
                      std::get<0>(std::make_tuple(args...)));
-        }
-      },
-      num_equal);
+        },
+        num_equal);
+  }
 
   return num_equal == n;
 }


### PR DESCRIPTION
Current implementation does not work because we don't call `AccessValues` constructor explicitly on the passed in data. This PR changes that, allowing to call `make_intersects` and friends on the data that is only provided through `AccessTraits`. Prior to this, `make_intersects` only worked with Kokkos views.

Fix #1231 

