### PR TITLE
Improve scratch size allocation mechanism for MLS

### DIFF
--- a/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -67,26 +67,20 @@ public:
       , _num_targets(target_access.size())
       , _num_neighbors(source_points.extent_int(1))
   {
-// FIXME_HIP The HIP backend is limited by the small level 0 scratch space since
-// Kokkos through at least version 5.2 requires at least enough scratch memory
-// to run with a workgroup size of 64.
-#ifdef KOKKOS_ENABLE_HIP
     if (perTargetMem() >
         static_cast<std::size_t>(
             Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1)))
       Kokkos::abort("Can't allocate enough scratch space!");
+
+#ifdef KOKKOS_ENABLE_HIP
+    // FIXME_HIP The HIP backend is limited by the small level 0 scratch space
+    // since Kokkos through at least version 5.2 requires at least enough
+    // scratch memory to run with a workgroup size of 64.
     _scratch_level = 1;
 #else
-    if (perTargetMem() <=
-        static_cast<std::size_t>(
-            Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(0)))
-      _scratch_level = 0;
-    else if (perTargetMem() <=
-             static_cast<std::size_t>(
-                 Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1)))
-      _scratch_level = 1;
-    else
-      Kokkos::abort("Can't allocate enough scratch space!");
+    std::size_t scratch_0_max_size =
+        Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(0);
+    _scratch_level = (perTargetMem() > scratch_0_max_size);
 #endif
   }
 

--- a/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -71,7 +71,7 @@ public:
   template <typename TeamMember>
   KOKKOS_FUNCTION void operator()(TeamMember const &member) const
   {
-    auto const &scratch = member.thread_scratch(0);
+    auto const &scratch = member.thread_scratch(_scratch_level);
 
     int target = member.league_rank() * member.team_size() + member.team_rank();
     if (target >= _num_targets)
@@ -199,19 +199,34 @@ public:
   }
 
   auto makePolicy(ExecutionSpace const &space) const
+
   {
-    Kokkos::TeamPolicy dummy_policy(space, 1, Kokkos::AUTO);
-    dummy_policy.set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
+// FIXME_HIP The HIP backend is limited by the small level 0 scratch space since
+// Kokkos through at least version 5.2 requires at least enough scratch memory
+// to run with a workgroup size of 64.
+#ifdef KOKKOS_ENABLE_HIP
+    if (perTargetMem() <
+        Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1))
+      Kokkos::abort("Can't allocate enough scratch space!");
+    _scratch_level = 1;
+#else
+    if (perTargetMem() <
+        Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(0))
+      _scratch_level = 0;
+    else if (perTargetMem() <
+             Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1))
+      _scratch_level = 1;
+    else
+      Kokkos::abort("Can't allocate enough scratch space!");
+#endif
+
+    Kokkos::TeamPolicy policy(space, 1, Kokkos::AUTO);
+    policy.set_scratch_size(_scratch_level, Kokkos::PerThread(perTargetMem()));
     int team_size =
-        dummy_policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
-    if (team_size != 0)
-    {
-      int league_size = (_num_targets + team_size - 1) / team_size;
-      return Kokkos::TeamPolicy(space, league_size, team_size)
-          .set_scratch_size(0, Kokkos::PerThread(perTargetMem()));
-    }
-    return Kokkos::TeamPolicy(space, _num_targets, 1, 1)
-        .set_scratch_size(0, Kokkos::PerTeam(perTargetMem()));
+        policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
+    int league_size = (_num_targets + team_size - 1) / team_size;
+    return Kokkos::TeamPolicy(space, league_size, team_size)
+        .set_scratch_size(_scratch_level, Kokkos::PerThread(perTargetMem()));
   }
 
 private:
@@ -365,6 +380,7 @@ private:
   Coefficients _coefficients;
   int _num_targets;
   int _num_neighbors;
+  mutable int _scratch_level;
 };
 
 template <typename CRBFunc, typename PolynomialDegree,

--- a/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -221,12 +221,12 @@ public:
   }
 
   auto makePolicy(ExecutionSpace const &space) const
-
   {
-    Kokkos::TeamPolicy policy(space, 1, Kokkos::AUTO);
-    policy.set_scratch_size(_scratch_level, Kokkos::PerThread(perTargetMem()));
+    Kokkos::TeamPolicy dummy_policy(space, 1, Kokkos::AUTO);
+    dummy_policy.set_scratch_size(_scratch_level,
+                                  Kokkos::PerThread(perTargetMem()));
     int team_size =
-        policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
+        dummy_policy.team_size_recommended(*this, Kokkos::ParallelForTag{});
     int league_size = (_num_targets + team_size - 1) / team_size;
     return Kokkos::TeamPolicy(space, league_size, team_size)
         .set_scratch_size(_scratch_level, Kokkos::PerThread(perTargetMem()));

--- a/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
+++ b/src/interpolation/detail/ArborX_InterpDetailsMovingLeastSquaresCoefficients.hpp
@@ -66,7 +66,29 @@ public:
       , _coefficients(coefficients)
       , _num_targets(target_access.size())
       , _num_neighbors(source_points.extent_int(1))
-  {}
+  {
+// FIXME_HIP The HIP backend is limited by the small level 0 scratch space since
+// Kokkos through at least version 5.2 requires at least enough scratch memory
+// to run with a workgroup size of 64.
+#ifdef KOKKOS_ENABLE_HIP
+    if (perTargetMem() >
+        static_cast<std::size_t>(
+            Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1)))
+      Kokkos::abort("Can't allocate enough scratch space!");
+    _scratch_level = 1;
+#else
+    if (perTargetMem() <=
+        static_cast<std::size_t>(
+            Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(0)))
+      _scratch_level = 0;
+    else if (perTargetMem() <=
+             static_cast<std::size_t>(
+                 Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1)))
+      _scratch_level = 1;
+    else
+      Kokkos::abort("Can't allocate enough scratch space!");
+#endif
+  }
 
   template <typename TeamMember>
   KOKKOS_FUNCTION void operator()(TeamMember const &member) const
@@ -201,25 +223,6 @@ public:
   auto makePolicy(ExecutionSpace const &space) const
 
   {
-// FIXME_HIP The HIP backend is limited by the small level 0 scratch space since
-// Kokkos through at least version 5.2 requires at least enough scratch memory
-// to run with a workgroup size of 64.
-#ifdef KOKKOS_ENABLE_HIP
-    if (perTargetMem() <
-        Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1))
-      Kokkos::abort("Can't allocate enough scratch space!");
-    _scratch_level = 1;
-#else
-    if (perTargetMem() <
-        Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(0))
-      _scratch_level = 0;
-    else if (perTargetMem() <
-             Kokkos::TeamPolicy<ExecutionSpace>::scratch_size_max(1))
-      _scratch_level = 1;
-    else
-      Kokkos::abort("Can't allocate enough scratch space!");
-#endif
-
     Kokkos::TeamPolicy policy(space, 1, Kokkos::AUTO);
     policy.set_scratch_size(_scratch_level, Kokkos::PerThread(perTargetMem()));
     int team_size =
@@ -380,7 +383,7 @@ private:
   Coefficients _coefficients;
   int _num_targets;
   int _num_neighbors;
-  mutable int _scratch_level;
+  int _scratch_level;
 };
 
 template <typename CRBFunc, typename PolynomialDegree,

--- a/test/tstInterpDetailsMLSCoefficients.cpp
+++ b/test/tstInterpDetailsMLSCoefficients.cpp
@@ -44,17 +44,6 @@ interpolate(ExecutionSpace const &space, SourceValues const &source_values,
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};
@@ -134,17 +123,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients, DeviceType, ARBORX_DEVICE_TYPES)
 BOOST_AUTO_TEST_CASE_TEMPLATE(mls_coefficients_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};

--- a/test/tstInterpMovingLeastSquares.cpp
+++ b/test/tstInterpMovingLeastSquares.cpp
@@ -23,18 +23,6 @@
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
-
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};
@@ -111,18 +99,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares, DeviceType,
 BOOST_AUTO_TEST_CASE_TEMPLATE(moving_least_squares_edge_cases, DeviceType,
                               ARBORX_DEVICE_TYPES)
 {
-  // FIXME_HIP: the CI fails with:
-  // fatal error: in "mls_coefficients_edge_cases<Kokkos__Device<Kokkos__HIP_
-  // Kokkos__HIPSpace>>": std::runtime_error: Kokkos::Impl::ParallelFor/Reduce<
-  // HIP > could not find a valid team size.
-  // The error seems similar to https://github.com/kokkos/kokkos/issues/6743
-#ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same_v<typename DeviceType::execution_space, Kokkos::HIP>)
-  {
-    return;
-  }
-#endif
-
   using ExecutionSpace = typename DeviceType::execution_space;
   using MemorySpace = typename DeviceType::memory_space;
   ExecutionSpace space{};


### PR DESCRIPTION
This pull request fixes the MovingLeastSquares unit tests when running with HIP by using scratch level 1. With https://github.com/kokkos/kokkos/pull/9339 we could also use scratch level 0 with the tests.

Generally, this pull request automatically switches to scratch level 1 when there isn't enough memory available for scratch level 0.