### PR TITLE
Reduce polynomial basis for momentum matrix to be non-singular

### DIFF
--- a/test/tstDetailsSVD.cpp
+++ b/test/tstDetailsSVD.cpp
@@ -61,7 +61,8 @@ void makeCase(ExecutionSpace const &exec, Value const (&src_arr)[M][N][N],
     Kokkos::parallel_for(
         "Testing::run_inverse", Kokkos::RangePolicy(exec, 0, 1),
         KOKKOS_LAMBDA(int) {
-          ArborX::Details::symmetricPseudoInverseSVDKernel(inv, diag, unit);
+          ArborX::Details::symmetricSVDKernel(inv, diag, unit);
+          ArborX::Details::symmetricPseudoInverseSVDKernel(diag, unit, inv);
         });
     ARBORX_MDVIEW_TEST_TOL(ref, inv, Kokkos::Experimental::epsilon_v<float>);
   }


### PR DESCRIPTION
When the momentum matrix in the moving least squares implementation is singular, the polynomial ansatz space isn't interpolated exactly anymore but we always choose the minimum norm solution for the coefficients. This pull request suggests to penalize higher-order polynomials in this case so that we can expect constant and linear functions still to be approximated well.