### PR TITLE
Fortify dendrogram test

### DIFF
--- a/test/tstDendrogram.cpp
+++ b/test/tstDendrogram.cpp
@@ -114,12 +114,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(dendrogram_boruvka, DeviceType,
 
   ExecutionSpace space;
 
+  int const n = 3000;
+
   // Choosing n > 5000 often results in MST producing edges of equal weight.
   // This is a bit problematic because there are multiple correspondoning
   // binary dendrograms which are all correct. This makes the comparison very
-  // hard, and something we want to avoid for now.
-  int const n = 3000;
-  auto points = ArborXTest::make_random_cloud<ArborX::Point<3>>(space, n);
+  // hard, and something we want to avoid for now. The box is changed from
+  // [0,1]^3 to [0,100]^3 to decrease the chance of having equal weights.
+  auto points = ArborXTest::make_random_cloud<ArborX::Point<3>>(space, n, 100.f,
+                                                                100.f, 100.f);
 
   ArborX::Experimental::MinimumSpanningTree<MemorySpace, BoruvkaMode::HDBSCAN>
       mst(space, points);


### PR DESCRIPTION
Dendrogram test can fail when the generated data produces an MST with equal edges. I was able to make the test fail using OpenMP on my Mac running the clustering test fewer than 10 times (using all threads; does not fail with OMP_NUM_THREADS=4).

One of the issues is that we draw the numbers from [0,1]^3 box, which may result in dropping the number of significant digits during distance calculation. As a workaround, I changed the box to [0, 100^3].

I can no longer reproduce the failure locally running it 1,000 times.

The alternative solution would be to use `double`. But at the moment, MST does not support any precision besides `float`.

This issue may fix #1113. It also spotted in #1196 ([this](https://github.com/arborx/ArborX/issues/1196#issuecomment-2524215592) comment).