### PR TITLE
Update minimum clang version for aggregate initialization guide

### DIFF
--- a/src/cluster/detail/ArborX_DistributedDBSCANHelpers.hpp
+++ b/src/cluster/detail/ArborX_DistributedDBSCANHelpers.hpp
@@ -46,10 +46,11 @@ struct PointsRequiringResolution
   Coordinate _eps;
 };
 
-// FIXME_CLANG(Clang<17): Clang 16 or earlier does not support aggregate
-// initialization type deduction
+// FIXME_CLANG(Clang<=17): Clang 16 and some Clang 17 based compilers do not
+// support aggregate initialization type deduction
 // https://github.com/llvm/llvm-project/issues/54050
-#if defined(__clang__) && (__clang_major__ < 17)
+// Reproducer: https://godbolt.org/z/nEdjb5rP4
+#if defined(__clang__) && KOKKOS_COMPILER_CLANG < 17001
 template <typename Points, typename GhostPoints>
 KOKKOS_DEDUCTION_GUIDE UnifiedPoints(Points, GhostPoints)
     -> UnifiedPoints<Points, GhostPoints>;

--- a/src/spatial/detail/ArborX_IndexableGetter.hpp
+++ b/src/spatial/detail/ArborX_IndexableGetter.hpp
@@ -77,10 +77,11 @@ struct Indexables
   KOKKOS_FUNCTION auto size() const { return _values.size(); }
 };
 
-// FIXME_CLANG(Clang<17): Clang 16 or earlier does not support aggregate
-// initialization type deduction
+// FIXME_CLANG(Clang<=17): Clang 16 and some Clang 17 based compilers do not
+// support aggregate initialization type deduction
 // https://github.com/llvm/llvm-project/issues/54050
-#if defined(__clang__) && (__clang_major__ < 17)
+// Reproducer: https://godbolt.org/z/nEdjb5rP4
+#if defined(__clang__) && KOKKOS_COMPILER_CLANG < 17001
 template <typename Values, typename IndexableGetter>
 KOKKOS_DEDUCTION_GUIDE Indexables(Values, IndexableGetter)
     -> Indexables<Values, IndexableGetter>;


### PR DESCRIPTION
Compilers reporting 17.0.0 are actually based on different sources trees. Some of them fail, some succeed. I think it's safe to only check for < 17.0.1 ([godbolt](https://godbolt.org/z/nEdjb5rP4)).

| Compiler | Status | Reported clang version
| --- | --- | ---
| icx 2023.2.1 | ❌  | 17.0.0 (icx 2023.2.0.20230721)
| icx 2024.0.0 | ✔️ | 17.0.0 (icx 2024.0.0.20231017)
| rocm 5.7.0 | ❌ | 17.0.0 (https://gihub.com/RadeonOpenCompute/llvm-project d1e13c532a947d0cbfc94759c00dcf152294aa13 | Failure
| rocm 6.0.2 | ❌ | 17.0.0 (https://github.com/RadeonOpenCompute/llvm-project.git af27734ed982b52a9f1be0f035ac91726fc697e4 | Failure
| rocm 6.1.2 | ✔️ | 17.0.0 (https://github.com/ROCm/llvm-project.git 669db884972e769450470020c06a6f132a8a065b) | Success
| clang 16.0.0 | ❌  |
| clang 17.0.1 | ✔️ |
| Apple clang | ❌ | 17.0.0 (clang-1700.0.13.5) 
