### PR TITLE
Add a very light non-performant version of APIv1 back

### DIFF
--- a/benchmarks/bvh_driver/benchmark_registration.hpp
+++ b/benchmarks/bvh_driver/benchmark_registration.hpp
@@ -33,24 +33,6 @@ struct is_boost_rtree<BoostExt::RTree<Geometry>> : std::true_type
 template <typename Geometry>
 inline constexpr bool is_boost_rtree_v = is_boost_rtree<Geometry>::value;
 
-template <typename MemorySpace>
-struct Iota
-{
-  static_assert(Kokkos::is_memory_space_v<MemorySpace>);
-  using memory_space = MemorySpace;
-  int _n;
-};
-
-template <typename MemorySpace>
-struct ArborX::AccessTraits<Iota<MemorySpace>>
-{
-  using Self = Iota<MemorySpace>;
-
-  using memory_space = typename Self::memory_space;
-  static KOKKOS_FUNCTION size_t size(Self const &self) { return self._n; }
-  static KOKKOS_FUNCTION auto get(Self const &, int i) { return i; }
-};
-
 struct Spec
 {
   using PointCloudType = ArborXBenchmark::PointCloudType;
@@ -154,10 +136,7 @@ auto makeTree(ExecutionSpace const &space, Primitives const &primitives)
   if constexpr (is_boost_rtree_v<TreeType>)
     return TreeType(space, primitives);
   else
-    return TreeType(space,
-                    Iota<typename TreeType::memory_space>{
-                        static_cast<int>(primitives.size())},
-                    primitives);
+    return ArborX::create_index<TreeType>(space, primitives.size(), primitives);
 }
 
 template <typename DeviceType>

--- a/examples/brute_force/example_brute_force.cpp
+++ b/examples/brute_force/example_brute_force.cpp
@@ -23,24 +23,6 @@ struct Dummy
 using ExecutionSpace = Kokkos::DefaultExecutionSpace;
 using MemorySpace = ExecutionSpace::memory_space;
 
-template <typename MemorySpace>
-struct Iota
-{
-  static_assert(Kokkos::is_memory_space_v<MemorySpace>);
-  using memory_space = MemorySpace;
-  int _n;
-};
-
-template <typename MemorySpace>
-struct ArborX::AccessTraits<Iota<MemorySpace>>
-{
-  using Self = Iota<MemorySpace>;
-
-  using memory_space = typename Self::memory_space;
-  static KOKKOS_FUNCTION size_t size(Self const &self) { return self._n; }
-  static KOKKOS_FUNCTION auto get(Self const &, int i) { return i; }
-};
-
 struct DummyIndexableGetter
 {
   int count;
@@ -87,13 +69,13 @@ int main(int argc, char *argv[])
   int nprimitives = 5;
   int npredicates = 5;
 
-  Iota<MemorySpace> primitives{nprimitives};
   DummyIndexableGetter indexable_getter{nprimitives};
   Dummy predicates{npredicates};
 
   unsigned int out_count;
   {
-    ArborX::BoundingVolumeHierarchy bvh{space, primitives, indexable_getter};
+    auto bvh = ArborX::create_index<ArborX::BoundingVolumeHierarchy>(
+        space, nprimitives, indexable_getter);
 
     Kokkos::View<int *, ExecutionSpace> indices("Example::indices_ref", 0);
     Kokkos::View<int *, ExecutionSpace> offset("Example::offset_ref", 0);
@@ -106,7 +88,8 @@ int main(int argc, char *argv[])
   }
 
   {
-    ArborX::BruteForce brute{space, primitives, indexable_getter};
+    auto brute = ArborX::create_index<ArborX::BruteForce>(space, nprimitives,
+                                                          indexable_getter);
 
     Kokkos::View<int *, ExecutionSpace> indices("Example::indices", 0);
     Kokkos::View<int *, ExecutionSpace> offset("Example::offset", 0);

--- a/examples/custom_distance/example_custom_distance.cpp
+++ b/examples/custom_distance/example_custom_distance.cpp
@@ -99,13 +99,13 @@ int main(int argc, char *argv[])
   query_points_host[0] = {0, 1};
   Kokkos::deep_copy(query_points, query_points_host);
 
-  ArborX::BoundingVolumeHierarchy bvh(
-      space, ArborX::Experimental::attach_indices(points));
+  auto bvh = ArborX::create_index<ArborX::BoundingVolumeHierarchy>(
+      space, points.size(), points);
 
   Kokkos::View<int *, MemorySpace> offsets("Example::offsets", 0);
   Kokkos::View<int *, MemorySpace> indices("Example::indices", 0);
-  bvh.query(space, ArborX::Experimental::make_nearest(query_points, 2),
-            ArborX::Experimental::ExtractPairIndexCallback{}, indices, offsets);
+  bvh.query(space, ArborX::Experimental::make_nearest(query_points, 2), indices,
+            offsets);
 
   auto offsets_host =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, offsets);

--- a/src/spatial/ArborX_CrsGraphWrapper.hpp
+++ b/src/spatial/ArborX_CrsGraphWrapper.hpp
@@ -12,9 +12,16 @@
 #ifndef ARBORX_CRS_GRAPH_WRAPPER_HPP
 #define ARBORX_CRS_GRAPH_WRAPPER_HPP
 
+#include <ArborX_Config.hpp>
+
 #include <detail/ArborX_AccessTraits.hpp>
+#include <detail/ArborX_Iota.hpp>
 
 #include <Kokkos_Core.hpp>
+
+#ifdef ARBORX_ENABLE_MPI
+#include <mpi.h>
+#endif
 
 namespace ArborX
 {
@@ -32,6 +39,62 @@ inline void query(Tree const &tree, ExecutionSpace const &space,
   tree.query(space, predicates, std::forward<CallbackOrView>(callback_or_view),
              std::forward<View>(view), std::forward<Args>(args)...);
 }
+
+template <template <typename...> class Index, typename MemorySpace,
+          typename ExecutionSpace, typename IndexableGetter>
+auto create_index(ExecutionSpace const &space, int size,
+                  IndexableGetter &&indexable_getter)
+{
+  return Index<MemorySpace, int, IndexableGetter>(
+      space, Details::Iota<MemorySpace>(size),
+      std::forward<IndexableGetter>(indexable_getter));
+}
+
+template <template <typename...> class Index, typename ExecutionSpace,
+          typename IndexableGetter>
+auto create_index(ExecutionSpace const &space, int size,
+                  IndexableGetter &&indexable_getter)
+{
+  return create_index<Index, typename ExecutionSpace::memory_space>(
+      space, size, std::forward<IndexableGetter>(indexable_getter));
+}
+
+template <typename Index, typename ExecutionSpace, typename IndexableGetter>
+auto create_index(ExecutionSpace const &space, int size,
+                  IndexableGetter &&indexable_getter)
+{
+  return Index(space, Details::Iota<typename Index::memory_space>(size),
+               std::forward<IndexableGetter>(indexable_getter));
+}
+
+#ifdef ARBORX_ENABLE_MPI
+template <template <typename...> class Index, typename MemorySpace,
+          typename ExecutionSpace, typename IndexableGetter>
+auto create_index(MPI_Comm comm, ExecutionSpace const &space, int size,
+                  IndexableGetter &&indexable_getter)
+{
+  return Index<MemorySpace, int, IndexableGetter>(
+      comm, space, Details::Iota<MemorySpace>(size),
+      std::forward<IndexableGetter>(indexable_getter));
+}
+
+template <template <typename...> class Index, typename ExecutionSpace,
+          typename IndexableGetter>
+auto create_index(MPI_Comm comm, ExecutionSpace const &space, int size,
+                  IndexableGetter &&indexable_getter)
+{
+  return create_index<Index, typename ExecutionSpace::memory_space>(
+      comm, space, size, std::forward<IndexableGetter>(indexable_getter));
+}
+
+template <typename Index, typename ExecutionSpace, typename IndexableGetter>
+auto create_index(MPI_Comm comm, ExecutionSpace const &space, int size,
+                  IndexableGetter &&indexable_getter)
+{
+  return Index(comm, space, Details::Iota<typename Index::memory_space>(size),
+               std::forward<IndexableGetter>(indexable_getter));
+}
+#endif
 
 } // namespace ArborX
 

--- a/test/tstQueryTreeIntersectsKDOP.cpp
+++ b/test/tstQueryTreeIntersectsKDOP.cpp
@@ -13,7 +13,6 @@
 #include <ArborX_KDOP.hpp>
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_Point.hpp>
-#include <detail/ArborX_Iota.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -46,8 +45,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(intersects_kdop, DeviceType, ARBORX_DEVICE_TYPES)
       {{0, 0, 2}}, // 11
       {{0, 0, 3}}, // 12
   };
-  ArborX::BoundingVolumeHierarchy const tree(
-      ExecutionSpace{}, ArborX::Details::Iota<MemorySpace>(primitives.size()),
+  auto tree = ArborX::create_index<ArborX::BoundingVolumeHierarchy>(
+      ExecutionSpace{}, primitives.size(),
       Kokkos::create_mirror_view_and_copy(
           MemorySpace{},
           Kokkos::View<Point *, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(


### PR DESCRIPTION
Performant version of using `PairValueIndex` is really challenging to grasp initially. For new users, this introduces too steep of a learning curve, potentially making people give up.

Instead, it may make more sense to provide something much easier even if it does not have the best performance.

This PR introduces a new constructor to `BVH` and `BruteForce`:
```
Index(ExecutionSpace, int, indexable_getter)
```
This way, users will only have to write indexable getter, which should provide a lower barrier for entry.
Because we won't store the leaf nodes' geometries, it will result in a penalty during the traversal.

I'd like to hear the thoughts.