### PR TITLE
Change --binary to --ascii when data loading in cluster benchmarks

### DIFF
--- a/benchmarks/cluster/CMakeLists.txt
+++ b/benchmarks/cluster/CMakeLists.txt
@@ -10,17 +10,17 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${input_file} ${CMAKE_CURRENT_BINARY_
 add_executable(ArborX_Benchmark_DBSCAN.exe dbscan.cpp)
 target_include_directories(ArborX_Benchmark_DBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(ArborX_Benchmark_DBSCAN.exe ArborX::ArborX Boost::program_options cluster_benchmark_helpers)
-add_test(NAME ArborX_Benchmark_DBSCAN COMMAND ArborX_Benchmark_DBSCAN.exe --filename=${input_file} --eps=1.4 --verify)
+add_test(NAME ArborX_Benchmark_DBSCAN COMMAND ArborX_Benchmark_DBSCAN.exe --ascii --filename=${input_file} --eps=1.4 --verify)
 
 add_executable(ArborX_Benchmark_MST.exe mst.cpp)
 target_include_directories(ArborX_Benchmark_MST.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(ArborX_Benchmark_MST.exe ArborX::ArborX Boost::program_options cluster_benchmark_helpers)
-add_test(NAME ArborX_Benchmark_HDBSCAN COMMAND ArborX_Benchmark_HDBSCAN.exe --filename=${input_file})
+add_test(NAME ArborX_Benchmark_HDBSCAN COMMAND ArborX_Benchmark_HDBSCAN.exe --ascii --filename=${input_file})
 
 add_executable(ArborX_Benchmark_HDBSCAN.exe hdbscan.cpp)
 target_include_directories(ArborX_Benchmark_HDBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(ArborX_Benchmark_HDBSCAN.exe ArborX::ArborX Boost::program_options cluster_benchmark_helpers)
-add_test(NAME ArborX_Benchmark_MST COMMAND ArborX_Benchmark_MST.exe --filename=${input_file})
+add_test(NAME ArborX_Benchmark_MST COMMAND ArborX_Benchmark_MST.exe --ascii --filename=${input_file})
 
 if (ARBORX_ENABLE_MPI)
   add_executable(ArborX_Benchmark_DistributedDBSCAN.exe distributed_dbscan.cpp)

--- a/benchmarks/cluster/dbscan.cpp
+++ b/benchmarks/cluster/dbscan.cpp
@@ -261,10 +261,11 @@ int main(int argc, char *argv[])
   std::vector<std::string> allowed_impls = {"fdbscan", "fdbscan-densebox"};
 
   bpo::options_description desc("Allowed options");
+  bool ascii;
   // clang-format off
   desc.add_options()
       ( "help", "help message" )
-      ( "binary", bpo::bool_switch(&params.binary), "binary file indicator")
+      ( "ascii", bpo::bool_switch(&ascii), "ascii file indicator")
       ( "cluster-min-size", bpo::value<int>(&params.cluster_min_size)->default_value(1), "minimum cluster size")
       ( "core-min-size", bpo::value<int>(&params.core_min_size)->default_value(2), "DBSCAN min_pts")
       ( "dimension", bpo::value<int>(&params.dim)->default_value(-1), "dimension of points to generate" )
@@ -283,6 +284,8 @@ int main(int argc, char *argv[])
   bpo::variables_map vm;
   bpo::store(bpo::command_line_parser(argc, argv).options(desc).run(), vm);
   bpo::notify(vm);
+
+  params.binary = !ascii;
 
   if (vm.count("help") > 0)
   {

--- a/benchmarks/cluster/hdbscan.cpp
+++ b/benchmarks/cluster/hdbscan.cpp
@@ -117,10 +117,11 @@ int main(int argc, char *argv[])
   std::vector<std::string> allowed_dendrograms = {"boruvka", "union-find"};
 
   bpo::options_description desc("Allowed options");
+  bool ascii;
   // clang-format off
   desc.add_options()
       ( "help", "help message" )
-      ( "binary", bpo::bool_switch(&params.binary), "binary file indicator")
+      ( "ascii", bpo::bool_switch(&ascii), "ascii file indicator")
       ( "core-min-size", bpo::value<int>(&params.core_min_size)->default_value(2), "DBSCAN min_pts")
       ( "dendrogram", bpo::value<std::string>(&params.dendrogram)->default_value("boruvka"), ("dendrogram " + vec2string(allowed_dendrograms, " | ")).c_str() )
       ( "dimension", bpo::value<int>(&params.dim)->default_value(-1), "dimension of points to generate" )
@@ -134,6 +135,8 @@ int main(int argc, char *argv[])
   bpo::variables_map vm;
   bpo::store(bpo::command_line_parser(argc, argv).options(desc).run(), vm);
   bpo::notify(vm);
+
+  params.binary = !ascii;
 
   if (vm.count("help") > 0)
   {

--- a/benchmarks/cluster/mst.cpp
+++ b/benchmarks/cluster/mst.cpp
@@ -76,10 +76,11 @@ int main(int argc, char *argv[])
   std::vector<std::string> allowed_dendrograms = {"boruvka", "union-find"};
 
   bpo::options_description desc("Allowed options");
+  bool ascii;
   // clang-format off
   desc.add_options()
       ( "help", "help message" )
-      ( "binary", bpo::bool_switch(&params.binary), "binary file indicator")
+      ( "ascii", bpo::bool_switch(&ascii), "ascii file indicator")
       ( "core-min-size", bpo::value<int>(&params.core_min_size)->default_value(2), "DBSCAN min_pts")
       ( "dimension", bpo::value<int>(&params.dim)->default_value(-1), "dimension of points to generate" )
       ( "filename", bpo::value<std::string>(&params.filename), "filename containing data" )
@@ -93,6 +94,8 @@ int main(int argc, char *argv[])
   bpo::variables_map vm;
   bpo::store(bpo::command_line_parser(argc, argv).options(desc).run(), vm);
   bpo::notify(vm);
+
+  params.binary = !ascii;
 
   if (vm.count("help") > 0)
   {


### PR DESCRIPTION
This avoids requiring to always type it in.