### PR TITLE
Fix using statement referring to outdated Experimental::intersects

### DIFF
--- a/src/spatial/detail/ArborX_Predicates.hpp
+++ b/src/spatial/detail/ArborX_Predicates.hpp
@@ -79,7 +79,7 @@ struct Intersects
   template <typename OtherGeometry>
   KOKKOS_FUNCTION bool operator()(OtherGeometry const &other) const
   {
-    using Experimental::intersects;
+    using ::ArborX::intersects;
     return intersects(_geometry, other);
   }
 


### PR DESCRIPTION
Follow up on #1307.

In user application, was getting errors
```
<snip>/ArborX/spatial/detail/ArborX_Predicates.hpp(83): error: no instance of overloaded function "intersects" matches the argument list
argument types are: (const ArborX::Experimental::Segment<2, double>, const ArborX::Experimental::Segment<2, double>)
      return intersects(_geometry, other);
```
We didn't encounter that because at least one of our arguments was always in `ArborX` namespace, and context deduction worked. 