### PR TITLE
Distributed DBSCAN timers and cleanup

### DIFF
--- a/benchmarks/cluster/CMakeLists.txt
+++ b/benchmarks/cluster/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(ArborX_Benchmark_HDBSCAN.exe ArborX::ArborX Boost::program
 add_test(NAME ArborX_Benchmark_MST COMMAND ArborX_Benchmark_MST.exe --ascii --filename=${input_file})
 
 if (ARBORX_ENABLE_MPI)
-  set(ARBORX_BENCHMARK_UTILS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/benchmarks/utils)
+  set(ARBORX_BENCHMARK_UTILS_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/benchmarks/utils)
   add_executable(ArborX_Benchmark_DistributedDBSCAN.exe distributed_dbscan.cpp)
   target_include_directories(ArborX_Benchmark_DistributedDBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${ARBORX_BENCHMARK_UTILS_INCLUDE_DIR})
   target_link_libraries(ArborX_Benchmark_DistributedDBSCAN.exe ArborX::ArborX Boost::program_options cluster_benchmark_helpers)

--- a/benchmarks/cluster/CMakeLists.txt
+++ b/benchmarks/cluster/CMakeLists.txt
@@ -23,8 +23,9 @@ target_link_libraries(ArborX_Benchmark_HDBSCAN.exe ArborX::ArborX Boost::program
 add_test(NAME ArborX_Benchmark_MST COMMAND ArborX_Benchmark_MST.exe --ascii --filename=${input_file})
 
 if (ARBORX_ENABLE_MPI)
+  set(ARBORX_BENCHMARK_UTILS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/benchmarks/utils)
   add_executable(ArborX_Benchmark_DistributedDBSCAN.exe distributed_dbscan.cpp)
-  target_include_directories(ArborX_Benchmark_DistributedDBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_include_directories(ArborX_Benchmark_DistributedDBSCAN.exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${ARBORX_BENCHMARK_UTILS_INCLUDE_DIR})
   target_link_libraries(ArborX_Benchmark_DistributedDBSCAN.exe ArborX::ArborX Boost::program_options cluster_benchmark_helpers)
   add_test(NAME ArborX_Benchmark_DistributedDBSCAN COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:ArborX_Benchmark_DistributedDBSCAN.exe> ${MPIEXEC_POSTFLAGS} --n 1000 --dimension 3 --num-seq 4 --spacing 4 --core-min-size 2 --eps 2 --verify)
 endif()

--- a/benchmarks/cluster/distributed_dbscan.cpp
+++ b/benchmarks/cluster/distributed_dbscan.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include "ArborX_DBSCANVerification.hpp"
+#include <ArborXBenchmark_TimeMonitor.hpp>
 #include <ArborX_DistributedDBSCAN.hpp>
 #include <ArborX_Version.hpp>
 
@@ -66,10 +67,28 @@ bool run_dist_dbscan(MPI_Comm comm, ExecutionSpace const &exec_space,
                                labels, dbscan_params);
   Kokkos::Profiling::popRegion();
 
-  if (timer_hooks_set_up && comm_rank == 0)
+  if (timer_hooks_set_up)
   {
-    printf("total time          : %10.3f\n",
-           ArborXBenchmark::get_time("ArborX::DistributedDBSCAN::total"));
+    // Copy Kokkos timers to TimeMonitor
+    ArborXBenchmark::TimeMonitor time_monitor;
+    for (auto const &timer_name :
+         std::vector<std::pair<std::string, std::string>>{
+             {"step_1", "step 1: receive global neighbors"},
+             {"step_2", "step 2: local DBSCAN"},
+             {"step_3", "step 3: convert local to global labels"},
+             {"step_4", "step 4: communicate labels back to owning ranks"},
+             {"step_5", "step 5: process multi-labeled indices"},
+             {"step_6", "step 6: communicate merge pairs"},
+             {"step_7", "step 7: flatten labels"}})
+    {
+      auto timer = time_monitor.getNewTimer(timer_name.second);
+      timer->set(ArborXBenchmark::get_time(
+          std::string("ArborX::DistributedDBSCAN::") + timer_name.first));
+    }
+    time_monitor.summarize(comm);
+    if (comm_rank == 0)
+      printf("total time: %10.3f\n",
+             ArborXBenchmark::get_time("ArborX::DistributedDBSCAN::total"));
   }
 
   bool success = true;
@@ -112,7 +131,7 @@ int main(int argc, char *argv[])
     std::cout << "ArborX hash       : " << ArborX::gitCommitHash() << std::endl;
     std::cout << "Kokkos version    : " << ArborX::Details::KokkosExt::version()
               << std::endl;
-    std::cout << "#MPI ranks         : " << comm_size << std::endl;
+    std::cout << "#MPI ranks        : " << comm_size << std::endl;
   }
 
   // Strip "--help" and "--kokkos-help" from the flags passed to Kokkos if we

--- a/benchmarks/cluster/distributed_dbscan.cpp
+++ b/benchmarks/cluster/distributed_dbscan.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
     --argc;
   }
 
-  Kokkos::ScopeGuard guard(argc, argv);
+  Kokkos::initialize(argc, argv);
 
   namespace bpo = boost::program_options;
   using namespace ArborXBenchmark;
@@ -301,6 +301,7 @@ int main(int argc, char *argv[])
 #undef SWITCH_DIM
   }
 
+  Kokkos::finalize();
   MPI_Finalize();
 
   return success ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/benchmarks/utils/ArborXBenchmark_TimeMonitor.hpp
+++ b/benchmarks/utils/ArborXBenchmark_TimeMonitor.hpp
@@ -66,6 +66,16 @@ public:
       _entry.second = duration.count();
       _started = false;
     }
+    // Explicitly set the duration. This is useful for copying Kokkos timers
+    // we get from hooking Kokkos profiling tools into our own TimeMonitor
+    // timers. In that case, we don't have the start/stop semantics, but we
+    // just want to set the duration of the timer to the value we get from
+    // Kokkos timer.
+    void set(double duration)
+    {
+      assert(!_started);
+      _entry.second = duration;
+    }
   };
   // NOTE Original code had the pointer semantics.  Can change in the future.
   // The smart pointer is a distraction.  The main problem here is that the

--- a/src/cluster/ArborX_DistributedDBSCAN.hpp
+++ b/src/cluster/ArborX_DistributedDBSCAN.hpp
@@ -80,38 +80,8 @@ void dbscan(MPI_Comm comm, ExecutionSpace const &space,
          core_min_size, local_labels, params);
 
   // Step 3: convert local labels to global
-  Kokkos::View<long long *, MemorySpace> rank_offsets(prefix + "rank_offsets",
-                                                      0);
-  {
-    std::vector<int> counts;
-    std::vector<long long> offsets;
-    Details::computeCountsAndOffsets(comm, (long long)n_local, counts, offsets);
-
-    Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing),
-                   rank_offsets, offsets.size());
-    Kokkos::deep_copy(
-        space, rank_offsets,
-        Kokkos::View<long long *, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(
-            offsets.data(), offsets.size()));
-  }
-  Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing), labels,
-                 local_labels.size());
-  Kokkos::parallel_for(
-      prefix + "convert_labels",
-      Kokkos::RangePolicy(space, 0, local_labels.size()), KOKKOS_LAMBDA(int i) {
-        auto label = local_labels(i);
-        if (label == -1)
-        {
-          labels(i) = -1;
-          return;
-        }
-
-        if (label < n_local)
-          labels(i) = rank_offsets(comm_rank) + label;
-        else
-          labels(i) = rank_offsets(ghost_ranks(label - n_local)) +
-                      ghost_ids(label - n_local);
-      });
+  Details::convertLocalToGlobal(comm, space, n_local, ghost_ids, ghost_ranks,
+                                local_labels, labels);
   Kokkos::resize(local_labels, 0); // free space
 
   // Step 4: pack and communicate results back to owning ranks

--- a/src/cluster/ArborX_DistributedDBSCAN.hpp
+++ b/src/cluster/ArborX_DistributedDBSCAN.hpp
@@ -62,6 +62,7 @@ void dbscan(MPI_Comm comm, ExecutionSpace const &space,
   MPI_Comm_rank(comm, &comm_rank);
 
   // Step 1: receive ghost neighbors
+  Kokkos::Profiling::pushRegion(prefix + "step_1");
   Kokkos::View<int *, MemorySpace> ghost_ids(prefix + "ghost_ids", 0);
   Kokkos::View<Point *, MemorySpace> ghost_points(prefix + "ghost_points", 0);
   Kokkos::View<int *, MemorySpace> ghost_ranks(prefix + "ghost_ranks", 0);
@@ -73,18 +74,24 @@ void dbscan(MPI_Comm comm, ExecutionSpace const &space,
       (is_special_case ? eps : std::nextafter(2 * eps, 10 * eps)), ghost_points,
       ghost_ids, ghost_ranks);
   int const n_ghost = ghost_points.size();
+  Kokkos::Profiling::popRegion();
 
   // Step 2: do local DBSCAN
+  Kokkos::Profiling::pushRegion(prefix + "step_2");
   Kokkos::View<int *, MemorySpace> local_labels(prefix + "local_labels", 0);
   dbscan(space, Details::UnifiedPoints{points, ghost_points}, eps,
          core_min_size, local_labels, params);
+  Kokkos::Profiling::popRegion();
 
   // Step 3: convert local labels to global
+  Kokkos::Profiling::pushRegion(prefix + "step_3");
   Details::convertLocalToGlobal(comm, space, n_local, ghost_ids, ghost_ranks,
                                 local_labels, labels);
   Kokkos::resize(local_labels, 0); // free space
+  Kokkos::Profiling::popRegion();
 
   // Step 4: pack and communicate results back to owning ranks
+  Kokkos::Profiling::pushRegion(prefix + "step_4");
   Kokkos::View<long long *, MemorySpace> ghost_labels(
       Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
                          prefix + "ghost_labels"),
@@ -120,8 +127,10 @@ void dbscan(MPI_Comm comm, ExecutionSpace const &space,
       Kokkos::view_alloc(space, prefix + "ghost_offsets"), 0);
   Details::computeOffsetsInOrderedView(space, ghost_ids, ghost_offsets);
   Kokkos::resize(ghost_ranks, 0); // free space
+  Kokkos::Profiling::popRegion();
 
   // Step 5: process multi-labeled indices
+  Kokkos::Profiling::pushRegion(prefix + "step_5");
   Kokkos::View<Details::MergePair *, MemorySpace> local_merge_pairs(
       prefix + "local_merge_pairs", 0);
   if (ghost_offsets.size() > 1)
@@ -162,15 +171,20 @@ void dbscan(MPI_Comm comm, ExecutionSpace const &space,
   Kokkos::resize(ghost_points, 0); // free space
   Kokkos::resize(ghost_ids, 0);    // free space
   Kokkos::resize(ghost_labels, 0); // free space
+  Kokkos::Profiling::popRegion();
 
   // Step 6: communicate merge pairs (all-to-all)
+  Kokkos::Profiling::pushRegion(prefix + "step_6");
   Kokkos::View<Details::MergePair *, MemorySpace> global_merge_pairs(
       prefix + "global_merge_pairs", 0);
   communicateMergePairs(comm, space, local_merge_pairs, global_merge_pairs);
   Details::sortAndFilterMergePairs(space, global_merge_pairs);
+  Kokkos::Profiling::popRegion();
 
   // Step 7: flatten the labels
+  Kokkos::Profiling::pushRegion(prefix + "step_7");
   Details::relabel(space, global_merge_pairs, labels);
+  Kokkos::Profiling::popRegion();
 }
 
 } // namespace ArborX::Experimental

--- a/src/cluster/detail/ArborX_DistributedDBSCANHelpers.hpp
+++ b/src/cluster/detail/ArborX_DistributedDBSCANHelpers.hpp
@@ -130,6 +130,55 @@ void computeCountsAndOffsets(MPI_Comm comm, Index k, std::vector<int> &counts,
     offsets[i + 1] = counts[i] + offsets[i];
 }
 
+template <typename ExecutionSpace, typename GhostIds, typename GhostRanks,
+          typename LocalLabels, typename GlobalLabels>
+void convertLocalToGlobal(MPI_Comm comm, ExecutionSpace const &space,
+                          long long n_local, GhostIds const &ghost_ids,
+                          GhostRanks const &ghost_ranks,
+                          LocalLabels const &local_labels, GlobalLabels &labels)
+{
+  std::string prefix = "ArborX::DistributedDBSCAN::convertLocalToGlobal";
+  Kokkos::Profiling::ScopedRegion guard(prefix);
+  prefix += "::";
+
+  using MemorySpace = typename LocalLabels::memory_space;
+
+  int comm_rank;
+  MPI_Comm_rank(comm, &comm_rank);
+
+  std::vector<int> counts;
+  std::vector<long long> offsets;
+  computeCountsAndOffsets(comm, n_local, counts, offsets);
+
+  Kokkos::View<long long *, MemorySpace> rank_offsets(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing,
+                         prefix + "rank_offsets"),
+      offsets.size());
+  Kokkos::deep_copy(
+      space, rank_offsets,
+      Kokkos::View<long long *, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(
+          offsets.data(), offsets.size()));
+
+  Kokkos::resize(Kokkos::view_alloc(space, Kokkos::WithoutInitializing), labels,
+                 local_labels.size());
+  Kokkos::parallel_for(
+      prefix + "convert_labels",
+      Kokkos::RangePolicy(space, 0, local_labels.size()), KOKKOS_LAMBDA(int i) {
+        auto label = local_labels(i);
+        if (label == -1)
+        {
+          labels(i) = -1;
+          return;
+        }
+
+        if (label < n_local)
+          labels(i) = rank_offsets(comm_rank) + label;
+        else
+          labels(i) = rank_offsets(ghost_ranks(label - n_local)) +
+                      ghost_ids(label - n_local);
+      });
+}
+
 template <typename ExecutionSpace, typename Points>
 auto gatherGlobalBoxes(MPI_Comm comm, ExecutionSpace const &space,
                        Points const &points)


### PR DESCRIPTION
- Add an additional details function to reduce the amount of code in the distributed `dbscan` function
- Add profiling regions for each step of the distributed algorithm
- Actually hook the timers for algorithm steps and print them out in verbose
- Update `Timer` used in `TimeMonitor` to be able to explicitly set the time