### PR TITLE
Use MPI_Dist_graph_create to determine comm pattern

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -226,7 +226,7 @@ pipeline {
                         dockerfile {
                             filename "Dockerfile"
                             dir "docker"
-                            additionalBuildArgs '--build-arg BASE=ubuntu:22.04 --build-arg ADDITIONAL_PACKAGES="clang clang-tidy" --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=ubuntu:22.04 --build-arg ADDITIONAL_PACKAGES="clang clang-tidy libopenmpi-dev" --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=20 -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                             registryCredentialsId "${env.DOCKER_CREDENTIALS_ID}"
@@ -290,7 +290,7 @@ pipeline {
                             // We use gfortran- to avoid problems with openmpi
                             // when using gcc images. See
                             // https://github.com/docker-library/gcc/issues/57
-                            additionalBuildArgs '--build-arg BASE=gcc:13.3 --build-arg ADDITIONAL_PACKAGES="gfortran-" --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
+                            additionalBuildArgs '--build-arg BASE=gcc:13.3 --build-arg ADDITIONAL_PACKAGES="gfortran- libmpich-dev" --build-arg KOKKOS_VERSION=4.6.00 --build-arg KOKKOS_OPTIONS="-DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu"'
                             args '-v /tmp/ccache:/tmp/ccache'
                             label 'docker'
                             registryCredentialsId "${env.DOCKER_CREDENTIALS_ID}"
@@ -310,7 +310,6 @@ pipeline {
                                     -D CMAKE_CXX_FLAGS="-Wpedantic -Wall -Wextra" \
                                     -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$BOOST_DIR;$BENCHMARK_DIR" \
                                     -D ARBORX_ENABLE_MPI=ON \
-                                    -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
                                     -D MPIEXEC_MAX_NUMPROCS=4 \
                                     -D ARBORX_ENABLE_TESTS=ON \
                                     -D ARBORX_ENABLE_EXAMPLES=ON \
@@ -337,7 +336,6 @@ pipeline {
                                         -D CMAKE_CXX_COMPILER=g++ \
                                         -D CMAKE_CXX_EXTENSIONS=OFF \
                                         -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
-                                        -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
                                     examples \
                                 '''
                                 sh 'make VERBOSE=1'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
         curl \
         git \
         libomp-dev \
-        libopenmpi-dev \
         libbenchmark-dev \
         libboost-program-options-dev \
         libboost-test-dev \

--- a/src/distributed/detail/ArborX_Distributor.hpp
+++ b/src/distributed/detail/ArborX_Distributor.hpp
@@ -447,26 +447,41 @@ private:
     Kokkos::Profiling::ScopedRegion guard(
         "ArborX::Distributor::preparePointToPointCommunication");
 
-    int comm_size;
-    MPI_Comm_size(_comm, &comm_size);
+    int comm_rank;
+    MPI_Comm_rank(_comm, &comm_rank);
 
-    std::vector<int> src_counts_dense(comm_size);
-    int const dest_size = _destinations.size();
-    for (int i = 0; i < dest_size; ++i)
-    {
-      src_counts_dense[_destinations[i]] =
-          _dest_offsets[i + 1] - _dest_offsets[i];
-    }
-    MPI_Alltoall(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, src_counts_dense.data(), 1,
-                 MPI_INT, _comm);
+    int outdegree = _destinations.size();
+    std::vector<int> dest_weights(outdegree);
+    for (int i = 0; i < outdegree; ++i)
+      dest_weights[i] = _dest_offsets[i + 1] - _dest_offsets[i];
 
+    MPI_Comm graph_comm;
+    MPI_Dist_graph_create(_comm, (outdegree ? 1 : 0), &comm_rank, &outdegree,
+                          _destinations.data(), dest_weights.data(),
+                          MPI_INFO_NULL, 0 /*reorder*/, &graph_comm);
+
+    int indegree, outdegree_check, weighted;
+    MPI_Dist_graph_neighbors_count(graph_comm, &indegree, &outdegree_check,
+                                   &weighted);
+    ARBORX_ASSERT(outdegree_check == outdegree);
+
+    // FIXME: it should be possible to call MPI_Dist_graph_neighbors with
+    // maxoutdegree = 0. However, running on Frontier results in an error:
+    //   Invalid argument for maxoutdegree: value is 0 but must be at least 8
+    // So, we provide correct outdegree instead here.
+    _sources.resize(indegree);
+    std::vector<int> source_weights(indegree);
+    MPI_Dist_graph_neighbors(graph_comm, indegree, _sources.data(),
+                             source_weights.data(), outdegree,
+                             _destinations.data(), dest_weights.data());
+
+    MPI_Comm_free(&graph_comm);
+
+    // Reconstruct the sparse offsets
+    _src_offsets.clear();
     _src_offsets.push_back(0);
-    for (int i = 0; i < comm_size; ++i)
-      if (src_counts_dense[i] > 0)
-      {
-        _sources.push_back(i);
-        _src_offsets.push_back(_src_offsets.back() + src_counts_dense[i]);
-      }
+    for (int count : source_weights)
+      _src_offsets.push_back(_src_offsets.back() + count);
 
     return _src_offsets.back();
   }

--- a/src/distributed/detail/ArborX_Distributor.hpp
+++ b/src/distributed/detail/ArborX_Distributor.hpp
@@ -22,7 +22,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 
-#include <sstream>
+#include <numeric> // iota
 #include <vector>
 
 #include <mpi.h>
@@ -450,7 +450,8 @@ private:
     int comm_rank;
     MPI_Comm_rank(_comm, &comm_rank);
 
-    int outdegree = _destinations.size();
+    int const outdegree = _destinations.size();
+
     std::vector<int> dest_weights(outdegree);
     for (int i = 0; i < outdegree; ++i)
       dest_weights[i] = _dest_offsets[i + 1] - _dest_offsets[i];
@@ -464,24 +465,39 @@ private:
     MPI_Dist_graph_neighbors_count(graph_comm, &indegree, &outdegree_check,
                                    &weighted);
     ARBORX_ASSERT(outdegree_check == outdegree);
+    ARBORX_ASSERT(weighted == 1);
 
     // FIXME: it should be possible to call MPI_Dist_graph_neighbors with
     // maxoutdegree = 0. However, running on Frontier results in an error:
     //   Invalid argument for maxoutdegree: value is 0 but must be at least 8
     // So, we provide correct outdegree instead here.
-    _sources.resize(indegree);
+    std::vector<int> sources(indegree);
     std::vector<int> source_weights(indegree);
-    MPI_Dist_graph_neighbors(graph_comm, indegree, _sources.data(),
+    std::vector<int> dummy_destinations(
+        outdegree); // destinations may be reordered by MPI
+    MPI_Dist_graph_neighbors(graph_comm, indegree, sources.data(),
                              source_weights.data(), outdegree,
-                             _destinations.data(), dest_weights.data());
+                             dummy_destinations.data(), dest_weights.data());
 
     MPI_Comm_free(&graph_comm);
 
-    // Reconstruct the sparse offsets
-    _src_offsets.clear();
-    _src_offsets.push_back(0);
-    for (int count : source_weights)
-      _src_offsets.push_back(_src_offsets.back() + count);
+    // Retain the previous behavior of having the sources sorted.
+    // Not strictly neceessary, but it makes testing easier and doesn't have a
+    // significant performance impact.
+    std::vector<int> source_permute(indegree);
+    std::iota(source_permute.begin(), source_permute.end(), 0);
+    std::sort(source_permute.begin(), source_permute.end(),
+              [&](int i, int j) { return sources[i] < sources[j]; });
+
+    _sources.resize(indegree);
+    _src_offsets.resize(indegree + 1);
+    _src_offsets[0] = 0;
+    for (int i = 0; i < indegree; ++i)
+    {
+      auto permuted_i = source_permute[i];
+      _sources[i] = sources[permuted_i];
+      _src_offsets[i + 1] = _src_offsets[i] + source_weights[permuted_i];
+    }
 
     return _src_offsets.back();
   }

--- a/src/distributed/detail/ArborX_Distributor.hpp
+++ b/src/distributed/detail/ArborX_Distributor.hpp
@@ -447,6 +447,34 @@ private:
     Kokkos::Profiling::ScopedRegion guard(
         "ArborX::Distributor::preparePointToPointCommunication");
 
+#if OPEN_MPI && (OMPI_MAJOR_VERSION * 10000 + OMPI_MINOR_VERSION * 100 +       \
+                     OMPI_RELEASE_VERSION <                                    \
+                 50011)
+    // OpenMPI prior to 5.0.11 has a bug where MPI_Dist_graph_create may hang
+    // when called multiple times with treematch topo. See
+    //   https://github.com/open-mpi/ompi/issues/13918
+    // Use the old algorithm instead.
+    int comm_size;
+    MPI_Comm_size(_comm, &comm_size);
+
+    std::vector<int> src_counts_dense(comm_size);
+    int const dest_size = _destinations.size();
+    for (int i = 0; i < dest_size; ++i)
+    {
+      src_counts_dense[_destinations[i]] =
+          _dest_offsets[i + 1] - _dest_offsets[i];
+    }
+    MPI_Alltoall(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, src_counts_dense.data(), 1,
+                 MPI_INT, _comm);
+
+    _src_offsets.push_back(0);
+    for (int i = 0; i < comm_size; ++i)
+      if (src_counts_dense[i] > 0)
+      {
+        _sources.push_back(i);
+        _src_offsets.push_back(_src_offsets.back() + src_counts_dense[i]);
+      }
+#else
     int comm_rank;
     MPI_Comm_rank(_comm, &comm_rank);
 
@@ -498,6 +526,7 @@ private:
       _sources[i] = sources[permuted_i];
       _src_offsets[i + 1] = _src_offsets[i] + source_weights[permuted_i];
     }
+#endif
 
     return _src_offsets.back();
   }


### PR DESCRIPTION
`MPI_Alltoall` has issues with scaling. This patch replaces it by using `MPI_Dist_graph_create` and other helper functions to rely on MPI. This seems to scale better on Frontier:
<img width="545" height="435" alt="Screenshot 2026-05-17 at 12 49 22 PM" src="https://github.com/user-attachments/assets/c5c14d96-86ae-4c0c-99ec-2034d4ab17b1" />

This bumps our MPI requirement to 2.2.

Also replaced OpenMPI with MPICH in the HIP build.

@dalg24 pointed out that we did something similar in ORNL-CEES/DataTransferKit#516. So this can be seen as a partial revert of that.