### PR TITLE
change two lambdas to functors to avoid segfaults on hops

### DIFF
--- a/src/spatial/detail/ArborX_CrsGraphWrapperImpl.hpp
+++ b/src/spatial/detail/ArborX_CrsGraphWrapperImpl.hpp
@@ -128,9 +128,9 @@ public:
       , _t(t)
   {
     static_assert(Kokkos::is_execution_space_v<ExecutionSpace>);
-    KOKKOS_ASSERT(s.size() == t.size());
+    auto const n = Kokkos::min(s.size(), t.size());
     Kokkos::parallel_for("ArborX::CrsGraphWrapper::copy_" + label,
-                         Kokkos::RangePolicy(space, 0, s.size()), *this);
+                         Kokkos::RangePolicy(space, 0, n), *this);
   }
 
   KOKKOS_FUNCTION


### PR DESCRIPTION
This changes a two lambda functions to be functors, which avoids segfaults on hops.  We have seen this a few times different parts of Sierra and submitted a bug report to Nvidia, but this patch fixes things in the meantime.