### PR TITLE
Disable KDOP<18> manufactured query test for SYCL

### DIFF
--- a/test/tstQueryTreeManufacturedSolution.cpp
+++ b/test/tstQueryTreeManufacturedSolution.cpp
@@ -42,16 +42,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(structured_grid, TreeTypeTraits,
   {
 #ifdef __NVCC__
     // FIXME_NVCC inexplicable test failures with NVCC and KDOP<18> and KDOP<26>
-    if constexpr (BoundingVolume::n_directions == 9 ||
-                  BoundingVolume::n_directions == 13)
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda> &&
+                  (BoundingVolume::n_directions == 9 ||
+                   BoundingVolume::n_directions == 13))
     {
       return;
     }
 #endif
 #if defined(KOKKOS_ENABLE_SYCL) && defined(__INTEL_LLVM_COMPILER)
-    // FIXME_INTEL inexplicable test failures with Intel and KDOP<14>
+    // FIXME_INTEL inexplicable test failures with Intel and KDOP<14> and
+    // KDOP<18>
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL> &&
-                  BoundingVolume::n_directions == 7)
+                  (BoundingVolume::n_directions == 7 ||
+                   BoundingVolume::n_directions == 9))
     {
       return;
     }


### PR DESCRIPTION
Failed in #1250 (see [here](https://cloud1.cees.ornl.gov/jenkins-ci/job/ArborX/job/PR-1250/1/)).