### PR TITLE
Disable manufactured solution tree query test for SYCL with KDOP<14>

### DIFF
--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -38,16 +38,25 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
   using Point = ArborX::Point<DIM, Coordinate>;
   using Box = ArborX::Box<DIM, Coordinate>;
 
-  // FIXME_NVCC we see inexplainable test failures with NVCC and KDOP<18> and
-  // KDOP<26> here.
-#ifdef __NVCC__
   if constexpr (ArborX::GeometryTraits::is_kdop_v<BoundingVolume>)
   {
+#ifdef __NVCC__
+    // FIXME_NVCC inexplicable test failures with NVCC and KDOP<18> and KDOP<26>
     if constexpr (BoundingVolume::n_directions == 9 ||
                   BoundingVolume::n_directions == 13)
+    {
       return;
-  }
+    }
 #endif
+#if defined(KOKKOS_ENABLE_SYCL) && defined(__INTEL_LLVM_COMPILER)
+    // FIXME_INTEL inexplicable test failures with Intel and KDOP<14>
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL> &&
+                  BoundingVolume::n_directions == 7)
+    {
+      return;
+    }
+#endif
+  }
 
   Coordinate Lx = 100.0;
   Coordinate Ly = 100.0;


### PR DESCRIPTION
Fix #1234 