### PR TITLE
Fix comment about version in ArborX_Config.hpp

### DIFF
--- a/src/ArborX_Config.hpp.in
+++ b/src/ArborX_Config.hpp.in
@@ -16,8 +16,8 @@
 // ARBORX_VERSION / 100 % 100 is the minor version
 // ARBORX_VERSION / 10000 is the major version
 #cmakedefine ARBORX_VERSION @ARBORX_VERSION@
-// not using #cmakedefine below because a "0" version number yields
-// /* #undef KOKKOS_VERSION_X */
+// not using cmakedefine below because a "0" version number yields
+// /* #undef ARBORX_VERSION_X */
 #define ARBORX_VERSION_MAJOR @ARBORX_VERSION_MAJOR@
 #define ARBORX_VERSION_MINOR @ARBORX_VERSION_MINOR@
 #define ARBORX_VERSION_PATCH @ARBORX_VERSION_PATCH@


### PR DESCRIPTION
CMake was auto-translating #cmakedefine, so the resulting comment inside ArborX_Config.hpp looked wrong:
```
/* #undef below */
// /* #undef KOKKOS_VERSION_X */
```
It now is correct:
```
// not using cmakedefine below because a "0" version number yields
// /* #undef ARBORX_VERSION_X */
```