### PR TITLE
Add barycentric coordinates algorithm (triangle and tetrahedron only)

### DIFF
--- a/src/geometry/algorithms/ArborX_BarycentricCoordinates.hpp
+++ b/src/geometry/algorithms/ArborX_BarycentricCoordinates.hpp
@@ -17,26 +17,31 @@
 #include <Kokkos_Array.hpp>
 #include <Kokkos_Macros.hpp>
 
-namespace ArborX::Details
+namespace ArborX
 {
-namespace Dispatch
+
+namespace Details::Dispatch
 {
 template <typename Tag1, typename Tag2, typename Geometry1, typename Geometry2>
 struct barycentric;
 }
 
+namespace Experimental
+{
 template <typename Geometry1, typename Geometry2>
 KOKKOS_INLINE_FUNCTION auto barycentricCoordinates(Geometry1 const &geometry1,
                                                    Geometry2 const &geometry2)
 {
   static_assert(GeometryTraits::dimension_v<Geometry1> ==
                 GeometryTraits::dimension_v<Geometry2>);
-  return Dispatch::barycentric<GeometryTraits::tag_t<Geometry1>,
-                               GeometryTraits::tag_t<Geometry2>, Geometry1,
-                               Geometry2>::apply(geometry1, geometry2);
+  return Details::Dispatch::barycentric<GeometryTraits::tag_t<Geometry1>,
+                                        GeometryTraits::tag_t<Geometry2>,
+                                        Geometry1, Geometry2>::apply(geometry1,
+                                                                     geometry2);
 }
+} // namespace Experimental
 
-namespace Dispatch
+namespace Details::Dispatch
 {
 
 using namespace GeometryTraits;
@@ -114,8 +119,8 @@ struct barycentric<TetrahedronTag, PointTag, Tetrahedron, Point>
   }
 };
 
-} // namespace Dispatch
+} // namespace Details::Dispatch
 
-} // namespace ArborX::Details
+} // namespace ArborX
 
 #endif

--- a/src/geometry/algorithms/ArborX_BarycentricCoordinates.hpp
+++ b/src/geometry/algorithms/ArborX_BarycentricCoordinates.hpp
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * Copyright (c) 2025, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#ifndef ARBORX_GEOMETRY_BARYCENTRIC_COORDINATES_HPP
+#define ARBORX_GEOMETRY_BARYCENTRIC_COORDINATES_HPP
+
+#include <ArborX_GeometryTraits.hpp>
+#include <misc/ArborX_Vector.hpp>
+
+#include <Kokkos_Array.hpp>
+#include <Kokkos_Macros.hpp>
+
+namespace ArborX::Details
+{
+namespace Dispatch
+{
+template <typename Tag1, typename Tag2, typename Geometry1, typename Geometry2>
+struct barycentric;
+}
+
+template <typename Geometry1, typename Geometry2>
+KOKKOS_INLINE_FUNCTION auto barycentricCoordinates(Geometry1 const &geometry1,
+                                                   Geometry2 const &geometry2)
+{
+  static_assert(GeometryTraits::dimension_v<Geometry1> ==
+                GeometryTraits::dimension_v<Geometry2>);
+  return Dispatch::barycentric<GeometryTraits::tag_t<Geometry1>,
+                               GeometryTraits::tag_t<Geometry2>, Geometry1,
+                               Geometry2>::apply(geometry1, geometry2);
+}
+
+namespace Dispatch
+{
+
+using namespace GeometryTraits;
+
+template <typename Triangle, typename Point>
+struct barycentric<TriangleTag, PointTag, Triangle, Point>
+{
+  KOKKOS_FUNCTION static constexpr auto apply(Triangle const &triangle,
+                                              Point const &point)
+  {
+    using Coordinate = GeometryTraits::coordinate_type_t<Point>;
+
+    // ArborX should probably provide the interpolation function
+    auto const a = triangle.a;
+    auto const b = triangle.b;
+    auto const c = triangle.c;
+
+    // Find coefficients alpha and beta such that
+    // x = a + alpha * (b - a) + beta * (c - a)
+    //   = (1 - alpha - beta) * a + alpha * b + beta * c
+    // recognizing the linear system
+    // ((b - a) (c - a)) (alpha beta)^T = (x - a)
+    Coordinate u[2] = {b[0] - a[0], b[1] - a[1]};
+    Coordinate v[2] = {c[0] - a[0], c[1] - a[1]};
+    Coordinate const det = v[1] * u[0] - v[0] * u[1];
+    if (det == 0)
+      Kokkos::abort("Degenerate triangles are not supported!");
+    auto const inv_det = 1 / det;
+
+    Coordinate alpha[2] = {v[1] * inv_det, -v[0] * inv_det};
+    Coordinate beta[2] = {-u[1] * inv_det, u[0] * inv_det};
+
+    auto alpha_coeff =
+        alpha[0] * (point[0] - a[0]) + alpha[1] * (point[1] - a[1]);
+    auto beta_coeff = beta[0] * (point[0] - a[0]) + beta[1] * (point[1] - a[1]);
+
+    return Kokkos::Array<Coordinate, 3>{1 - alpha_coeff - beta_coeff,
+                                        alpha_coeff, beta_coeff};
+  }
+};
+
+template <typename Tetrahedron, typename Point>
+struct barycentric<TetrahedronTag, PointTag, Tetrahedron, Point>
+{
+  template <typename Coordinate>
+  using Vector = ::ArborX::Details::Vector<3, Coordinate>;
+
+  template <typename Coordinate>
+  KOKKOS_FUNCTION static constexpr auto
+  triple_product(Vector<Coordinate> const &u, Vector<Coordinate> const &v,
+                 Vector<Coordinate> const &w)
+  {
+    return u.dot(v.cross(w));
+  }
+
+  KOKKOS_FUNCTION static constexpr auto apply(Tetrahedron const &tet,
+                                              Point const &point)
+  {
+    using Coordinate = GeometryTraits::coordinate_type_t<Point>;
+
+    auto ap = point - tet.a;
+    auto bp = point - tet.b;
+
+    auto ab = tet.b - tet.a;
+    auto ac = tet.c - tet.a;
+    auto ad = tet.d - tet.a;
+
+    auto bc = tet.c - tet.b;
+    auto bd = tet.d - tet.b;
+
+    auto denom = 1 / triple_product(ab, ac, ad);
+    return Kokkos::Array<Coordinate, 4>{
+        triple_product(bp, bd, bc) * denom, triple_product(ap, ac, ad) * denom,
+        triple_product(ap, ad, ab) * denom, triple_product(ap, ab, ac) * denom};
+  }
+};
+
+} // namespace Dispatch
+
+} // namespace ArborX::Details
+
+#endif

--- a/test/ArborX_EnableArrayComparison.hpp
+++ b/test/ArborX_EnableArrayComparison.hpp
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright (c) 2025, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef ARBORX_ENABLE_ARRAY_COMPARISON_HPP
+#define ARBORX_ENABLE_ARRAY_COMPARISON_HPP
+
+#include <Kokkos_Array.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+#include <boost/test/utils/is_forward_iterable.hpp>
+
+namespace boost::unit_test
+{
+
+template <typename T, size_t N>
+struct is_forward_iterable<Kokkos::Array<T, N>> : public boost::mpl::true_
+{};
+
+template <typename T, size_t N>
+struct bt_iterator_traits<Kokkos::Array<T, N>, true>
+{
+  using array_type = Kokkos::Array<T, N>;
+  using value_type = typename array_type::value_type;
+  using const_iterator = typename array_type::const_pointer;
+  static const_iterator begin(array_type const &v) { return v.data(); }
+  static const_iterator end(array_type const &v) { return v.data() + v.size(); }
+  static std::size_t size(array_type const &v) { return v.size(); }
+};
+
+} // namespace boost::unit_test
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,7 @@ target_include_directories(ArborX_Test_KokkosExt.exe PRIVATE ${CMAKE_CURRENT_BIN
 add_test(NAME ArborX_Test_KokkosExt COMMAND ArborX_Test_KokkosExt.exe)
 
 add_executable(ArborX_Test_Geometry.exe
+  tstGeometryBarycentricCoordinates.cpp
   tstGeometryCentroid.cpp
   tstGeometryDistance.cpp
   tstGeometryExpand.cpp

--- a/test/tstGeometryBarycentricCoordinates.cpp
+++ b/test/tstGeometryBarycentricCoordinates.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(barycentric_triangle)
 {
   using ArborX::Point;
   using ArborX::Triangle;
-  using ArborX::Details::barycentricCoordinates;
+  using ArborX::Experimental::barycentricCoordinates;
 
   Triangle<2> tri{{-1, -1}, {1, -1}, {-1, 1}};
   // clang-format off
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(barycentric_triangle)
 BOOST_AUTO_TEST_CASE(barycentric_tetrahedron)
 {
   using ArborX::Point;
-  using ArborX::Details::barycentricCoordinates;
+  using ArborX::Experimental::barycentricCoordinates;
   using ArborX::ExperimentalHyperGeometry::Tetrahedron;
 
   Tetrahedron<> tet{{0, 0, 0}, {0, 2, 0}, {2, 0, 0}, {0, 0, 2}};

--- a/test/tstGeometryBarycentricCoordinates.cpp
+++ b/test/tstGeometryBarycentricCoordinates.cpp
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * Copyright (c) 2025, ArborX authors                                       *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "ArborX_EnableArrayComparison.hpp"
+#include <ArborX_Box.hpp>
+#include <ArborX_GeometryTraits.hpp>
+#include <ArborX_Point.hpp>
+#include <ArborX_Tetrahedron.hpp>
+#include <ArborX_Triangle.hpp>
+#include <algorithms/ArborX_BarycentricCoordinates.hpp>
+
+#include "BoostTest_CUDA_clang_workarounds.hpp"
+#include <boost/test/unit_test.hpp>
+
+namespace tt = boost::test_tools;
+
+template <int N>
+using Array = Kokkos::Array<float, N>;
+
+BOOST_AUTO_TEST_CASE(barycentric_triangle)
+{
+  using ArborX::Point;
+  using ArborX::Triangle;
+  using ArborX::Details::barycentricCoordinates;
+
+  Triangle<2> tri{{-1, -1}, {1, -1}, {-1, 1}};
+  // clang-format off
+  // vertices
+  BOOST_TEST(barycentricCoordinates(tri, Point{-1.f, -1.f}) == (Array<3>{1, 0, 0}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tri, Point{1.f, -1.f}) == (Array<3>{0, 1, 0}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tri, Point{-1.f, 1.f}) == (Array<3>{0, 0, 1}), tt::per_element());
+  // mid edges
+  BOOST_TEST(barycentricCoordinates(tri, Point{0.f, -1.f}) == (Array<3>{0.5f, 0.5f, 0}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tri, Point{-1.f, 0.f}) == (Array<3>{0.5f, 0, 0.5f}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tri, Point{0.f, 0.f}) == (Array<3>{0, 0.5f, 0.5f}), tt::per_element());
+  // center
+  BOOST_TEST(barycentricCoordinates(tri, Point{-1.f/3, -1.f/3}) == (Array<3>{1.f/3, 1.f/3, 1.f/3}), tt::tolerance(1e-7f) << tt::per_element());
+  // off-center
+  BOOST_TEST(barycentricCoordinates(tri, Point{-0.4f, 0.2f}) == (Array<3>{0.1f, 0.3f, 0.6f}), tt::tolerance(1e-6f) << tt::per_element());
+  // clang-format on
+}
+
+BOOST_AUTO_TEST_CASE(barycentric_tetrahedron)
+{
+  using ArborX::Point;
+  using ArborX::Details::barycentricCoordinates;
+  using ArborX::ExperimentalHyperGeometry::Tetrahedron;
+
+  Tetrahedron<> tet{{0, 0, 0}, {0, 2, 0}, {2, 0, 0}, {0, 0, 2}};
+  // clang-format off
+  // vertices
+  BOOST_TEST(barycentricCoordinates(tet, Point{0.f, 0.f, 0.f}) == (Array<4>{1, 0, 0, 0}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tet, Point{0.f, 2.f, 0.f}) == (Array<4>{0, 1, 0, 0}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tet, Point{2.f, 0.f, 0.f}) == (Array<4>{0, 0, 1, 0}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tet, Point{0.f, 0.f, 2.f}) == (Array<4>{0, 0, 0, 1}), tt::per_element());
+  // (some) mid edges
+  BOOST_TEST(barycentricCoordinates(tet, Point{0.f, 1.f, 0.f}) == (Array<4>{0.5f, 0.5f, 0, 0}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tet, Point{0.f, 1.f, 1.f}) == (Array<4>{0, 0.5f, 0, 0.5f}), tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tet, Point{1.f, 0.f, 1.f}) == (Array<4>{0, 0, 0.5f, 0.5f}), tt::per_element());
+  // (some) mid faces
+  BOOST_TEST(barycentricCoordinates(tet, Point{2.f/3, 2.f/3, 0.f}) == (Array<4>{1.f/3, 1.f/3, 1.f/3, 0}), tt::tolerance(1e-6f) << tt::per_element());
+  BOOST_TEST(barycentricCoordinates(tet, Point{2.f/3, 2.f/3, 2.f/3}) == (Array<4>{0, 1.f/3, 1.f/3, 1.f/3}), tt::tolerance(1e-7f) << tt::per_element());
+  // center
+  BOOST_TEST(barycentricCoordinates(tet, Point{0.5f, 0.5f, 0.5f}) == (Array<4>{0.25f, 0.25f, 0.25f, 0.25f}), tt::tolerance(1e-7f) << tt::per_element());
+  // clang-format on
+}


### PR DESCRIPTION
Add barycentric coordinates calculations for triangle and tetrahedron.
Adding to ArborX because it is useful for many other applications (e.g., interpolation).