### PR TITLE
Workaround CUDA image issue

### DIFF
--- a/docker/Dockerfile.nvcc
+++ b/docker/Dockerfile.nvcc
@@ -26,7 +26,7 @@ RUN KEYDUMP_URL=https://cloud1.cees.ornl.gov/download && \
     gpg --verify ${KEYDUMP_FILE}.sig ${KEYDUMP_FILE} && \
     rm ${KEYDUMP_FILE}*
 
-# Remove empty /usr/lib/x86_64-linux-gnu/libcuda.so being as it causes problems
+# Remove empty /usr/lib/x86_64-linux-gnu/libcuda.so as it causes problems
 RUN rm -f /usr/lib/x86_64-linux-gnu/libcuda.so
 
 # Install OpenMPI


### PR DESCRIPTION
It turned out that /usr/lib/x86_64-linux-gnu/libcuda.so is empty for some images which makes nvlink fail. Instead, there is /usr/lib64/libcuda.so which seems to work OK for these builds.

Just following kokkos/kokkos#8680.