### PR TITLE
Change HostMirror -> host_mirror_type

### DIFF
--- a/test/tstDetailsSVD.cpp
+++ b/test/tstDetailsSVD.cpp
@@ -22,7 +22,7 @@ void makeCase(ExecutionSpace const &exec, Value const (&src_arr)[M][N][N],
               Value const (&ref_arr)[M][N][N])
 {
   using DeviceView = Kokkos::View<Value[N][N], MemorySpace>;
-  using HostView = typename DeviceView::HostMirror;
+  using HostView = typename DeviceView::host_mirror_type;
 
   HostView src("Testing::src");
   HostView ref("Testing::ref");

--- a/test/tstInterpDetailsCompactRadialBasisFunction.cpp
+++ b/test/tstInterpDetailsCompactRadialBasisFunction.cpp
@@ -23,7 +23,7 @@ void makeCase(ES const &es, std::function<T(T const)> const &tf, T tol = 1e-5)
 {
   using Point = ArborX::Point<1, T>;
   using View = Kokkos::View<T *, typename ES::memory_space>;
-  using HostView = typename View::HostMirror;
+  using HostView = typename View::host_mirror_type;
   static constexpr int range = 15;
 
   HostView input("Testing::input", 4 * range);


### PR DESCRIPTION
@Rombur noticed nightly CI complaints
```
no type named 'HostMirror' in 'using DeviceView = class Kokkos::View' {aka 'class Kokkos::View'}
```

`HostMirror` is deprecated, see kokkos/kokkos#8232.
`HostMirror` and `host_mirror_type` are equivalent since kokkos/kokkos#7244 (which is pre Kokkos 4.5).