### PR TITLE
Fix few instances of the wrong const qualifier order

### DIFF
--- a/examples/raytracing/example_raytracing.cpp
+++ b/examples/raytracing/example_raytracing.cpp
@@ -359,7 +359,7 @@ int main(int argc, char *argv[])
           float ray_energy = (total_energy * dx * dy * dz) / rays_per_box;
           for (int j = offsets(i); j < offsets(i + 1); ++j)
           {
-            const auto &v = values(permutation(j));
+            auto const &v = values(permutation(j));
             float const energy_deposited =
                 lost_energy(ray_energy, v.optical_path_length);
             ray_energy += energy_deposited;

--- a/test/tstInterpDetailsMLSCoefficients.cpp
+++ b/test/tstInterpDetailsMLSCoefficients.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
         srcp0(i, 1) = {{2. * i + 2}};
         tgtp0(i) = {{2. * i + 1}};
 
-        auto f = [](const Point0 &) { return 3.; };
+        auto f = [](Point0 const &) { return 3.; };
 
         srcv0(i, 0) = f(srcp0(i, 0));
         srcv0(i, 1) = f(srcp0(i, 1));
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
         }
         tgtp1(i) = {{double(u), double(v)}};
 
-        auto f = [](const Point1 &p) { return p[0] * p[1] + 4 * p[0]; };
+        auto f = [](Point1 const &p) { return p[0] * p[1] + 4 * p[0]; };
 
         for (int j = 0; j < 8; j++)
           srcv1(i, j) = f(srcp1(i, j));
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients_edge_cases, DeviceType,
         srcp0(i, 1) = {{2. * i + 2, 0.}};
         tgtp0(i) = {{2. * i + 1, 0.}};
 
-        auto f = [](const Point0 &) { return 3.; };
+        auto f = [](Point0 const &) { return 3.; };
 
         srcv0(i, 0) = f(srcp0(i, 0));
         srcv0(i, 1) = f(srcp0(i, 1));
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients_edge_cases, DeviceType,
         }
         tgtp1(i) = {{u * 2., v * 2.}};
 
-        auto f = [](const Point1 &p) { return p[0] * p[1] + 4 * p[0]; };
+        auto f = [](Point1 const &p) { return p[0] * p[1] + 4 * p[0]; };
 
         for (int j = 0; j < 8; j++)
           srcv1(i, j) = f(srcp1(i, j));

--- a/test/tstInterpMovingLeastSquares.cpp
+++ b/test/tstInterpMovingLeastSquares.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
   Kokkos::parallel_for(
       "Testing::moving_least_squares::for0", Kokkos::RangePolicy(space, 0, 4),
       KOKKOS_LAMBDA(int const i) {
-        auto f = [](const Point0 &) { return 3.; };
+        auto f = [](Point0 const &) { return 3.; };
 
         srcp0(i) = {{2. * i}};
         srcv0(i) = f(srcp0(i));
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
         int v = (i % 2) * 2 - 1;
         int x = (i / 3) - 1;
         int y = (i % 3) - 1;
-        auto f = [](const Point1 &p) { return p[0] * p[1] + 4 * p[0]; };
+        auto f = [](Point1 const &p) { return p[0] * p[1] + 4 * p[0]; };
 
         srcp1(i) = {{x * 2., y * 2.}};
         srcv1(i) = f(srcp1(i));
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares_edge_cases, DeviceType,
   Kokkos::parallel_for(
       "Testing::moving_least_squares_edge_cases::for0",
       Kokkos::RangePolicy(space, 0, 4), KOKKOS_LAMBDA(int const i) {
-        auto f = [](const Point0 &) { return 3.; };
+        auto f = [](Point0 const &) { return 3.; };
 
         srcp0(i) = {{2. * i, 0.}};
         srcv0(i) = f(srcp0(i));
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares_edge_cases, DeviceType,
         int v = (i % 2) * 2 - 1;
         int x = (i / 3) - 1;
         int y = (i % 3) - 1;
-        auto f = [](const Point1 &p) { return p[0] * p[1] + 4 * p[0]; };
+        auto f = [](Point1 const &p) { return p[0] * p[1] + 4 * p[0]; };
 
         srcp1(i) = {{x * 2., y * 2.}};
         srcv1(i) = f(srcp1(i));


### PR DESCRIPTION
I don't understand why `clang-format` does nothing with those.