### PR TITLE
Require Kokkos 4.5

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: kokkos/kokkos
-        ref: 4.4.00
+        ref: 4.6.00
         path: ${GITHUB_WORKSPACE}/../kokkos
     - name: Install Kokkos
       shell: bash

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -42,7 +42,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.5.2-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.3.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON" --build-arg CUDA_AWARE_MPI=1'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.5.2-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.5.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON" --build-arg CUDA_AWARE_MPI=1'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -103,7 +103,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.7.1-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.4.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.7.1-devel-ubuntu20.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -163,7 +163,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.0.3-devel-ubuntu18.04 --build-arg KOKKOS_VERSION="4.3.00" --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=clang++ -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.0.3-devel-ubuntu18.04 --build-arg KOKKOS_VERSION="4.5.00" --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=clang++ -DKokkos_ENABLE_THREADS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}'
                             label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
                         }
@@ -221,7 +221,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=ubuntu:18.04 --build-arg KOKKOS_VERSION=4.4.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=ubuntu:18.04 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                         }
@@ -283,7 +283,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=gcc:12.2.0 --build-arg KOKKOS_VERSION=4.4.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_CXX_COMPILER=g++ -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=gcc:12.2.0 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_CXX_COMPILER=g++ -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                         }
@@ -344,7 +344,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile.hipcc"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.6 --build-arg KOKKOS_VERSION=4.4.00 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.6 --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_ARCH=${KOKKOS_ARCH}'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES} --env AMDGPU_TARGET=${AMDGPU_TARGET}'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                         }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 # use gnu standard install directories
 include(GNUInstallDirs)
 
-find_package(Kokkos 4.3 REQUIRED CONFIG)
+find_package(Kokkos 4.5 REQUIRED CONFIG)
 message(STATUS "Found Kokkos: ${Kokkos_DIR} (version \"${Kokkos_VERSION}\")")
 
 # We use minimum compiler versions from Kokkos, with the exception for NVCC (>= 11.5)

--- a/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
+++ b/benchmarks/triangulated_surface_distance/triangulated_surface_distance.cpp
@@ -31,7 +31,7 @@ template <typename MemorySpace>
 struct Triangles
 {
   Kokkos::View<Point *, MemorySpace> _points;
-  Kokkos::View<KokkosArray<int, 3> *, MemorySpace> _triangle_vertices;
+  Kokkos::View<Kokkos::Array<int, 3> *, MemorySpace> _triangle_vertices;
 };
 
 template <typename MemorySpace>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -131,7 +131,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
 ENV LD_LIBRARY_PATH=/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}
 
 # Install Kokkos
-ARG KOKKOS_VERSION=4.3.00
+ARG KOKKOS_VERSION=4.5.00
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_CUDA=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -89,7 +89,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     rm -rf ${SCRATCH_DIR}
 
 # Install Kokkos
-ARG KOKKOS_VERSION=4.3.00
+ARG KOKKOS_VERSION=4.5.00
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_OPENMP=ON"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -127,7 +127,7 @@ RUN SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     rm -rf ${SCRATCH_DIR}
 
 # Install Kokkos
-ARG KOKKOS_VERSION=4.3.00
+ARG KOKKOS_VERSION=4.5.00
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SYCL=ON -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON -DKokkos_ARCH_VOLTA70=ON -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS=-w"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \

--- a/src/cluster/detail/ArborX_CartesianGrid.hpp
+++ b/src/cluster/detail/ArborX_CartesianGrid.hpp
@@ -142,13 +142,8 @@ private:
 };
 
 template <int DIM, typename Coordinate>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    CartesianGrid(Box<DIM, Coordinate>, Coordinate)
-        -> CartesianGrid<DIM, Coordinate>;
+KOKKOS_DEDUCTION_GUIDE CartesianGrid(Box<DIM, Coordinate>, Coordinate)
+    -> CartesianGrid<DIM, Coordinate>;
 
 } // namespace ArborX::Details
 

--- a/src/distributed/ArborX_DistributedTree.hpp
+++ b/src/distributed/ArborX_DistributedTree.hpp
@@ -151,14 +151,9 @@ public:
 };
 
 template <typename ExecutionSpace, typename Values>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    DistributedTree(MPI_Comm, ExecutionSpace, Values)
-        -> DistributedTree<typename Details::AccessValues<Values>::memory_space,
-                           typename Details::AccessValues<Values>::value_type>;
+KOKKOS_DEDUCTION_GUIDE DistributedTree(MPI_Comm, ExecutionSpace, Values)
+    -> DistributedTree<typename Details::AccessValues<Values>::memory_space,
+                       typename Details::AccessValues<Values>::value_type>;
 
 template <typename BottomTree>
 template <typename ExecutionSpace, typename... Args>

--- a/src/geometry/ArborX_Box.hpp
+++ b/src/geometry/ArborX_Box.hpp
@@ -67,12 +67,7 @@ struct Box
 };
 
 template <typename T, std::size_t N>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-Box(T const (&)[N], T const (&)[N]) -> Box<N, T>;
+KOKKOS_DEDUCTION_GUIDE Box(T const (&)[N], T const (&)[N]) -> Box<N, T>;
 
 } // namespace ArborX
 

--- a/src/geometry/ArborX_Ellipsoid.hpp
+++ b/src/geometry/ArborX_Ellipsoid.hpp
@@ -71,12 +71,8 @@ struct Ellipsoid
 };
 
 template <typename T, std::size_t N>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-Ellipsoid(T const (&)[N], T const (&)[N][N]) -> Ellipsoid<N, T>;
+KOKKOS_DEDUCTION_GUIDE Ellipsoid(T const (&)[N], T const (&)[N][N])
+    -> Ellipsoid<N, T>;
 
 } // namespace ArborX::Experimental
 

--- a/src/geometry/ArborX_Point.hpp
+++ b/src/geometry/ArborX_Point.hpp
@@ -38,22 +38,12 @@ struct Point
 };
 
 template <typename T, typename... Ts>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-Point(T, Ts...)
+KOKKOS_DEDUCTION_GUIDE Point(T, Ts...)
     -> Point<sizeof...(Ts) + 1,
              std::enable_if_t<std::conjunction_v<std::is_same<T, Ts>...>, T>>;
 
 template <typename T, std::size_t N>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-Point(T const (&)[N])
+KOKKOS_DEDUCTION_GUIDE Point(T const (&)[N])
     -> Point<N, std::enable_if_t<std::is_floating_point_v<T>, T>>;
 
 } // namespace ArborX

--- a/src/geometry/ArborX_Segment.hpp
+++ b/src/geometry/ArborX_Segment.hpp
@@ -27,21 +27,11 @@ struct Segment
 };
 
 template <int DIM, typename Coordinate>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    Segment(Point<DIM, Coordinate>, Point<DIM, Coordinate>)
-        -> Segment<DIM, Coordinate>;
+KOKKOS_DEDUCTION_GUIDE Segment(Point<DIM, Coordinate>, Point<DIM, Coordinate>)
+    -> Segment<DIM, Coordinate>;
 
 template <int N, typename T>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-Segment(T const (&)[N], T const (&)[N]) -> Segment<N, T>;
+KOKKOS_DEDUCTION_GUIDE Segment(T const (&)[N], T const (&)[N]) -> Segment<N, T>;
 
 } // namespace ArborX::Experimental
 

--- a/src/geometry/ArborX_Sphere.hpp
+++ b/src/geometry/ArborX_Sphere.hpp
@@ -47,12 +47,7 @@ struct Sphere
 };
 
 template <typename T, std::size_t N>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-Sphere(T const (&)[N], T) -> Sphere<N, T>;
+KOKKOS_DEDUCTION_GUIDE Sphere(T const (&)[N], T) -> Sphere<N, T>;
 
 } // namespace ArborX
 

--- a/src/geometry/ArborX_Triangle.hpp
+++ b/src/geometry/ArborX_Triangle.hpp
@@ -26,21 +26,13 @@ struct Triangle
 };
 
 template <int DIM, class Coordinate>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    Triangle(Point<DIM, Coordinate>, Point<DIM, Coordinate>,
-             Point<DIM, Coordinate>) -> Triangle<DIM, Coordinate>;
+KOKKOS_DEDUCTION_GUIDE Triangle(Point<DIM, Coordinate>, Point<DIM, Coordinate>,
+                                Point<DIM, Coordinate>)
+    -> Triangle<DIM, Coordinate>;
 
 template <typename T, std::size_t N>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-Triangle(T const (&)[N], T const (&)[N], T const (&)[N]) -> Triangle<N, T>;
+KOKKOS_DEDUCTION_GUIDE Triangle(T const (&)[N], T const (&)[N], T const (&)[N])
+    -> Triangle<N, T>;
 
 } // namespace ArborX
 

--- a/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -118,20 +118,19 @@ public:
     coefficientsComputation(phi, vandermonde, moment, coefficients);
   }
 
-  Kokkos::TeamPolicy<ExecutionSpace>
-  makePolicy(ExecutionSpace const &space) const
+  auto makePolicy(ExecutionSpace const &space) const
   {
-    Kokkos::TeamPolicy<ExecutionSpace> dummy_policy(space, 1, Kokkos::AUTO);
+    Kokkos::TeamPolicy dummy_policy(space, 1, Kokkos::AUTO);
     dummy_policy.set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
     int team_size =
         dummy_policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
     if (team_size != 0)
     {
       int league_size = (_num_targets + team_size - 1) / team_size;
-      return Kokkos::TeamPolicy<ExecutionSpace>(space, league_size, team_size)
+      return Kokkos::TeamPolicy(space, league_size, team_size)
           .set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
     }
-    return Kokkos::TeamPolicy<ExecutionSpace>(space, _num_targets, 1, 1)
+    return Kokkos::TeamPolicy(space, _num_targets, 1, 1)
         .set_scratch_size(0, Kokkos::PerTeam(perTargetMem()));
   }
 

--- a/src/spatial/ArborX_BruteForce.hpp
+++ b/src/spatial/ArborX_BruteForce.hpp
@@ -100,25 +100,15 @@ private:
 };
 
 template <typename ExecutionSpace, typename Values>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    BruteForce(ExecutionSpace, Values)
-        -> BruteForce<typename Details::AccessValues<Values>::memory_space,
-                      typename Details::AccessValues<Values>::value_type>;
+KOKKOS_DEDUCTION_GUIDE BruteForce(ExecutionSpace, Values)
+    -> BruteForce<typename Details::AccessValues<Values>::memory_space,
+                  typename Details::AccessValues<Values>::value_type>;
 
 template <typename ExecutionSpace, typename Values, typename IndexableGetter>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    BruteForce(ExecutionSpace, Values, IndexableGetter)
-        -> BruteForce<typename Details::AccessValues<Values>::memory_space,
-                      typename Details::AccessValues<Values>::value_type,
-                      IndexableGetter>;
+KOKKOS_DEDUCTION_GUIDE BruteForce(ExecutionSpace, Values, IndexableGetter)
+    -> BruteForce<typename Details::AccessValues<Values>::memory_space,
+                  typename Details::AccessValues<Values>::value_type,
+                  IndexableGetter>;
 
 template <typename MemorySpace, typename Value, typename IndexableGetter,
           typename BoundingVolume>

--- a/src/spatial/ArborX_LinearBVH.hpp
+++ b/src/spatial/ArborX_LinearBVH.hpp
@@ -141,26 +141,17 @@ private:
 };
 
 template <typename ExecutionSpace, typename Values>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    BoundingVolumeHierarchy(ExecutionSpace, Values) -> BoundingVolumeHierarchy<
+KOKKOS_DEDUCTION_GUIDE BoundingVolumeHierarchy(ExecutionSpace, Values)
+    -> BoundingVolumeHierarchy<
         typename Details::AccessValues<Values>::memory_space,
         typename Details::AccessValues<Values>::value_type>;
 
 template <typename ExecutionSpace, typename Values, typename IndexableGetter>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    BoundingVolumeHierarchy(ExecutionSpace, Values, IndexableGetter)
-        -> BoundingVolumeHierarchy<
-            typename Details::AccessValues<Values>::memory_space,
-            typename Details::AccessValues<Values>::value_type,
-            IndexableGetter>;
+KOKKOS_DEDUCTION_GUIDE BoundingVolumeHierarchy(ExecutionSpace, Values,
+                                               IndexableGetter)
+    -> BoundingVolumeHierarchy<
+        typename Details::AccessValues<Values>::memory_space,
+        typename Details::AccessValues<Values>::value_type, IndexableGetter>;
 
 template <typename MemorySpace, typename Value,
           typename IndexableGetter = Experimental::DefaultIndexableGetter,

--- a/src/spatial/detail/ArborX_ExpandHalfToFull.hpp
+++ b/src/spatial/detail/ArborX_ExpandHalfToFull.hpp
@@ -50,7 +50,7 @@ void expandHalfToFull(ExecutionSpace const &space, Offsets &offsets,
                                  "ArborX::Experimental::HalfToFull::counts");
   Kokkos::parallel_for(
       "ArborX::Experimental::HalfToFull::rewrite",
-      Kokkos::TeamPolicy<ExecutionSpace>(space, n, Kokkos::AUTO, 1),
+      Kokkos::TeamPolicy(space, n, Kokkos::AUTO, 1),
       KOKKOS_LAMBDA(
           typename Kokkos::TeamPolicy<ExecutionSpace>::member_type const
               &member) {

--- a/src/spatial/detail/ArborX_IndexableGetter.hpp
+++ b/src/spatial/detail/ArborX_IndexableGetter.hpp
@@ -78,12 +78,8 @@ struct Indexables
 
 #ifdef KOKKOS_ENABLE_CXX17
 template <typename Values, typename IndexableGetter>
-#if KOKKOS_VERSION >= 40400
-KOKKOS_DEDUCTION_GUIDE
-#else
-KOKKOS_FUNCTION
-#endif
-    Indexables(Values, IndexableGetter) -> Indexables<Values, IndexableGetter>;
+KOKKOS_DEDUCTION_GUIDE Indexables(Values, IndexableGetter)
+    -> Indexables<Values, IndexableGetter>;
 #endif
 
 } // namespace Details

--- a/src/spatial/detail/ArborX_NeighborList.hpp
+++ b/src/spatial/detail/ArborX_NeighborList.hpp
@@ -163,7 +163,7 @@ void findFullNeighborList(ExecutionSpace const &space,
   auto counts_copy = KokkosExt::clone(space, counts, counts.label() + "_copy");
   Kokkos::parallel_for(
       "ArborX::Experimental::FullNeighborList::Copy",
-      Kokkos::TeamPolicy<ExecutionSpace>(space, n, Kokkos::AUTO, 1),
+      Kokkos::TeamPolicy(space, n, Kokkos::AUTO, 1),
       KOKKOS_LAMBDA(
           typename Kokkos::TeamPolicy<ExecutionSpace>::member_type const
               &member) {

--- a/test/tstDetailsSVD.cpp
+++ b/test/tstDetailsSVD.cpp
@@ -43,7 +43,7 @@ void makeCase(ExecutionSpace const &exec, Value const (&src_arr)[M][N][N],
     // Test SVD
     Kokkos::deep_copy(exec, inv, src);
     Kokkos::parallel_for(
-        "Testing::run_svd", Kokkos::RangePolicy<ExecutionSpace>(exec, 0, 1),
+        "Testing::run_svd", Kokkos::RangePolicy(exec, 0, 1),
         KOKKOS_LAMBDA(int) {
           ArborX::Details::symmetricSVDKernel(inv, diag, unit);
           for (int p = 0; p < N; ++p)
@@ -59,7 +59,7 @@ void makeCase(ExecutionSpace const &exec, Value const (&src_arr)[M][N][N],
     // Test pseudo-inverse through SVD
     Kokkos::deep_copy(exec, inv, src);
     Kokkos::parallel_for(
-        "Testing::run_inverse", Kokkos::RangePolicy<ExecutionSpace>(exec, 0, 1),
+        "Testing::run_inverse", Kokkos::RangePolicy(exec, 0, 1),
         KOKKOS_LAMBDA(int) {
           ArborX::Details::symmetricPseudoInverseSVDKernel(inv, diag, unit);
         });


### PR DESCRIPTION
Note: Trilinos 16.1 contains Kokkos 4.5.1. So this update will still allow ArborX work with the latest Trilinos.