### PR TITLE
Disable SYCL KDOP<14> for query comparison with Boost

### DIFF
--- a/test/tstQueryTreeComparisonWithBoost.cpp
+++ b/test/tstQueryTreeComparisonWithBoost.cpp
@@ -116,14 +116,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(boost_rtree_spatial_predicate, TreeTypeTraits,
 
   // FIXME_NVCC we see inexplainable test failures with NVCC and KDOP<18> and
   // KDOP<26> here.
-#ifdef __NVCC__
   if constexpr (ArborX::GeometryTraits::is_kdop_v<BoundingVolume>)
   {
-    if constexpr (BoundingVolume::n_directions == 9 ||
-                  BoundingVolume::n_directions == 13)
+#ifdef __NVCC__
+    // FIXME_NVCC inexplicable test failures with NVCC and KDOP<18> and KDOP<26>
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda> &&
+                  (BoundingVolume::n_directions == 9 ||
+                   BoundingVolume::n_directions == 13))
       return;
-  }
 #endif
+#if defined(KOKKOS_ENABLE_SYCL) && defined(__INTEL_LLVM_COMPILER)
+    // FIXME_INTEL inexplicable test failures with Intel and KDOP<14>
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL> &&
+                  BoundingVolume::n_directions == 7)
+      return;
+#endif
+  }
 
   // construct a cloud of points (nodes of a structured grid)
   Coordinate Lx = 10.0;


### PR DESCRIPTION
Failed in #1260 ([failure](https://cloud1.cees.ornl.gov/jenkins-ci/job/ArborX/job/PR-1260/4/testReport/junit/projectroot/test/Build___SYCL___ArborX_Test_QueryTree/)).