### PR TITLE
Fix a compilation error for clang 22

### DIFF
--- a/src/spatial/detail/ArborX_AccessTraits.hpp
+++ b/src/spatial/detail/ArborX_AccessTraits.hpp
@@ -155,14 +155,14 @@ concept AccessTraits = requires() {
       typename ArborX::AccessTraits<T>::memory_space>;
 } && requires(T const &v) {
   {
-    AccessTraits<T>::size(v)
+    ArborX::AccessTraits<T>::size(v)
   } -> std::integral;
   // Cannot check return type of get() here as we need to test for non-void, but
   // there's no not_same_as concept, and !std::same_as<void> does not work
-  AccessTraits<T>::get(v, 0);
+  ArborX::AccessTraits<T>::get(v, 0);
 } && !requires(T const &v) {
   {
-    AccessTraits<T>::get(v, 0)
+    ArborX::AccessTraits<T>::get(v, 0)
   } -> std::same_as<void>;
 };
 


### PR DESCRIPTION
Was getting when compiling pyArborX
```
[ 50%] Building CXX object static/CMakeFiles/pyArborX_static.dir/generated_files/pyArborX_static.cpp.o
cd /Users/xap/code/pyarborx/build/static && /Users/xap/code/pyarborx/.pixi/envs/default/bin/c++ -DKOKKOS_DEPENDENCE -DpyArborX_static_EXPORTS -I/Users/xap/code/pyarborx/static/include -I/Users/xap/code/pyarborx/build/static/generated_files -isystem /Users/xap/code/pyarborx/.pixi/envs/default/include -isystem /Users/xap/code/pyarborx/.pixi/envs/default/include/python3.14 -isystem /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX -isystem /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/geometry -isystem /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/cluster -isystem /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/distributed -isystem /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/interpolation -isystem /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial -isystem /Users/xap/local/opt/kokkos-bounds-5.0.1/kokkos/include -isystem /opt/homebrew/Cellar/open-mpi/5.0.9/include -O3 -DNDEBUG -std=gnu++20 -arch arm64 -fPIC -fvisibility=hidden -fdiagnostics-color -MD -MT static/CMakeFiles/pyArborX_static.dir/generated_files/pyArborX_static.cpp.o -MF CMakeFiles/pyArborX_static.dir/generated_files/pyArborX_static.cpp.o.d -o CMakeFiles/pyArborX_static.dir/generated_files/pyArborX_static.cpp.o -c /Users/xap/code/pyarborx/build/static/generated_files/pyArborX_static.cpp
In file included from /Users/xap/code/pyarborx/build/static/generated_files/pyArborX_static.cpp:5:
In file included from /Users/xap/code/pyarborx/static/include/pyArborX_Experimental.hpp:4:
In file included from /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/ArborX_LinearBVH.hpp:16:
In file included from /Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/ArborX_CrsGraphWrapper.hpp:15:
/Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/detail/ArborX_AccessTraits.hpp:158:5: error: qualified name refers into a specialization of function template 'AccessTraits'
  158 |     AccessTraits<T>::size(v)
      |     ^~~~~~~~~~~~~~~
/Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/detail/ArborX_AccessTraits.hpp:152:9: note: template template parameter 'AccessTraits' declared here
  152 | concept AccessTraits = requires() {
      |         ^
/Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/detail/ArborX_AccessTraits.hpp:162:3: error: qualified name refers into a specialization of function template 'AccessTraits'
  162 |   AccessTraits<T>::get(v, 0);
      |   ^~~~~~~~~~~~~~~
/Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/detail/ArborX_AccessTraits.hpp:152:9: note: template template parameter 'AccessTraits' declared here
  152 | concept AccessTraits = requires() {
      |         ^
/Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/detail/ArborX_AccessTraits.hpp:165:5: error: qualified name refers into a specialization of function template 'AccessTraits'
  165 |     AccessTraits<T>::get(v, 0)
      |     ^~~~~~~~~~~~~~~
/Users/xap/local/opt/kokkos-bounds-5.0.1/arborx-mpi-2.1/include/ArborX/spatial/detail/ArborX_AccessTraits.hpp:152:9: note: template template parameter 'AccessTraits' declared here
  152 | concept AccessTraits = requires() {
      |         ^
```
The patch fixes it.