### PR TITLE
Reduce GCC parallelism further to -j3

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -309,7 +309,7 @@ pipeline {
                                     -D ARBORX_ENABLE_BENCHMARKS=ON \
                                 ..
                             '''
-                            sh 'make -j4 VERBOSE=1'
+                            sh 'make -j3 VERBOSE=1'
                             sh 'ctest $CTEST_OPTIONS'
                         }
                     }


### PR DESCRIPTION
Getting killed by `g++: fatal error: Killed signal terminated program cc1plus`. Likely OOM. It was passing before but maybe we are running in some new memory requirements now. Going to try to reduce. We are not spending much time building anyway on GCC.